### PR TITLE
chore(deps): ignore jest/babel-jest 30.4.x in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Jest 30.4.x has a regression where jest-runtime.resetModules
+      # calls _moduleMocker.clearMocksOnScope without checking existence,
+      # breaking the ModuleMocker shipped via react-native/jest/react-native-env.js.
+      # Revisit once jest 30.5 lands.
+      - dependency-name: "jest"
+        versions: ["30.4.x"]
+      - dependency-name: "babel-jest"
+        versions: ["30.4.x"]
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
## Summary

- Add a dependabot `ignore` for `jest` and `babel-jest` in the `30.4.x` range
- Unblocks the weekly dev-dependencies group from being held back by a broken Jest release

## Why

Jest 30.4.x has a regression in `jest-runtime.resetModules` where it calls `_moduleMocker.clearMocksOnScope` without checking that the method exists on the `ModuleMocker`. The `ModuleMocker` shipped via `react-native/jest/react-native-env.js` (RN 0.83) doesn't implement it, so all 143 native-rd test suites fail with:

```
TypeError: this._moduleMocker.clearMocksOnScope is not a function
    at Runtime.resetModules (jest-runtime@30.4.2/build/index.js:3784:28)
```

No upstream fix yet — latest is 30.4.2 (May 9, 2026). Surfaced by dependabot PR #1 (now closed). Other four updates in that group (`@types/bun`, `eslint-config-expo` patch, `react-test-renderer` patch) were benign and will return in the next weekly batch without jest.

Revisit the ignore once Jest 30.5 ships.

## Test plan
- [ ] Verify dependabot config syntax via the GitHub UI's dependabot tab after merge
- [ ] Confirm next Monday's dev-dependencies PR does not include jest 30.4.x