### PR TITLE
chore: prepare repo for public release (CodeQL + SECURITY + CONTRIBUTING)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,16 +1,13 @@
 name: CodeQL Security Scanning
 
-# Disabled by default: CodeQL requires GitHub Advanced Security on private repos.
-# To re-enable, restore the push/pull_request/schedule triggers below.
-#
-#   push:
-#     branches: [main]
-#   pull_request:
-#     branches: [main]
-#   schedule:
-#     - cron: "0 0 * * 0"
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Sunday at midnight UTC
+    - cron: "0 0 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thanks for considering a contribution. This is a personal-scale project for neurodivergent users — feedback and patches from the ND/accessibility community are especially welcome.
+
+## Set up
+
+Requires Bun 1.3.7+, plus Xcode (iOS) and/or Android Studio (Android) for native builds.
+
+```bash
+bun install
+bun run native:ios       # iOS simulator
+bun run native:android   # Android device/emulator
+```
+
+Workspace tasks (from the root):
+
+```bash
+bun run type-check
+bun run lint
+bun run test
+bun run build            # build packages, then native-rd
+```
+
+## Before opening a PR
+
+- `bun run type-check` passes
+- `bun run lint` passes
+- `bun run test` passes for affected packages
+- Tests added for new behavior; existing tests updated when behavior changes
+- ND accessibility checked where relevant: a11y contract tests pass, 44×44pt touch targets, `accessibilityRole` / `accessibilityLabel` set on interactive elements
+
+See [`apps/native-rd/AGENTS.md`](apps/native-rd/AGENTS.md) for app-level conventions and [`AGENTS.md`](AGENTS.md) for the repo map.
+
+## DCO sign-off (required)
+
+This repo enforces the [Developer Certificate of Origin](https://developercertificate.org/) on AGPL-licensed components. Sign every commit:
+
+```bash
+git commit -s -m "your message"
+```
+
+This appends a `Signed-off-by: Your Name <you@example.com>` trailer. Without it, the DCO CI check will fail on PRs to `main`.
+
+If you forgot, amend:
+
+```bash
+git commit --amend --signoff
+```
+
+For multiple commits, rebase with sign-off:
+
+```bash
+git rebase --signoff HEAD~N
+```
+
+See [`LICENSING.md`](LICENSING.md) for the rationale — short version: it preserves the option to dual-license AGPL code for institutions in the future.
+
+## Licensing
+
+Per-package licensing — see [`LICENSING.md`](LICENSING.md) for the full breakdown:
+
+| Package                    | License       |
+| -------------------------- | ------------- |
+| `packages/openbadges-core` | Apache-2.0    |
+| `packages/design-tokens`   | MIT           |
+| `apps/native-rd`           | AGPL-3.0-only |
+
+By submitting a contribution with DCO sign-off, you place your contribution under the relevant package's license and grant the project the rights described in the DCO.
+
+## Issues
+
+- **Bug reports:** include reproduction steps, expected vs. actual behavior, device + OS version
+- **Feature requests:** explain the user need — especially how it serves ND users
+- **Design feedback:** screenshots welcome; reference design tokens or themes by name when relevant
+- **Security issues:** see [`SECURITY.md`](SECURITY.md) — please report privately, not in public issues
+
+## Code style
+
+ESLint + Prettier configs are checked in; lint-staged runs on commit. You generally don't need to format by hand.
+
+## Commit & PR conventions
+
+- Commit messages: prefix with `feat:`, `fix:`, `chore:`, `docs:`, etc. — see `git log` for the house style
+- PR titles: keep under ~70 chars
+- PR descriptions: a short summary, the why, and a test plan checklist
+
+## Questions
+
+Open a GitHub Discussion if you're unsure whether something belongs in an issue. For private matters, email `joe.czar@outlook.com`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+Thanks for taking security seriously. This project handles cryptographic signing and end-to-end encrypted personal data, so reports — especially around `packages/openbadges-core` (Ed25519 signing, PNG baking, key handling) and `apps/native-rd` (Evolu sync, secure storage, badge verification) — are taken seriously.
+
+## Reporting a vulnerability
+
+Please report security issues **privately**. Do not open a public GitHub issue for security-impacting bugs.
+
+**Preferred:** GitHub's private security advisory feature:
+[Report a vulnerability](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/security/advisories/new)
+
+**Alternative:** Email `joe.czar@outlook.com` with subject `Security: <brief description>`.
+
+## What to include
+
+If possible:
+
+- Affected component (package / file / version)
+- Reproduction steps or proof-of-concept
+- Impact assessment (what can an attacker do?)
+- Suggested remediation, if you have one
+
+## Scope
+
+**In scope:**
+
+- `packages/openbadges-core` — credential signing, key management, badge baking
+- `apps/native-rd` — mobile app, local storage (Evolu/SQLite), sync layer, secure store usage
+- `packages/design-tokens` — lower security surface, but reports welcome
+
+**Out of scope / low priority:**
+
+- Bugs in third-party dependencies — please report upstream first
+- Attacks requiring physical device access with the app already unlocked
+- Social-engineering scenarios against the maintainer
+- Theoretical issues with no plausible impact path
+
+## Response timeline
+
+This is a solo-maintained indie project. I aim for:
+
+- **Acknowledge** within 7 days
+- **Initial assessment** within 14 days
+- **Coordinated disclosure** within 90 days of acknowledgment (per industry-standard CVD)
+
+Severe issues (data leak, key compromise, RCE) get faster turnaround.
+
+## Recognition
+
+Reporters who responsibly disclose are credited in release notes and `SECURITY.md` acknowledgments, unless you'd prefer to remain anonymous. Just let me know your preference.


### PR DESCRIPTION
## Summary

Final pre-flip prep before making this repo public. Three changes:

1. **Revert [`2bb0afc`](../commit/2bb0afcf604e50cecfdf5567d29ef71238949a84)** — re-enable CodeQL on push / pull_request / weekly schedule. CodeQL is free on public repos, and that commit explicitly listed "repo is made public" as a re-enable trigger.
2. **Add `SECURITY.md`** — private reporting via GitHub Security Advisories or email; scope; realistic solo-maintainer response timeline; recognition policy.
3. **Add `CONTRIBUTING.md`** — setup, pre-PR checklist, DCO sign-off requirement, per-package licensing pointer, issue and commit conventions.

## Why now

The repo will be made public soon. A pre-flip secret scan (working tree + full git history) came back clean:

- No `.env*` files ever committed (only `.env.example` template)
- No private keys (RSA / EC / Ed25519 / OpenSSH / PGP) in history
- No AWS / GitHub / Stripe / Slack token shapes
- `play-service-account.json` is `.gitignore`d and never committed
- Sentry DSN is injected via `EXPO_PUBLIC_SENTRY_DSN` at build time, not hardcoded
- Exposed public identifiers (Apple Team ID, ASC App ID, EAS project ID, `info@rollercoaster.dev`) are all designed to be public

No history surgery needed.

## Merge order

⚠️ Merge **after** #12 — both `SECURITY.md` and `CONTRIBUTING.md` link to `LICENSING.md`, which is introduced in #12.

## Test plan

- [ ] DCO check passes (both commits signed off)
- [ ] CodeQL workflow does **not** run on this PR yet (still private), but the workflow file is correctly re-armed for next push to `main` once the repo is public
- [ ] `SECURITY.md` renders correctly in the GitHub "Security" tab once present on `main`
- [ ] `CONTRIBUTING.md` is surfaced by GitHub on the "New issue" / "Open PR" pages once present on `main`
- [ ] `LICENSING.md` cross-links from CONTRIBUTING/SECURITY resolve after #12 is merged

## Still-pending public-release checklist

After both PRs merge, before flipping the toggle:

- [ ] Re-run a quick history scan against final `main` (sanity)
- [ ] Set up branch protection on `main` (require PR + passing CI) in GitHub repo settings
- [ ] Make repo public via Settings → General → Change repository visibility
- [ ] Verify CodeQL runs on the next push to `main` after the flip
- [ ] (Recommended) Do DPMA + EUIPO trademark prior-art search for "Rollercoaster.dev" before any public announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)