### PR TITLE
chore(ci): disable CodeQL workflow until GHAS is enabled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,16 @@
 name: CodeQL Security Scanning
 
+# Disabled by default: CodeQL requires GitHub Advanced Security on private repos.
+# To re-enable, restore the push/pull_request/schedule triggers below.
+#
+#   push:
+#     branches: [main]
+#   pull_request:
+#     branches: [main]
+#   schedule:
+#     - cron: "0 0 * * 0"
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  schedule:
-    # Run weekly on Sunday at midnight UTC
-    - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Why

CodeQL requires GitHub Advanced Security on private repos. The workflow fails the SARIF upload step with `Advanced Security must be enabled for this repository to use code scanning` (see [first failed run](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/25848851205)).

## What

Switch the workflow's triggers to `workflow_dispatch:` only so it doesn't run on push/PR/schedule. The file is preserved as a re-enable-ready reference — the original triggers are kept as a comment block above the new trigger.

## When to re-enable

When either:
- the repo is made public (CodeQL runs free on public repos), OR
- GHAS is purchased for this private repo.

To re-enable, restore the commented-out triggers in `.github/workflows/codeql.yml`.

## Verification

`git diff main` shows only `.github/workflows/codeql.yml` modified.