### PR TITLE
fix(native-rd): android bug triage — video, audio, photo, badge, reopen

### DIFF
--- a/apps/native-rd/AGENTS.md
+++ b/apps/native-rd/AGENTS.md
@@ -107,3 +107,7 @@ Each `docs/` subdirectory has an `index.md` with a summary and links:
 4. `/finalize` — push branch, create PR, update board
 
 After merge: `/review-to-task <pr-number>` to convert unresolved review comments into tracked issues.
+
+### Handling Review-Skipped Findings
+
+Every review finding (`/simplify`, `/review`, `/self-review`, CodeRabbit) you choose not to fix in scope must be tracked as a **GH issue** (preferred) and/or a **"Follow-ups" section in the active plan** under `apps/native-rd/docs/plans/`. Never chat-only.

--- a/apps/native-rd/CLAUDE.md
+++ b/apps/native-rd/CLAUDE.md
@@ -82,6 +82,7 @@ Badge logic lives in `@rollercoaster-dev/openbadges-core` (workspace package at 
 - **Planning stack**: use `p-stack`, `p-goal`, `p-plan` etc. for tracking work
 - **Issue workflow**: graph-flow skills (`setup`, `implement`, `finalize`)
 - **Code review**: CodeRabbit CLI at `~/.local/bin/coderabbit` — use `coderabbit review --plain`
+- **Review-skipped findings**: track as GH issue or in plan "Follow-ups" — never chat-only. See `AGENTS.md` → Handling Review-Skipped Findings.
 
 ## Graph Flow (Issue Workflow)
 

--- a/apps/native-rd/docs/plans/2026-05-14-android-bug-triage.md
+++ b/apps/native-rd/docs/plans/2026-05-14-android-bug-triage.md
@@ -204,3 +204,13 @@ Per `apps/native-rd/CLAUDE.md`, run native builds (not `expo start`):
    - **Badge**: Create a fresh goal with no prior badges. Complete it. Add evidence. Confirm: no blue badge modal appears; the celebration card instead shows the "Design your badge" CTA. Tap it → `BadgeDesigner` opens in `new-goal` mode → design + save → returns to completion screen → `BadgeEarnedModal` now opens with the _designed_ badge image, not blue.
 
 3. **Regression check**: Complete a _second_ goal where a badge design already exists in `pendingDesignStore` (via the New Goal → design flow). Confirm the modal still appears immediately with the designed image — the `needs-design` branch should not fire when `capturedPng` is provided.
+
+---
+
+## Follow-ups from `/simplify` review (commit dfb0aeb)
+
+Items flagged by review but intentionally out of scope for this fix:
+
+- **#21** — Centralize `GoalsStackNav` / `BadgesStackNav` type aliases. Five+ screens repeat `useNavigation<NativeStackNavigationProp<GoalsStackParamList>>()` inline; `EditModeScreen.tsx:57` still uses the older `NavigationProp<…>` form.
+- **#22** — Clarify FocusMode auto-nav behavior when steps re-complete in the same mount post-Reopen. May be intended; needs product input. Related to #15 (badge rebake on reopen).
+- **#23** — Stabilize `goal` reference in `FocusModeScreen.tsx:103` to avoid effect re-runs on every Evolu emission. Pre-existing, not a regression.

--- a/apps/native-rd/docs/plans/2026-05-14-android-bug-triage.md
+++ b/apps/native-rd/docs/plans/2026-05-14-android-bug-triage.md
@@ -1,0 +1,206 @@
+# Android Bug Triage — Video Controls, Audio Timer, Badge Fallback
+
+**Status:** Active
+**Created:** 2026-05-14
+
+## Context
+
+A test pass on the Android build of `native-rd` (`apps/native-rd`) surfaced three discrete bugs:
+
+1. **Video capture screen** — the record + flip buttons render under the lifted `FocusPillTabBar`, so users can't reliably tap them on Android.
+2. **Voice memo screen** — the duration timer stays at `00:00` while recording; it only updates after `stopRecording()` completes.
+3. **Badge on goal completion** — when the user has no saved badge design, `useCreateBadge` silently falls back to a solid-blue 64×64 PNG and ships that as the credential image. We want to _block_ the bake until the user designs a badge instead.
+
+The fixes are independent and can land in one PR.
+
+---
+
+## Bug 1 — Video screen: controls hidden under FocusPillTabBar
+
+### Root cause
+
+`CaptureVideoScreen` is a `<Stack.Screen>` inside `GoalsStack` (`apps/native-rd/src/navigation/GoalsStack.tsx:37`), which is itself inside the bottom-tab navigator. The tab bar is **never hidden** on capture screens, so it overlays the bottom of the screen.
+
+`CaptureVideoScreen.styles.ts:40` sets a hardcoded `paddingBottom: theme.space[16]` on `controls`. On Android the lifted-pill tab bar (`PILL_LIFT = PILL_HEIGHT / 2 + borderWidth.medium = 32 + ~3`) plus the gesture/system inset eats more space than that hardcoded value, so the record/flip buttons end up under the pill.
+
+The codebase already has a dedicated hook for exactly this offset: `useTabScreenContentInset()` (`apps/native-rd/src/navigation/useTabScreenContentInset.ts:10`) returns `paddingBottom: 2 * PILL_LIFT + insets.bottom + space[4]`.
+
+### Fix
+
+In `apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.tsx`:
+
+- Import `useTabScreenContentInset` from `../../navigation/useTabScreenContentInset`.
+- Call it at the top of `CaptureVideoScreen` and pass the result to the `controls` `View` as an inline style: `style={[styles.controls, tabInset]}`.
+- Do the same for `previewControls` (line 273) so the Retake / Use Video buttons clear the tab bar in preview mode.
+
+In `apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.styles.ts`:
+
+- Remove the hardcoded `paddingBottom: theme.space[16]` from `controls` (line 40). Keep `paddingTop` and `paddingHorizontal`.
+- The `flipButton`'s absolute `top` (line 75) is computed from the row's vertical padding — that still uses `theme.space[4]` for `paddingTop`, so no change needed there.
+
+### Critical files
+
+- `apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.tsx` (lines 50, 273, 320)
+- `apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.styles.ts` (lines 35–42)
+- `apps/native-rd/src/navigation/useTabScreenContentInset.ts` (reuse — no change)
+
+---
+
+## Bug 2 — Voice memo: timer doesn't tick during recording
+
+### Root cause
+
+`useAudioRecorder` (`apps/native-rd/src/hooks/useAudioRecorder.ts`) only updates `durationMs` inside the expo-audio recorder callback, which **only fires on `isFinished`** (lines 71–76). There is no live polling, so the consumer (`VoiceMemoScreen.tsx:159`) reads a stale `0` until recording stops.
+
+`CaptureVideoScreen` already has the correct pattern (its own `setInterval` on lines 91–93), but `useAudioRecorder` doesn't replicate it.
+
+### Fix
+
+In `apps/native-rd/src/hooks/useAudioRecorder.ts`:
+
+- Add a `useEffect` keyed on `status` that, when `status === "recording"`, starts a `setInterval` (~200ms cadence is plenty for an MM:SS display) calling `setDurationMs(recorder.getStatus().durationMillis)`.
+- The effect's cleanup must `clearInterval` — also runs on unmount and on transitions out of `"recording"` (including to `"paused"`).
+- When `status === "paused"`, stop ticking (cleanup runs) but keep the last `durationMs` value — do _not_ reset to 0. On resume, the effect restarts and continues counting from `recorder.getStatus().durationMillis`, which expo-audio resumes from the paused total.
+- Keep the existing `isFinished` callback path — it still provides the authoritative final duration when recording stops.
+
+### Edge cases to cover in the implementation
+
+- The `setDurationMs(0)` at line 122 in `startRecording` runs _before_ the effect schedules the first tick, so the UI shows `00:00` then begins ticking — correct behavior, no change needed.
+- Don't list `recorder` in the effect deps if it's a stable hook handle; if it isn't, store the recorder in a ref. Verify by reading the `useExpoRecorder` signature — `recorder` is returned each render, so use a ref (`recorderRef.current = recorder`) and read inside the interval to avoid stale closures or constant restart.
+
+### Critical files
+
+- `apps/native-rd/src/hooks/useAudioRecorder.ts` (add effect near lines 87–99, after the playback-position effect)
+
+### Tests
+
+The hook has a Jest test directory at `apps/native-rd/src/__tests__/`. Search for `useAudioRecorder` test files; add a test that fakes timers, calls `startRecording`, advances time, and asserts `durationMs > 0` while still recording.
+
+---
+
+## Bug 3 — Badge: blue solid-color fallback on goal completion
+
+**Status note (2026-05-14, post-implementation):** the approach below was pivoted during implementation. The user opted to align the design-system default with the first-letter rendering already used by `BadgeCard` tiles (`components/BadgeCard/BadgeCard.tsx:36-42`) instead of blocking with a `needs-design` status. The implemented design:
+
+- `createDefaultBadgeDesign` (`badges/types.ts:146`) now returns `shape: roundedRect`, `centerMode: monogram`, `monogram: <first letter of title uppercased>`. `BadgeShape.square` does not exist in the enum, so `roundedRect` is the closest fit.
+- `useCreateBadge` (`hooks/useCreateBadge.ts`) deletes the `generateBadgeImagePNG` solid-color branch entirely. `capturedPng` is required; missing PNG throws (the outer catch surfaces `status === "error"` with a clear message). Unused imports `generateBadgeImagePNG` / `DEFAULT_BADGE_COLOR` are dropped.
+- `CompletionFlowScreen` (`screens/CompletionFlowScreen/CompletionFlowScreen.tsx`) auto-captures the default-design PNG when `pendingDesignStore.consume()` returns undefined: an offscreen `<View>` hosts a `<BadgeRenderer design={createDefaultBadgeDesign(goal.title, goal.color)} />`, and a `useEffect` calls `captureBadge(fallbackRef, getCaptureDimensions(...))` once. The captured PNG plus the serialized default design are then fed to `useCreateBadge`. The `enabled` gate becomes `phase === "celebration" && capturedPngForBake !== undefined` so badge creation waits for the capture to land.
+- No `needs-design` status, no `returnTo` BadgeDesigner param, no `useFocusEffect` re-consume. The two architectural gaps identified during plan review (post-save nav, re-consume) disappear because the user is never re-routed to BadgeDesigner.
+
+Original `needs-design` plan retained below for posterity but not implemented.
+
+---
+
+### Root cause
+
+`useCreateBadge` (`apps/native-rd/src/hooks/useCreateBadge.ts:243–249`) has three branches for the PNG source:
+
+1. `capturedPng` provided → use it.
+2. `design` provided without `capturedPng` → throw (programmer error).
+3. **Neither provided → fall back to `generateBadgeImagePNG(hexColor)`** ← this is the blue PNG.
+
+The third branch fires on every goal completion where the user has not designed a badge, baking a `DEFAULT_BADGE_COLOR = "#4B7BE5"` solid-blue square into the OB3 credential.
+
+The user's chosen behavior: **block badge creation until the user designs a badge.** No solid-color fallback should ever ship.
+
+### Fix — block until designed
+
+The existing flow already has the right machinery: `CompletionFlowScreen` passes `enabled: phase === "celebration"` to gate badge creation, and the modal already has a `Customize` button that routes to `BadgeDesigner`. We extend this with a "needs-design" status that fires _before_ `useCreateBadge` runs.
+
+#### 3a. Add a `needs-design` status to `useCreateBadge`
+
+In `apps/native-rd/src/hooks/useCreateBadge.ts`:
+
+- Extend `BadgeCreationStatus` (lines 58–67) with `"needs-design"`.
+- In the effect's bake branch (lines 243–249), **delete the `generateBadgeImagePNG` fallback path**. Replace it with:
+  ```
+  if (!capturedPngRef.current) {
+    setStatus("needs-design");
+    hasTriggered.current = false; // allow re-entry once design arrives
+    return;
+  }
+  ```
+  Resetting `hasTriggered` here is the one exception — we _want_ the effect to re-run when the design eventually arrives via prop change. To avoid a re-entry race, also gate on a separate `hasCompletedRef` for the success path.
+- Keep the `design` provided without `capturedPng` throw — that's still a programmer error.
+- The unused imports `generateBadgeImagePNG` and `DEFAULT_BADGE_COLOR` from `../badges` can be dropped (lines 43, 47) once the fallback is gone. Verify no other consumer in `apps/native-rd/src` imports them; if so, leave the badges module exports intact and just remove the import here.
+
+#### 3b. Update `CompletionFlowScreen` to handle `needs-design`
+
+In `apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx`:
+
+- After `useCreateBadge` returns (line 120), add a check: if `badgeStatus === "needs-design"`, render a **"Design your badge to continue"** card in the celebration phase (around lines 363–381 where the action buttons live).
+- The card shows a primary button "Design your badge" → `navigation.navigate("BadgeDesigner", { mode: "new-goal", goalId, returnTo: "completion-flow" })`.
+- Suppress `BadgeEarnedModal` while `badgeStatus === "needs-design"` (already implicit — `badgeRow` will be null since `createBadge` hasn't fired).
+
+**Gap 1 fix — post-save navigation (`returnTo` param):**
+
+`BadgeDesignerContentNewGoal.saveAndNavigate` currently always `navigation.replace("EditMode", { goalId })` (`BadgeDesignerScreen.tsx:581`). That's wrong when launched from the completion flow — the user would end up in EditMode instead of back at the celebration screen.
+
+- Extend `GoalsStackParamList`'s `BadgeDesigner` `new-goal` params with `returnTo?: "edit-mode" | "completion-flow"` (defaults to `"edit-mode"` for back-compat with the existing "New Goal → design" flow). Update `apps/native-rd/src/navigation/types.ts` accordingly.
+- In `saveAndNavigate`, branch on `returnTo`:
+  - `"edit-mode"` (default) → existing `navigation.replace("EditMode", { goalId })`.
+  - `"completion-flow"` → `navigation.goBack()`.
+- The `pendingDesignStore.set(goalId, ...)` call at line 577 stays unchanged for both paths — that's already correct.
+- Pass `returnTo: "completion-flow"` from `CompletionFlowScreen`'s "Design your badge" CTA.
+
+**Gap 2 fix — re-consume `pendingDesignStore` on return:**
+
+`CompletionFlowScreen.tsx:478` consumes the pending design inside `useRef`'s initializer — runs once at mount. The outer wrapper stays mounted while the user navigates to BadgeDesigner, so the existing ref captured `undefined` and won't re-consume after `goBack`.
+
+- Replace the `useRef(pendingDesignStore.consume(goalId))` pattern with a `useState` holding the design + a `useFocusEffect` (from `@react-navigation/native`) that re-consumes _only when state is still empty_:
+  ```ts
+  const [pendingDesign, setPendingDesign] = useState(() =>
+    pendingDesignStore.consume(goalId),
+  );
+  useFocusEffect(
+    useCallback(() => {
+      if (pendingDesign) return; // already have it — preserve existing Suspense protection
+      const next = pendingDesignStore.consume(goalId);
+      if (next) setPendingDesign(next);
+    }, [goalId, pendingDesign]),
+  );
+  ```
+- The Suspense-remount protection that motivated the original `useRef` pattern still holds: once we have a non-null value, we don't re-consume.
+- `pendingCapturedPngRef` becomes derived state (also moves into the same flow), or just compute the Buffer on render from `pendingDesign.pngBase64` — refs aren't load-bearing here.
+- Verify by reading `apps/native-rd/src/stores/pendingDesignStore.ts` to confirm `consume()` is safely idempotent after the entry is gone (returns `undefined`).
+
+#### 3c. Update `BadgeEarnedModal` (defensive)
+
+In `apps/native-rd/src/screens/BadgeEarnedModal/BadgeEarnedModal.tsx`:
+
+- The existing `PLACEHOLDER_IMAGE_URI` branch (lines 91–99) stays — it covers the legitimate `saveBadgePNG` filesystem failure case (lines 254–265 in `useCreateBadge`), which is unrelated to the blue-fallback bug.
+- No structural changes needed here.
+
+### Critical files
+
+- `apps/native-rd/src/hooks/useCreateBadge.ts` (lines 58–67, 243–249 — extend status, drop solid-color fallback)
+- `apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx` (lines 120, 363–381, 455–463, 478–482 — new CTA + `useFocusEffect` re-consume)
+- `apps/native-rd/src/screens/BadgeDesignerScreen/BadgeDesignerScreen.tsx` (lines 564–595 — branch `saveAndNavigate` on `returnTo`)
+- `apps/native-rd/src/navigation/types.ts` (extend `BadgeDesigner` `new-goal` params with `returnTo?: "edit-mode" | "completion-flow"`)
+- `apps/native-rd/src/stores/pendingDesignStore.ts` (reuse — verify `consume()` is idempotent)
+
+### Tests
+
+- The badge create flow has tests under `apps/native-rd/src/__tests__/`. Add a case for `useCreateBadge` that asserts `status === "needs-design"` when neither `design` nor `capturedPng` is supplied. Remove or update any existing test that asserts the solid-color fallback path (it's now an error path).
+- For `CompletionFlowScreen`, add a test that the "Design your badge" CTA renders when `badgeStatus === "needs-design"`.
+
+---
+
+## Verification
+
+Per `apps/native-rd/CLAUDE.md`, run native builds (not `expo start`):
+
+1. **Static checks** (run from `apps/native-rd`):
+
+   ```
+   bun run type-check
+   bun run lint
+   bun test --testPathPatterns "useAudioRecorder|useCreateBadge|CaptureVideo|CompletionFlow"
+   ```
+
+2. **Native Android build & manual checks** — load the `native-rd-build` skill for Android-specific build commands. Then on a connected Android device or emulator:
+   - **Video**: Goals → focus a goal → complete → add evidence → tap a video chip → `CaptureVideo`. Confirm the red record button and the flip button are both fully visible above the tab bar pill, and both are tappable. Rotate / try gesture and 3-button nav modes if available.
+   - **Audio**: Same path, voice-memo chip → `VoiceMemo`. Tap record. Confirm the `00:00` timer ticks every second through recording. Pause → confirm freeze. Resume → confirm continue. Stop → confirm final duration matches.
+   - **Badge**: Create a fresh goal with no prior badges. Complete it. Add evidence. Confirm: no blue badge modal appears; the celebration card instead shows the "Design your badge" CTA. Tap it → `BadgeDesigner` opens in `new-goal` mode → design + save → returns to completion screen → `BadgeEarnedModal` now opens with the _designed_ badge image, not blue.
+
+3. **Regression check**: Complete a _second_ goal where a badge design already exists in `pendingDesignStore` (via the New Goal → design flow). Confirm the modal still appears immediately with the designed image — the `needs-design` branch should not fire when `capturedPng` is provided.

--- a/apps/native-rd/docs/plans/2026-05-14-badge-rebake-on-reopen.md
+++ b/apps/native-rd/docs/plans/2026-05-14-badge-rebake-on-reopen.md
@@ -1,0 +1,109 @@
+# Badge Rebake on Reopen + Re-Completion
+
+**Status:** Tracked on GitHub
+**Tracking issue:** [#15](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/issues/15)
+**Created:** 2026-05-14
+**Related:** [2026-05-14-android-bug-triage.md](./2026-05-14-android-bug-triage.md) — same session; the reopen-loop fix landed there, this is the follow-up feature it surfaced.
+
+## Context
+
+After the reopen-loop fix in `FocusModeScreen.tsx:247`, a user can now reopen a completed goal, add evidence / steps, and re-complete it without being force-navigated to the celebration screen. **However, on legitimate re-completion the badge is not re-baked.**
+
+Current behavior in `useCreateBadge.ts:125-130`:
+
+```ts
+if (existingBadge) {
+  setStatus("done");
+  return;
+}
+```
+
+When a badge already exists, `useCreateBadge` short-circuits to `"done"` and the BadgeEarnedModal pops with the original (now stale) badge image and credential — even though the user added new evidence after reopening. The credential's `evidence[]` is frozen at the time of the first bake.
+
+We want: when a user reopens a goal, **updates** it, and re-completes, prompt them to overwrite the original badge with a freshly-baked one based on the latest state.
+
+## Desired behavior
+
+1. **Detect "rebake needed":** existing badge + `goal.status === active` (reopen) + the credential's snapshot diverges from the current goal/evidence state.
+2. **Confirmation prompt:** native `Alert.alert` (or in-screen card) with:
+   - Title: _"Rebake your badge?"_
+   - Body: _"You reopened this goal and made changes. Re-completing will replace your original badge with a new one based on the latest evidence. The old badge cannot be recovered."_
+   - Buttons: `[Cancel]` `[Rebake & overwrite]`
+3. **On Rebake:** rebuild credential with current evidence, re-sign, re-bake PNG, persist via `updateBadge` (already exists at `db/queries.ts:976` and supports `credential` + `imageUri`), then `completeGoal`. BadgeEarnedModal then shows the new image.
+4. **On Cancel:** `navigation.goBack()` to `FocusMode`. Goal stays `active`. User can come back to it later.
+5. **Reopen + re-complete with NO changes** (e.g. user reopened by accident): silent `completeGoal`, no prompt, modal shows the original badge unchanged.
+
+## Open design decisions
+
+| Question                  | Recommended default                                                                                                                                  | Alternative                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| What counts as "updated"? | Diff vs credential snapshot: `evidence[]` count, `goal.title`, `goal.description`. Catches the common "added evidence" case.                         | Full structural diff including step rows; track an explicit `goal.dirtySinceBake` column. Heavier. |
+| Cancel UX                 | Back to FocusMode, goal stays `active`.                                                                                                              | Mark goal completed but skip rebake (keep old badge). Confusing — stale badge with new evidence.   |
+| Rebake design source      | Reuse `existingBadge.design` if set, else `createDefaultBadgeDesign(goal.title, goal.color)`. Re-capture offscreen the same way the first bake does. | Open BadgeDesigner so user can re-design before rebake. More friction.                             |
+| Where confirmation lives  | Native `Alert.alert` triggered from `CompletionFlowScreen` when `useCreateBadge` returns the new status.                                             | In-screen card replacing the celebration content. More design work.                                |
+| New status name           | `"rebake-required"`                                                                                                                                  | `"awaiting-overwrite-confirmation"` (verbose)                                                      |
+
+## Implementation sketch
+
+### 1. `hooks/useCreateBadge.ts`
+
+- Extend `BadgeCreationStatus` with `"rebake-required"`.
+- Add a `confirmRebake?: boolean` option (`undefined` = waiting, `true` = user confirmed).
+- Helper: `hasChangesSinceBake(credentialJson, currentGoal, currentEvidence)` — parse credential JSON, compare evidence count + goal title/description.
+- Restructure the effect:
+  ```ts
+  if (existingBadge) {
+    if (goal.status === completed) { setStatus("done"); return; }
+    if (!hasChangesSinceBake(...)) {
+      // accidental reopen, silent re-complete
+      completeGoal(goalId, evidence);
+      setStatus("done");
+      return;
+    }
+    if (!options.confirmRebake) {
+      setStatus("rebake-required");
+      return;
+    }
+    // confirmed — fall through to bake IIFE, branch on existingBadge inside
+  }
+  ```
+- In the bake IIFE, swap `createBadge({...})` for `updateBadge(existingBadge.id, { credential, imageUri })` when `existingBadge` is set. `design` field stays untouched on the existing row.
+
+### 2. `screens/CompletionFlowScreen/CompletionFlowScreen.tsx`
+
+- New local state `rebakeConfirmed: boolean`.
+- Pass `confirmRebake: rebakeConfirmed` to `useCreateBadge`.
+- When `badgeStatus === "rebake-required"`, fire `Alert.alert` with the two buttons described above.
+- Cancel → `navigation.goBack()`.
+- Confirm → `setRebakeConfirmed(true)` (effect re-runs, bake proceeds).
+- Offscreen fallback design: when rebaking, prefer `parseBadgeDesign(existingBadge.design)` over the default. Keeps the user's customized badge look.
+
+### 3. Tests
+
+- `useCreateBadge.test.ts`:
+  - When `existingBadge` + `goal.status === active` + changes detected → returns `"rebake-required"`, does NOT call `updateBadge`/`completeGoal`.
+  - Same precondition + `confirmRebake: true` → calls `updateBadge` (not `createBadge`), then `completeGoal`.
+  - Same precondition + no changes detected → silently calls `completeGoal`, status `"done"`.
+  - `existingBadge` + `goal.status === completed` → idempotent `"done"`, no DB writes.
+- `CompletionFlowScreen.test.tsx`:
+  - Renders rebake Alert when status is `"rebake-required"`.
+  - Confirm tap sets `confirmRebake` and re-renders.
+  - Cancel tap calls `navigation.goBack()`.
+
+## Critical files
+
+- `apps/native-rd/src/hooks/useCreateBadge.ts` — status + branching + rebake path
+- `apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx` — Alert + state + fallback design override
+- `apps/native-rd/src/db/queries.ts:976` — `updateBadge` (already supports the fields we need; no change)
+
+## Verification
+
+1. `bun run type-check && bun run lint && npx jest --no-coverage --testPathPatterns "useCreateBadge|CompletionFlow"`
+2. Manual flow on a connected Android device (load `native-rd-build` skill for build commands):
+   - Create goal, design badge, add evidence, complete → badge appears.
+   - Reopen the goal from the celebration screen.
+   - Add an additional piece of evidence.
+   - Complete final step → CompletionFlow → Alert appears.
+   - Tap Cancel → returns to FocusMode, goal stays `active`.
+   - Re-complete → Alert again → tap Rebake → new badge image bakes, modal shows the new credential, goal is `completed`.
+3. Regression: complete a fresh goal — no Alert, normal flow still works.

--- a/apps/native-rd/docs/plans/index.md
+++ b/apps/native-rd/docs/plans/index.md
@@ -4,17 +4,19 @@ Implementation plans and vision documents. Active plans are in progress; complet
 
 ## Active
 
-| Document                                                                                                       | Summary                                                                   | Last Verified |
-| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------- |
-| [2026-02-24-agent-first-vision.md](./2026-02-24-agent-first-vision.md)                                         | Vision for agent-first development across 5 capability layers             | 2026-02-24    |
-| [2026-02-24-phase1-repo-legibility.md](./2026-02-24-phase1-repo-legibility.md)                                 | Implementation plan for Phase 1: Repository Legibility                    | 2026-02-24    |
-| [2026-02-27-badge-design-system-plan.md](./2026-02-27-badge-design-system-plan.md)                             | Badge designer system implementation plan                                 | 2026-02-27    |
-| [2026-04-21-goal-lifecycle-e2e-flow.md](./2026-04-21-goal-lifecycle-e2e-flow.md)                               | Land the goal-lifecycle Maestro flow green + codify E2E skill             | 2026-04-21    |
-| [2026-04-28-ios-testflight-readiness.md](./2026-04-28-ios-testflight-readiness.md)                             | Track iOS TestFlight readiness for Rollercoaster.dev                      | 2026-04-28    |
-| [2026-04-28-design-token-simplification-and-chrome.md](./2026-04-28-design-token-simplification-and-chrome.md) | Simplify native-rd themes and move app headers to chrome tokens           | 2026-04-28    |
-| [2026-05-01-badge-test-system-and-field-rename.md](./2026-05-01-badge-test-system-and-field-rename.md)         | Logic-only badge layout invariant tests + mismatched field rename         | 2026-05-01    |
-| [2026-05-02-expo-doctor-build-validation.md](./2026-05-02-expo-doctor-build-validation.md)                     | Resolve Expo build-readiness issues for preview testing                   | 2026-05-02    |
-| [2026-05-12-sentry-usage-finish.md](./2026-05-12-sentry-usage-finish.md)                                       | Finish Planned Sentry rollout: logger bridge + breadcrumbs + verification | 2026-05-12    |
+| Document                                                                                                                                                        | Summary                                                                           | Last Verified |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------- |
+| [2026-02-24-agent-first-vision.md](./2026-02-24-agent-first-vision.md)                                                                                          | Vision for agent-first development across 5 capability layers                     | 2026-02-24    |
+| [2026-02-24-phase1-repo-legibility.md](./2026-02-24-phase1-repo-legibility.md)                                                                                  | Implementation plan for Phase 1: Repository Legibility                            | 2026-02-24    |
+| [2026-02-27-badge-design-system-plan.md](./2026-02-27-badge-design-system-plan.md)                                                                              | Badge designer system implementation plan                                         | 2026-02-27    |
+| [2026-04-21-goal-lifecycle-e2e-flow.md](./2026-04-21-goal-lifecycle-e2e-flow.md)                                                                                | Land the goal-lifecycle Maestro flow green + codify E2E skill                     | 2026-04-21    |
+| [2026-04-28-ios-testflight-readiness.md](./2026-04-28-ios-testflight-readiness.md)                                                                              | Track iOS TestFlight readiness for Rollercoaster.dev                              | 2026-04-28    |
+| [2026-04-28-design-token-simplification-and-chrome.md](./2026-04-28-design-token-simplification-and-chrome.md)                                                  | Simplify native-rd themes and move app headers to chrome tokens                   | 2026-04-28    |
+| [2026-05-01-badge-test-system-and-field-rename.md](./2026-05-01-badge-test-system-and-field-rename.md)                                                          | Logic-only badge layout invariant tests + mismatched field rename                 | 2026-05-01    |
+| [2026-05-02-expo-doctor-build-validation.md](./2026-05-02-expo-doctor-build-validation.md)                                                                      | Resolve Expo build-readiness issues for preview testing                           | 2026-05-02    |
+| [2026-05-12-sentry-usage-finish.md](./2026-05-12-sentry-usage-finish.md)                                                                                        | Finish Planned Sentry rollout: logger bridge + breadcrumbs + verification         | 2026-05-12    |
+| [2026-05-14-android-bug-triage.md](./2026-05-14-android-bug-triage.md)                                                                                          | Fix Android bugs: video controls under tab bar, audio timer, badge fallback       | 2026-05-14    |
+| [2026-05-14-badge-rebake-on-reopen.md](./2026-05-14-badge-rebake-on-reopen.md) ([#15](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/issues/15)) | Rebake badge with confirmation when a goal is reopened, updated, and re-completed | 2026-05-14    |
 
 ## Reference
 

--- a/apps/native-rd/src/badges/__tests__/types.test.ts
+++ b/apps/native-rd/src/badges/__tests__/types.test.ts
@@ -51,13 +51,14 @@ describe("createDefaultBadgeDesign", () => {
     const design = createDefaultBadgeDesign("Learn TypeScript", "#ffe50c");
 
     expect(design).toEqual<BadgeDesign>({
-      shape: "circle",
+      shape: "roundedRect",
       frame: "none",
       color: "#ffe50c",
       iconName: "Trophy",
       iconWeight: "regular",
       title: "Learn TypeScript",
-      centerMode: "icon",
+      centerMode: "monogram",
+      monogram: "L",
     });
   });
 
@@ -92,7 +93,6 @@ describe("createDefaultBadgeDesign", () => {
   test("does not include optional fields by default", () => {
     const design = createDefaultBadgeDesign("Test");
     expect(design.frameParams).toBeUndefined();
-    expect(design.monogram).toBeUndefined();
     expect(design.bottomLabel).toBeUndefined();
     expect(design.pathText).toBeUndefined();
     expect(design.pathTextPosition).toBeUndefined();
@@ -100,9 +100,19 @@ describe("createDefaultBadgeDesign", () => {
     expect(design.banner).toBeUndefined();
   });
 
-  test("defaults to icon centerMode", () => {
+  test("defaults to monogram centerMode with the title's first letter", () => {
     const design = createDefaultBadgeDesign("Test");
-    expect(design.centerMode).toBe("icon");
+    expect(design.centerMode).toBe("monogram");
+    expect(design.monogram).toBe("T");
+  });
+
+  test("uses '?' as the monogram when title is empty or whitespace-only", () => {
+    expect(createDefaultBadgeDesign("").monogram).toBe("?");
+    expect(createDefaultBadgeDesign("   ").monogram).toBe("?");
+  });
+
+  test("uppercases the monogram when title starts with a lowercase letter", () => {
+    expect(createDefaultBadgeDesign("apple").monogram).toBe("A");
   });
 
   test("result is JSON-serializable", () => {

--- a/apps/native-rd/src/badges/types.ts
+++ b/apps/native-rd/src/badges/types.ts
@@ -140,7 +140,7 @@ export function isValidHexColor(value: string): boolean {
 /**
  * Create a sensible default BadgeDesign from a goal title and color.
  *
- * Square shape, monogram of the title's first letter — matches the
+ * Rounded rectangle shape, monogram of the title's first letter — matches the
  * placeholder rendering used in BadgeCard tiles, so the pre-bake preview
  * and the unstyled tile fallback agree.
  *

--- a/apps/native-rd/src/badges/types.ts
+++ b/apps/native-rd/src/badges/types.ts
@@ -140,8 +140,13 @@ export function isValidHexColor(value: string): boolean {
 /**
  * Create a sensible default BadgeDesign from a goal title and color.
  *
- * Uses circle shape, no frame, Trophy icon at regular weight.
- * Falls back to signature purple if no color provided or if color is invalid hex.
+ * Square shape, monogram of the title's first letter — matches the
+ * placeholder rendering used in BadgeCard tiles, so the pre-bake preview
+ * and the unstyled tile fallback agree.
+ *
+ * `iconName` / `iconWeight` are populated as harmless defaults; they are
+ * not drawn while `centerMode === monogram`, but BadgeDesigner re-uses
+ * them if the user toggles `centerMode` back to `icon`.
  */
 export function createDefaultBadgeDesign(
   title: string,
@@ -149,14 +154,16 @@ export function createDefaultBadgeDesign(
 ): BadgeDesign {
   const resolvedColor =
     color && isValidHexColor(color) ? color : DEFAULT_DESIGN_COLOR;
+  const firstLetter = (title.trim().charAt(0) || "?").toUpperCase();
   return {
-    shape: BadgeShape.circle,
+    shape: BadgeShape.roundedRect,
     frame: BadgeFrame.none,
     color: resolvedColor,
     iconName: DEFAULT_ICON_NAME,
     iconWeight: BadgeIconWeight.regular,
     title,
-    centerMode: BadgeCenterMode.icon,
+    centerMode: BadgeCenterMode.monogram,
+    monogram: firstLetter,
   };
 }
 

--- a/apps/native-rd/src/hooks/__tests__/useAudioRecorder.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useAudioRecorder.test.ts
@@ -23,6 +23,16 @@ beforeEach(() => {
   // Reset recorder state
   mockRecorder.isRecording = false;
   mockRecorder.uri = "file:///mock-recording.m4a";
+  // clearAllMocks does NOT reset mockImplementation, so re-install the
+  // default getStatus impl so a prior test's "live duration" override
+  // doesn't bleed into stopRecording's authoritative duration assertion.
+  mockRecorder.getStatus.mockImplementation(() => ({
+    canRecord: false,
+    isRecording: false,
+    durationMillis: 5000,
+    mediaServicesDidReset: false,
+    url: "file:///mock-recording.m4a",
+  }));
   // Default: permission granted
   (requestRecordingPermissionsAsync as jest.Mock).mockResolvedValue({
     granted: true,
@@ -92,6 +102,99 @@ describe("useAudioRecorder", () => {
 
       expect(result.current.status).toBe("idle");
       expect(result.current.error).toBe("Microphone busy");
+    });
+  });
+
+  describe("live duration", () => {
+    it("ticks durationMs while status is recording", async () => {
+      jest.useFakeTimers();
+      try {
+        // Recorder reports 0ms initially, then advances on each poll
+        let mockDurationMs = 0;
+        mockRecorder.getStatus.mockImplementation(() => ({
+          canRecord: true,
+          isRecording: true,
+          durationMillis: mockDurationMs,
+          mediaServicesDidReset: false,
+          url: "file:///mock-recording.m4a",
+        }));
+
+        const { result } = renderHook(() => useAudioRecorder());
+
+        await act(async () => {
+          mockRecorder.isRecording = true;
+          await result.current.startRecording();
+        });
+
+        expect(result.current.status).toBe("recording");
+        expect(result.current.durationMs).toBe(0);
+
+        // Advance the polling interval; recorder reports growing duration
+        mockDurationMs = 1200;
+        await act(async () => {
+          jest.advanceTimersByTime(200);
+        });
+        expect(result.current.durationMs).toBe(1200);
+
+        mockDurationMs = 2400;
+        await act(async () => {
+          jest.advanceTimersByTime(200);
+        });
+        expect(result.current.durationMs).toBe(2400);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("freezes durationMs when paused and resumes on resume", async () => {
+      jest.useFakeTimers();
+      try {
+        let mockDurationMs = 0;
+        mockRecorder.getStatus.mockImplementation(() => ({
+          canRecord: true,
+          isRecording: true,
+          durationMillis: mockDurationMs,
+          mediaServicesDidReset: false,
+          url: "file:///mock-recording.m4a",
+        }));
+
+        const { result } = renderHook(() => useAudioRecorder());
+
+        await act(async () => {
+          mockRecorder.isRecording = true;
+          await result.current.startRecording();
+        });
+
+        mockDurationMs = 1500;
+        await act(async () => {
+          jest.advanceTimersByTime(200);
+        });
+        expect(result.current.durationMs).toBe(1500);
+
+        await act(async () => {
+          await result.current.pauseRecording();
+        });
+
+        // While paused, even if the underlying recorder reports more time
+        // (it shouldn't, but defensively), our state should not change.
+        mockDurationMs = 9999;
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+        expect(result.current.durationMs).toBe(1500);
+
+        // On resume, polling restarts and duration advances again
+        mockDurationMs = 2000;
+        await act(async () => {
+          await result.current.resumeRecording();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(200);
+        });
+        expect(result.current.durationMs).toBe(2000);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
@@ -57,9 +57,6 @@ jest.mock("../../badges", () => ({
     type: ["VerifiableCredential"],
   })),
   buildDid: jest.fn(() => "did:key:testkey"),
-  generateBadgeImagePNG: jest.fn(
-    () => new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
-  ),
   bakePNG: jest.fn(() => Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])),
   isPNG: jest.fn(
     (buf: Buffer) => buf.length >= 8 && buf[0] === 137 && buf[1] === 80,
@@ -67,7 +64,6 @@ jest.mock("../../badges", () => ({
   saveBadgePNG: jest.fn(() =>
     Promise.resolve("file:///app/badges/test-badge.png"),
   ),
-  DEFAULT_BADGE_COLOR: "#4B7BE5",
 }));
 
 const mockUseQuery = useQuery as jest.Mock;
@@ -91,6 +87,10 @@ const MOCK_GOAL = {
   status: "active",
 };
 
+/** Minimal valid PNG header — captured by callers and required by useCreateBadge. */
+const VALID_PNG = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const WITH_PNG = { capturedPng: VALID_PNG };
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockUseUserKey.mockReturnValue({
@@ -98,9 +98,6 @@ beforeEach(() => {
     isReady: true,
     error: null,
   });
-  mockBadges.generateBadgeImagePNG.mockReturnValue(
-    new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
-  );
   mockBadges.bakePNG.mockReturnValue(
     Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
   );
@@ -131,7 +128,7 @@ describe("useCreateBadge", () => {
         return [MOCK_GOAL];
       });
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       expect(result.current.status).toBe("loading");
     });
   });
@@ -145,7 +142,7 @@ describe("useCreateBadge", () => {
         return [];
       });
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(result.current.status).toBe("done");
@@ -155,7 +152,7 @@ describe("useCreateBadge", () => {
 
   describe("successful badge creation", () => {
     it("calls keyProvider.getPublicKey and sign", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(mockKeyProvider.getPublicKey).toHaveBeenCalledWith("key-001");
@@ -167,14 +164,14 @@ describe("useCreateBadge", () => {
       mockCompleteGoal.mockImplementation(() => callOrder.push("completeGoal"));
       mockCreateBadge.mockImplementation(() => callOrder.push("createBadge"));
 
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(callOrder).toEqual(["createBadge", "completeGoal"]);
     });
 
     it("calls createBadge with the real image URI from saveBadgePNG (not the placeholder)", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(mockCreateBadge).toHaveBeenCalledWith(
@@ -186,7 +183,7 @@ describe("useCreateBadge", () => {
     });
 
     it("stores a credential JSON string", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(mockCreateBadge).toHaveBeenCalledWith(
@@ -197,67 +194,27 @@ describe("useCreateBadge", () => {
     });
 
     it("reaches status: done after successful creation", async () => {
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(result.current.status).toBe("done");
       expect(result.current.error).toBeNull();
     });
-
-    it("passes the goal color to generateBadgeImagePNG", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
-      await act(async () => {});
-
-      expect(mockBadges.generateBadgeImagePNG).toHaveBeenCalledWith("#FF5733");
-    });
-
-    it("falls back to DEFAULT_BADGE_COLOR when goal.color is null", async () => {
-      const goalWithoutColor = { ...MOCK_GOAL, color: null };
-      mockUseQuery.mockImplementation((query: string) => {
-        if (query === "mock-goals-query") return [goalWithoutColor];
-        if (query === "mock-badge-query") return [];
-        return [];
-      });
-
-      renderHook(() => useCreateBadge(GOAL_ID));
-      await act(async () => {});
-
-      expect(mockBadges.generateBadgeImagePNG).toHaveBeenCalledWith("#4B7BE5");
-    });
   });
 
-  describe("when design option is provided", () => {
-    it("passes design to createBadge when capturedPng is also provided", async () => {
-      const designJson =
-        '{"shape":"circle","color":"#FF0000","iconName":"Trophy","iconWeight":"regular","frame":"none","title":"Test"}';
-      const fakePng = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
-      renderHook(() =>
-        useCreateBadge(GOAL_ID, {
-          design: designJson,
-          capturedPng: fakePng,
-        }),
-      );
+  describe("when capturedPng is missing", () => {
+    it("fails loudly — callers must provide a PNG (no more silent blue fallback)", async () => {
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
       await act(async () => {});
 
-      expect(mockCreateBadge).toHaveBeenCalledWith(
-        expect.objectContaining({ design: designJson }),
-      );
+      expect(result.current.status).toBe("error");
+      expect(result.current.error).toContain("capturedPng");
+      expect(mockCreateBadge).not.toHaveBeenCalled();
     });
 
-    it("does not include design key when option is not provided", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
-      await act(async () => {});
-
-      const callArg = mockCreateBadge.mock.calls[0][0] as Record<
-        string,
-        unknown
-      >;
-      expect(callArg).not.toHaveProperty("design");
-    });
-
-    it("fails loudly when design is provided without capturedPng", async () => {
+    it("fails loudly when design is provided but capturedPng is not", async () => {
       const designJson =
-        '{"shape":"circle","color":"#FF0000","iconName":"Trophy","iconWeight":"regular","frame":"none","title":"Test"}';
+        '{"shape":"square","color":"#FF0000","iconName":"Trophy","iconWeight":"regular","frame":"none","title":"Test","centerMode":"monogram","monogram":"T"}';
       const { result } = renderHook(() =>
         useCreateBadge(GOAL_ID, { design: designJson }),
       );
@@ -269,24 +226,44 @@ describe("useCreateBadge", () => {
     });
   });
 
-  describe("when capturedPng is provided", () => {
-    it("passes the captured PNG to bakePNG instead of generating one", async () => {
-      const fakePng = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
-      renderHook(() => useCreateBadge(GOAL_ID, { capturedPng: fakePng }));
+  describe("when design option is provided", () => {
+    it("passes design to createBadge when capturedPng is also provided", async () => {
+      const designJson =
+        '{"shape":"square","color":"#FF0000","iconName":"Trophy","iconWeight":"regular","frame":"none","title":"Test","centerMode":"monogram","monogram":"T"}';
+      renderHook(() =>
+        useCreateBadge(GOAL_ID, {
+          design: designJson,
+          capturedPng: VALID_PNG,
+        }),
+      );
       await act(async () => {});
 
-      expect(mockBadges.bakePNG).toHaveBeenCalledWith(
-        fakePng,
-        expect.any(String),
+      expect(mockCreateBadge).toHaveBeenCalledWith(
+        expect.objectContaining({ design: designJson }),
       );
     });
 
-    it("does NOT call generateBadgeImagePNG", async () => {
-      const fakePng = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
-      renderHook(() => useCreateBadge(GOAL_ID, { capturedPng: fakePng }));
+    it("does not include design key when option is not provided", async () => {
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
-      expect(mockBadges.generateBadgeImagePNG).not.toHaveBeenCalled();
+      const callArg = mockCreateBadge.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      expect(callArg).not.toHaveProperty("design");
+    });
+  });
+
+  describe("when capturedPng is provided", () => {
+    it("passes the captured PNG to bakePNG", async () => {
+      renderHook(() => useCreateBadge(GOAL_ID, { capturedPng: VALID_PNG }));
+      await act(async () => {});
+
+      expect(mockBadges.bakePNG).toHaveBeenCalledWith(
+        VALID_PNG,
+        expect.any(String),
+      );
     });
   });
 
@@ -302,7 +279,7 @@ describe("useCreateBadge", () => {
         return [MOCK_GOAL];
       });
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       expect(result.current.status).toBe("no-key");
     });
   });
@@ -313,7 +290,7 @@ describe("useCreateBadge", () => {
         new Error("key not found in SecureStore"),
       );
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(result.current.status).toBe("error");
@@ -327,28 +304,11 @@ describe("useCreateBadge", () => {
         new Error("crypto unavailable"),
       );
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(result.current.status).toBe("error");
       expect(result.current.error).toContain("crypto unavailable");
-    });
-  });
-
-  describe("when image generation fails (generateBadgeImagePNG throws)", () => {
-    it("sets status: error — PNG generation failure is a code defect, not recoverable", async () => {
-      mockBadges.generateBadgeImagePNG.mockImplementationOnce(() => {
-        throw new Error("PNG generation failed");
-      });
-
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
-      await act(async () => {});
-
-      // generateBadgeImagePNG is pure computation — any throw is a code defect
-      // and must propagate to the outer error handler, not degrade gracefully.
-      expect(result.current.status).toBe("error");
-      expect(result.current.error).toContain("PNG generation failed");
-      expect(mockCreateBadge).not.toHaveBeenCalled();
     });
   });
 
@@ -358,7 +318,7 @@ describe("useCreateBadge", () => {
         throw new Error("corrupt PNG chunk");
       });
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       // bakePNG throwing means the PNG we generated is corrupt — a code defect.
@@ -373,7 +333,7 @@ describe("useCreateBadge", () => {
     it("still calls createBadge with the placeholder URI (graceful degradation)", async () => {
       mockBadges.saveBadgePNG.mockRejectedValueOnce(new Error("disk full"));
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(result.current.status).toBe("done");
@@ -391,7 +351,7 @@ describe("useCreateBadge", () => {
         throw new Error("db write failed");
       });
 
-      const { result } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(result.current.status).toBe("error");
@@ -405,7 +365,7 @@ describe("useCreateBadge", () => {
       // sign returns 64 zero bytes — deterministic base64url output
       mockKeyProvider.sign.mockResolvedValue(new Uint8Array(64));
 
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       const callArg = mockCreateBadge.mock.calls[0][0] as {
@@ -444,7 +404,7 @@ describe("useCreateBadge", () => {
         return [];
       });
 
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(mockBadges.buildUnsignedCredential).toHaveBeenCalledWith(
@@ -457,7 +417,7 @@ describe("useCreateBadge", () => {
     });
 
     it("omits stepTitle property for goal-level evidence", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       const callArg = mockBadges.buildUnsignedCredential.mock.calls[0][0] as {
@@ -470,10 +430,10 @@ describe("useCreateBadge", () => {
 
   describe("idempotency", () => {
     it("does not create a second badge on re-render", async () => {
-      const { rerender } = renderHook(() => useCreateBadge(GOAL_ID));
+      const { rerender } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
-      rerender(() => useCreateBadge(GOAL_ID));
+      rerender(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(mockCreateBadge).toHaveBeenCalledTimes(1);
@@ -482,7 +442,7 @@ describe("useCreateBadge", () => {
 
   describe("breadcrumbs", () => {
     it("emits build, sign, bake, store breadcrumbs in order on success", async () => {
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       const calls = mockBreadcrumb.mock.calls.map(
@@ -499,7 +459,7 @@ describe("useCreateBadge", () => {
     it("emits earlier-phase breadcrumbs but not later ones when an early phase throws", async () => {
       mockKeyProvider.sign.mockRejectedValueOnce(new Error("sign failed"));
 
-      renderHook(() => useCreateBadge(GOAL_ID));
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       const messages = mockBreadcrumb.mock.calls.map(

--- a/apps/native-rd/src/hooks/useAudioRecorder.ts
+++ b/apps/native-rd/src/hooks/useAudioRecorder.ts
@@ -98,6 +98,23 @@ export function useAudioRecorder(): AudioRecorderState & AudioRecorderActions {
     }
   }, [status, playerStatus.currentTime, playerStatus.didJustFinish]);
 
+  // Read latest recorder handle via a ref so the polling effect below
+  // doesn't restart its interval every render. expo-audio returns a new
+  // recorder reference each call, which would otherwise re-trigger the effect.
+  const recorderRef = useRef(recorder);
+  recorderRef.current = recorder;
+
+  // Poll the native recorder for elapsed duration while recording so the UI
+  // ticks live. The expo-audio status callback only fires on isFinished, so
+  // without this poll the timer stays at 00:00 until stopRecording().
+  useEffect(() => {
+    if (status !== "recording") return;
+    const id = setInterval(() => {
+      setDurationMs(recorderRef.current.getStatus().durationMillis);
+    }, 200);
+    return () => clearInterval(id);
+  }, [status]);
+
   const startRecording = useCallback(async () => {
     try {
       setError(null);

--- a/apps/native-rd/src/hooks/useCreateBadge.ts
+++ b/apps/native-rd/src/hooks/useCreateBadge.ts
@@ -219,14 +219,13 @@ export function useCreateBadge(
         setStatus("baking");
         breadcrumb({ category: "badge", message: "bake" });
 
-        // capturedPng is required. Callers (CompletionFlowScreen) must
-        // provide either a pending design's PNG or an auto-captured
-        // default-design PNG before enabling badge creation. The old
-        // solid-color fallback baked an unloved blue square into the
-        // credential and is gone for good.
+        // capturedPng is required — either a pending design's PNG or an
+        // auto-captured default-design PNG. The old solid-color fallback
+        // baked an unloved blue square into the credential and is gone
+        // for good.
         if (!capturedPngRef.current) {
           throw new Error(
-            "useCreateBadge: capturedPng is required — callers must capture a default-design PNG before enabling badge creation",
+            "useCreateBadge: capturedPng is required — callers must provide a captured badge PNG (from a pending design or auto-captured default) before enabling badge creation",
           );
         }
         if (!isPNG(capturedPngRef.current)) {

--- a/apps/native-rd/src/hooks/useCreateBadge.ts
+++ b/apps/native-rd/src/hooks/useCreateBadge.ts
@@ -40,11 +40,9 @@ import { keyProvider } from "../crypto";
 import {
   buildUnsignedCredential,
   buildDid,
-  generateBadgeImagePNG,
   bakePNG,
   isPNG,
   saveBadgePNG,
-  DEFAULT_BADGE_COLOR,
 } from "../badges";
 import { Buffer } from "buffer";
 import { useUserKey } from "./useUserKey";
@@ -221,32 +219,22 @@ export function useCreateBadge(
         setStatus("baking");
         breadcrumb({ category: "badge", message: "bake" });
 
-        // Use pre-captured designer PNG when available, otherwise fall back to
-        // the solid-color generator. When the caller provides a `design` but no
-        // `capturedPng`, that's always a programmer error — it means the designer
-        // surface forgot to capture the preview before handing off. Fail loudly
-        // so the silent "baked a solid color instead of the user's design" bug
-        // can't ship again.
-        const hexColor = (goal.color as string | null) ?? DEFAULT_BADGE_COLOR;
-        let pngBuffer: Buffer;
-        if (capturedPngRef.current) {
-          if (!isPNG(capturedPngRef.current)) {
-            throw new Error(
-              "useCreateBadge: capturedPng is not a valid PNG buffer",
-            );
-          }
-          pngBuffer = capturedPngRef.current;
-        } else if (designRef.current) {
+        // capturedPng is required. Callers (CompletionFlowScreen) must
+        // provide either a pending design's PNG or an auto-captured
+        // default-design PNG before enabling badge creation. The old
+        // solid-color fallback baked an unloved blue square into the
+        // credential and is gone for good.
+        if (!capturedPngRef.current) {
           throw new Error(
-            "useCreateBadge: design provided without capturedPng — the designer surface must capture the preview before triggering badge creation",
+            "useCreateBadge: capturedPng is required — callers must capture a default-design PNG before enabling badge creation",
           );
-        } else {
-          logger.warn(
-            "No captured PNG provided — falling back to solid-color badge image",
-            { goalId },
-          );
-          pngBuffer = Buffer.from(generateBadgeImagePNG(hexColor));
         }
+        if (!isPNG(capturedPngRef.current)) {
+          throw new Error(
+            "useCreateBadge: capturedPng is not a valid PNG buffer",
+          );
+        }
+        const pngBuffer = capturedPngRef.current;
         const bakedPng = bakePNG(pngBuffer, JSON.stringify(signedCredential));
 
         // Save to disk — legitimately recoverable (filesystem errors). Fall back

--- a/apps/native-rd/src/screens/CapturePhoto/CapturePhoto.tsx
+++ b/apps/native-rd/src/screens/CapturePhoto/CapturePhoto.tsx
@@ -16,8 +16,7 @@ import { styles } from "./CapturePhoto.styles";
 
 const PICKER_OPTIONS: ImagePicker.ImagePickerOptions = {
   mediaTypes: ["images"],
-  allowsEditing: true,
-  aspect: [4, 3] as [number, number],
+  allowsEditing: false,
   quality: 0.8,
 };
 

--- a/apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.styles.ts
+++ b/apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.styles.ts
@@ -37,7 +37,6 @@ export const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
     paddingTop: theme.space[4],
-    paddingBottom: theme.space[16],
     paddingHorizontal: theme.space[4],
   },
   recordButton: {

--- a/apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.tsx
+++ b/apps/native-rd/src/screens/CaptureVideoScreen/CaptureVideoScreen.tsx
@@ -17,6 +17,7 @@ import type { GoalId, StepId } from "../../db";
 import { reportError } from "../../services/sentry-report";
 import { useEvidenceStartBreadcrumb } from "../../hooks/useEvidenceStartBreadcrumb";
 import type { CaptureVideoScreenProps } from "../../navigation/types";
+import { useTabScreenContentInset } from "../../navigation/useTabScreenContentInset";
 import { styles } from "./CaptureVideoScreen.styles";
 
 /** Maximum recording duration in seconds */
@@ -50,6 +51,7 @@ function Preview({ uri, elapsed }: { uri: string; elapsed: number }) {
 export function CaptureVideoScreen({ route }: CaptureVideoScreenProps) {
   const navigation = useNavigation();
   const { goalId, stepId } = route.params;
+  const tabInset = useTabScreenContentInset();
 
   const cameraRef = useRef<CameraView>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -270,7 +272,7 @@ export function CaptureVideoScreen({ route }: CaptureVideoScreenProps) {
           <Text variant="caption" style={styles.timer}>
             Duration: {formatDuration(elapsed)}
           </Text>
-          <View style={styles.previewControls}>
+          <View style={[styles.previewControls, tabInset]}>
             <View style={styles.previewButton}>
               <Button
                 label="Retake"
@@ -317,7 +319,7 @@ export function CaptureVideoScreen({ route }: CaptureVideoScreenProps) {
               {MAX_DURATION_SECONDS - elapsed}s remaining
             </Text>
           )}
-          <View style={styles.controls}>
+          <View style={[styles.controls, tabInset]}>
             <Pressable
               style={styles.recordButton}
               onPress={handleToggleRecording}

--- a/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.styles.ts
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.styles.ts
@@ -137,4 +137,17 @@ export const styles = StyleSheet.create((theme) => ({
     flexWrap: "wrap",
     gap: theme.space[2],
   },
+  // Offscreen wrapper for the default-design BadgeRenderer used by
+  // captureBadge() when no pending design is available. Must stay inside
+  // the window — Android's view-shot rejects views with negative
+  // coordinates as "view is invalid". opacity: 0 keeps it invisible while
+  // still letting captureRef snapshot it.
+  fallbackCaptureHost: {
+    position: "absolute" as const,
+    left: 0,
+    top: 0,
+    width: 160,
+    height: 160,
+    opacity: 0,
+  },
 }));

--- a/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
@@ -12,6 +12,7 @@ import type { ImageSourcePropType } from "react-native";
 import { Buffer } from "buffer";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import { useQuery } from "@evolu/react";
+import { useUnistyles } from "react-native-unistyles";
 import { Text } from "../../components/Text";
 import { ErrorBoundary } from "../../components/ErrorBoundary";
 import { Button } from "../../components/Button";
@@ -19,6 +20,13 @@ import { ScreenSubHeader } from "../../components/ScreenHeader";
 import { Confetti } from "../../components/Confetti";
 import { ModeIndicator } from "../../components/ModeIndicator";
 import { BadgeEarnedModal } from "../BadgeEarnedModal";
+import {
+  BadgeRenderer,
+  getRendererLayoutOptions,
+} from "../../badges/BadgeRenderer";
+import { captureBadge, getCaptureDimensions } from "../../badges/captureBadge";
+import { createDefaultBadgeDesign } from "../../badges/types";
+import type { BadgeDesign } from "../../badges/types";
 import {
   goalsQuery,
   stepsByGoalQuery,
@@ -90,6 +98,7 @@ function CompletionContent({
   pendingCapturedPng: Buffer | undefined;
 }) {
   const navigation = useNavigation<NavigationProp<GoalsStackParamList>>();
+  const { theme } = useUnistyles();
   const rows = useQuery(goalsQuery);
   const goal = rows.find((r) => r.id === goalId);
   const stepRows = useQuery(stepsByGoalQuery(goalId as GoalId));
@@ -116,13 +125,62 @@ function CompletionContent({
     }
   }, [hasGoalEvidence, phase]);
 
-  // Only create badge when in celebration phase (evidence exists)
+  // Default-design fallback for goals with no pending design (typically goals
+  // whose New-Goal session expired before completion, since pendingDesignStore
+  // is in-memory). Render an offscreen BadgeRenderer with the design-system
+  // default (square + first-letter monogram), capture once, and feed the PNG
+  // into useCreateBadge. Kills the old solid-blue fallback.
+  const goalTitleForDefault = (goal?.title as string | null) ?? "";
+  const goalColorForDefault = (goal?.color as string | null) ?? null;
+  const fallbackDesign: BadgeDesign | null =
+    !pendingCapturedPng && goal
+      ? createDefaultBadgeDesign(goalTitleForDefault, goalColorForDefault)
+      : null;
+  const fallbackRef = useRef<View | null>(null);
+  const [fallbackPng, setFallbackPng] = useState<Buffer | null>(null);
+  const [fallbackHostLaidOut, setFallbackHostLaidOut] = useState(false);
+  const fallbackCaptureStarted = useRef(false);
+
+  useEffect(() => {
+    if (pendingCapturedPng || !fallbackDesign || fallbackPng) return;
+    if (!fallbackHostLaidOut) return; // wait for the offscreen view to be attached + measured
+    if (fallbackCaptureStarted.current) return;
+    fallbackCaptureStarted.current = true;
+    const dimensions = getCaptureDimensions(
+      fallbackDesign,
+      undefined,
+      getRendererLayoutOptions(theme),
+    );
+    captureBadge(fallbackRef, dimensions)
+      .then((buf) => setFallbackPng(buf))
+      .catch((err) => {
+        logger.error("Default-design capture failed", { goalId, error: err });
+        reportError(err, { area: "badge.create", kind: "bake" });
+        fallbackCaptureStarted.current = false;
+      });
+  }, [
+    pendingCapturedPng,
+    fallbackDesign,
+    fallbackPng,
+    fallbackHostLaidOut,
+    theme,
+    goalId,
+  ]);
+
+  const capturedPngForBake = pendingCapturedPng ?? fallbackPng ?? undefined;
+  const designJsonForBake =
+    pendingDesignJson ??
+    (fallbackDesign && fallbackPng
+      ? JSON.stringify(fallbackDesign)
+      : undefined);
+
+  // Only create badge when evidence exists AND we have a PNG (pending or auto-captured)
   const { status: badgeStatus, error: badgeError } = useCreateBadge(
     goalId as GoalId,
     {
-      ...(pendingDesignJson ? { design: pendingDesignJson } : {}),
-      ...(pendingCapturedPng ? { capturedPng: pendingCapturedPng } : {}),
-      enabled: phase === "celebration",
+      ...(designJsonForBake ? { design: designJsonForBake } : {}),
+      ...(capturedPngForBake ? { capturedPng: capturedPngForBake } : {}),
+      enabled: phase === "celebration" && capturedPngForBake !== undefined,
     },
   );
   const isBadgeCreating =
@@ -245,10 +303,32 @@ function CompletionContent({
     setShowBadgeModal(false);
   };
 
+  // Offscreen host for the default-design capture. Rendered in both phases
+  // so the PNG is ready by the time the user transitions to celebration.
+  const fallbackHost = fallbackDesign ? (
+    <View
+      ref={fallbackRef}
+      collapsable={false}
+      style={styles.fallbackCaptureHost}
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      testID="completion-fallback-capture-host"
+      onLayout={(e) => {
+        if (e.nativeEvent.layout.width > 0 && !fallbackHostLaidOut) {
+          setFallbackHostLaidOut(true);
+        }
+      }}
+    >
+      <BadgeRenderer design={fallbackDesign} size={160} showShadow={false} />
+    </View>
+  ) : null;
+
   // Evidence prompt phase — capture evidence before celebration
   if (phase === "evidence-prompt") {
     return (
       <KeyboardAvoidingView style={{ flex: 1 }} {...KEYBOARD_AVOIDING_PROPS}>
+        {fallbackHost}
         <ScrollView contentContainerStyle={styles.scrollContent}>
           <View
             style={styles.card}
@@ -327,6 +407,7 @@ function CompletionContent({
   // Celebration phase — evidence exists, badge being created
   return (
     <View style={{ flex: 1 }}>
+      {fallbackHost}
       <Confetti
         visible={showConfetti}
         onComplete={() => setShowConfetti(false)}

--- a/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
@@ -130,8 +130,8 @@ function CompletionContent({
   // Default-design fallback for goals with no pending design (typically goals
   // whose New-Goal session expired before completion, since pendingDesignStore
   // is in-memory). Render an offscreen BadgeRenderer with the design-system
-  // default (square + first-letter monogram), capture once, and feed the PNG
-  // into useCreateBadge. Kills the old solid-blue fallback.
+  // default (rounded-rectangle + first-letter monogram), capture once, and
+  // feed the PNG into useCreateBadge. Kills the old solid-blue fallback.
   const goalTitleForDefault = (goal?.title as string | null) ?? "";
   const goalColorForDefault = (goal?.color as string | null) ?? null;
   const fallbackDesign: BadgeDesign | null =

--- a/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
@@ -11,6 +11,7 @@ import {
 import type { ImageSourcePropType } from "react-native";
 import { Buffer } from "buffer";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useQuery } from "@evolu/react";
 import { useUnistyles } from "react-native-unistyles";
 import { Text } from "../../components/Text";
@@ -97,7 +98,8 @@ function CompletionContent({
   pendingDesignJson: string | undefined;
   pendingCapturedPng: Buffer | undefined;
 }) {
-  const navigation = useNavigation<NavigationProp<GoalsStackParamList>>();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<GoalsStackParamList>>();
   const { theme } = useUnistyles();
   const rows = useQuery(goalsQuery);
   const goal = rows.find((r) => r.id === goalId);
@@ -266,7 +268,9 @@ function CompletionContent({
 
   const handleReopenGoal = () => {
     uncompleteGoal(goalId as GoalId);
-    navigation.navigate("FocusMode", { goalId });
+    // replace so a back gesture doesn't drop the user back into the
+    // just-left celebration screen (which would re-show BadgeEarnedModal).
+    navigation.replace("FocusMode", { goalId });
   };
 
   const handleViewBadge = () => {

--- a/apps/native-rd/src/screens/CompletionFlowScreen/__tests__/CompletionFlowScreen.test.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/__tests__/CompletionFlowScreen.test.tsx
@@ -11,6 +11,7 @@ import { CompletionFlowScreen } from "../CompletionFlowScreen";
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockReplace = jest.fn();
 const mockParentNavigate = jest.fn();
 const mockGetParent = jest.fn(() => ({ navigate: mockParentNavigate }));
 jest.mock("@react-navigation/native", () => {
@@ -21,6 +22,7 @@ jest.mock("@react-navigation/native", () => {
       ...actual.useNavigation(),
       goBack: mockGoBack,
       navigate: mockNavigate,
+      replace: mockReplace,
       getParent: mockGetParent,
     })),
   };
@@ -332,7 +334,7 @@ describe("CompletionFlowScreen", () => {
       expect(screen.queryByLabelText("Reopen Goal")).not.toBeOnTheScreen();
     });
 
-    it("calls uncompleteGoal and navigates to FocusMode on reopen", () => {
+    it("calls uncompleteGoal and replaces with FocusMode on reopen", () => {
       setupQueries({
         goal: { ...GOAL, status: "completed" },
         goalEvidence: GOAL_EVIDENCE,
@@ -340,7 +342,9 @@ describe("CompletionFlowScreen", () => {
       renderWithProviders(<CompletionFlowScreen {...routeProps} />);
       fireEvent.press(screen.getByLabelText("Reopen Goal"));
       expect(mockUncompleteGoal).toHaveBeenCalledWith("goal-1");
-      expect(mockNavigate).toHaveBeenCalledWith("FocusMode", {
+      // replace (not navigate) so a back gesture from FocusMode doesn't
+      // drop the user back into the celebration screen they just left.
+      expect(mockReplace).toHaveBeenCalledWith("FocusMode", {
         goalId: "goal-1",
       });
     });

--- a/apps/native-rd/src/screens/CompletionFlowScreen/__tests__/CompletionFlowScreen.test.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/__tests__/CompletionFlowScreen.test.tsx
@@ -45,6 +45,20 @@ jest.mock("../../../hooks/useCreateBadge", () => ({
   useCreateBadge: (goalId: any, opts: any) => mockUseCreateBadge(goalId, opts),
 }));
 
+// The default-design auto-capture in CompletionContent calls these. Stub the
+// renderer (avoid expensive SVG render in jsdom) and resolve captureBadge
+// immediately with a fake PNG so the `enabled: true` branch can be observed.
+jest.mock("../../../badges/BadgeRenderer", () => ({
+  BadgeRenderer: () => null,
+  getRendererLayoutOptions: () => ({ strokeWidth: 3, hasShadow: false }),
+}));
+jest.mock("../../../badges/captureBadge", () => ({
+  captureBadge: jest.fn(() =>
+    Promise.resolve(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])),
+  ),
+  getCaptureDimensions: jest.fn(() => ({ width: 512, height: 512 })),
+}));
+
 const mockUncompleteGoal = jest.fn();
 const mockCreateEvidence = jest.fn();
 jest.mock("../../../db", () => ({
@@ -352,12 +366,24 @@ describe("CompletionFlowScreen", () => {
       expect(screen.getAllByText("Complete").length).toBeGreaterThanOrEqual(1);
     });
 
-    it("calls useCreateBadge with the correct goalId", () => {
+    it("calls useCreateBadge with the correct goalId", async () => {
       setupQueries({ goalEvidence: GOAL_EVIDENCE });
       renderWithProviders(<CompletionFlowScreen {...routeProps} />);
-      expect(mockUseCreateBadge).toHaveBeenCalledWith(
-        "goal-1",
-        expect.objectContaining({ enabled: true }),
+      // The default-design auto-capture waits for onLayout before snapshotting.
+      // RN's test renderer doesn't fire layout events automatically, so we
+      // dispatch one synthetically.
+      fireEvent(
+        screen.getByTestId("completion-fallback-capture-host", {
+          includeHiddenElements: true,
+        }),
+        "layout",
+        { nativeEvent: { layout: { x: 0, y: 0, width: 160, height: 160 } } },
+      );
+      await waitFor(() =>
+        expect(mockUseCreateBadge).toHaveBeenCalledWith(
+          "goal-1",
+          expect.objectContaining({ enabled: true }),
+        ),
       );
     });
 
@@ -370,12 +396,21 @@ describe("CompletionFlowScreen", () => {
       );
     });
 
-    it("passes enabled: true to useCreateBadge during celebration phase", () => {
+    it("passes enabled: true to useCreateBadge during celebration phase (after default-design capture)", async () => {
       setupQueries({ goalEvidence: GOAL_EVIDENCE }); // has evidence => celebration phase
       renderWithProviders(<CompletionFlowScreen {...routeProps} />);
-      expect(mockUseCreateBadge).toHaveBeenCalledWith(
-        "goal-1",
-        expect.objectContaining({ enabled: true }),
+      fireEvent(
+        screen.getByTestId("completion-fallback-capture-host", {
+          includeHiddenElements: true,
+        }),
+        "layout",
+        { nativeEvent: { layout: { x: 0, y: 0, width: 160, height: 160 } } },
+      );
+      await waitFor(() =>
+        expect(mockUseCreateBadge).toHaveBeenCalledWith(
+          "goal-1",
+          expect.objectContaining({ enabled: true }),
+        ),
       );
     });
   });

--- a/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
@@ -115,8 +115,7 @@ function FocusContent({ goalId }: { goalId: string }) {
   const { viewEvidence, viewerModals } = useEvidenceViewer();
   const { timelineHidden, setTimelineHidden } = useFocusModePrefs();
   const lifecycle = useRef({
-    announcedComplete: false,
-    triggeredCompletion: false,
+    completionFired: false,
     snappedToFirstPending: false,
     // Tracks whether we observed an incomplete-state during this mount.
     // Without this, reopening a goal (which leaves all steps completed)
@@ -256,26 +255,21 @@ function FocusContent({ goalId }: { goalId: string }) {
     if (!goal) return;
     if (!allStepsComplete) {
       lifecycle.current.sawIncomplete = true;
-      lifecycle.current.announcedComplete = false;
-      lifecycle.current.triggeredCompletion = false;
+      lifecycle.current.completionFired = false;
       return;
     }
     if (!lifecycle.current.sawIncomplete) return;
-    if (lifecycle.current.announcedComplete) return;
-    lifecycle.current.announcedComplete = true;
+    if (lifecycle.current.completionFired) return;
+    lifecycle.current.completionFired = true;
     AccessibilityInfo.announceForAccessibility(
       `All steps completed for "${goal.title}". Goal is ready to complete!`,
     );
-
-    if (!lifecycle.current.triggeredCompletion) {
-      lifecycle.current.triggeredCompletion = true;
-      const timer = setTimeout(() => {
-        if (isMounted.current) {
-          navigation.navigate("CompletionFlow", { goalId });
-        }
-      }, 400);
-      return () => clearTimeout(timer);
-    }
+    const timer = setTimeout(() => {
+      if (isMounted.current) {
+        navigation.navigate("CompletionFlow", { goalId });
+      }
+    }, 400);
+    return () => clearTimeout(timer);
   }, [goal, allStepsComplete, goalId, navigation]);
 
   const handleUndoDelete = useCallback(() => {

--- a/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
@@ -118,6 +118,11 @@ function FocusContent({ goalId }: { goalId: string }) {
     announcedComplete: false,
     triggeredCompletion: false,
     snappedToFirstPending: false,
+    // Tracks whether we observed an incomplete-state during this mount.
+    // Without this, reopening a goal (which leaves all steps completed)
+    // lands FocusMode in allStepsComplete=true, fires the auto-nav, and
+    // bounces the user straight back to CompletionFlow + BadgeEarnedModal.
+    sawIncomplete: false,
   });
   const isMounted = useRef(true);
   const pendingFileDeletionRef = useRef<{
@@ -243,28 +248,33 @@ function FocusContent({ goalId }: { goalId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire on initial population
   }, [stepRowsLength]);
 
-  // Announce when all steps become complete and auto-navigate to completion flow
+  // Announce when all steps become complete and auto-navigate to completion flow.
+  // Only fires on the incomplete → complete transition, not on a fresh mount
+  // that lands already-complete (e.g. after Reopen Goal, where the step rows
+  // stay completed but the goal status is back to active).
   useEffect(() => {
     if (!goal) return;
-    if (allStepsComplete && !lifecycle.current.announcedComplete) {
-      lifecycle.current.announcedComplete = true;
-      AccessibilityInfo.announceForAccessibility(
-        `All steps completed for "${goal.title}". Goal is ready to complete!`,
-      );
-
-      // Auto-navigate to completion flow after brief delay
-      if (!lifecycle.current.triggeredCompletion) {
-        lifecycle.current.triggeredCompletion = true;
-        const timer = setTimeout(() => {
-          if (isMounted.current) {
-            navigation.navigate("CompletionFlow", { goalId });
-          }
-        }, 400);
-        return () => clearTimeout(timer);
-      }
-    } else if (!allStepsComplete) {
+    if (!allStepsComplete) {
+      lifecycle.current.sawIncomplete = true;
       lifecycle.current.announcedComplete = false;
       lifecycle.current.triggeredCompletion = false;
+      return;
+    }
+    if (!lifecycle.current.sawIncomplete) return;
+    if (lifecycle.current.announcedComplete) return;
+    lifecycle.current.announcedComplete = true;
+    AccessibilityInfo.announceForAccessibility(
+      `All steps completed for "${goal.title}". Goal is ready to complete!`,
+    );
+
+    if (!lifecycle.current.triggeredCompletion) {
+      lifecycle.current.triggeredCompletion = true;
+      const timer = setTimeout(() => {
+        if (isMounted.current) {
+          navigation.navigate("CompletionFlow", { goalId });
+        }
+      }, 400);
+      return () => clearTimeout(timer);
     }
   }, [goal, allStepsComplete, goalId, navigation]);
 

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -483,7 +483,42 @@ describe("FocusModeScreen", () => {
     expect(screen.getByText("Focus Mode")).toBeOnTheScreen();
   });
 
-  it("auto-navigates to CompletionFlow when all steps are completed", () => {
+  it("auto-navigates to CompletionFlow on the pending→complete transition", () => {
+    jest.useFakeTimers();
+    // Start with one step pending so allStepsComplete=false on mount.
+    // The auto-nav only fires after we observe a transition from incomplete
+    // to complete — this prevents Reopen Goal from immediately bouncing the
+    // user back to CompletionFlow (since reopening leaves all steps completed).
+    setupQueries({
+      steps: [
+        { id: "step-1", title: "Read docs", status: "completed", ordinal: 0 },
+        { id: "step-2", title: "Practice", status: "pending", ordinal: 1 },
+      ],
+    });
+    const view = renderWithProviders(<FocusModeScreen {...routeProps} />);
+
+    jest.advanceTimersByTime(400);
+    expect(mockNavigate).not.toHaveBeenCalledWith("CompletionFlow", {
+      goalId: "goal-1",
+    });
+
+    // Now flip the pending step to completed and rerender.
+    setupQueries({
+      steps: [
+        { id: "step-1", title: "Read docs", status: "completed", ordinal: 0 },
+        { id: "step-2", title: "Practice", status: "completed", ordinal: 1 },
+      ],
+    });
+    view.rerender(<FocusModeScreen {...routeProps} />);
+
+    jest.advanceTimersByTime(400);
+    expect(mockNavigate).toHaveBeenCalledWith("CompletionFlow", {
+      goalId: "goal-1",
+    });
+    jest.useRealTimers();
+  });
+
+  it("does NOT auto-navigate on a fresh mount where every step is already completed (reopen-goal case)", () => {
     jest.useFakeTimers();
     setupQueries({
       steps: [
@@ -493,8 +528,8 @@ describe("FocusModeScreen", () => {
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
 
-    jest.advanceTimersByTime(400);
-    expect(mockNavigate).toHaveBeenCalledWith("CompletionFlow", {
+    jest.advanceTimersByTime(1000);
+    expect(mockNavigate).not.toHaveBeenCalledWith("CompletionFlow", {
       goalId: "goal-1",
     });
     jest.useRealTimers();
@@ -783,8 +818,32 @@ describe("FocusModeScreen", () => {
     ]);
   });
 
-  it("auto-navigates to CompletionFlow when all steps complete with evidence gate", () => {
+  it("auto-navigates to CompletionFlow on the transition when all steps complete with evidence gate", () => {
     jest.useFakeTimers();
+    setupQueries({
+      steps: [
+        {
+          id: "step-1",
+          title: "Read docs",
+          status: "completed",
+          ordinal: 0,
+          plannedEvidenceTypes: '["text"]',
+        },
+        {
+          id: "step-2",
+          title: "Practice",
+          status: "pending",
+          ordinal: 1,
+          plannedEvidenceTypes: null,
+        },
+      ],
+    });
+    const view = renderWithProviders(<FocusModeScreen {...routeProps} />);
+    jest.advanceTimersByTime(400);
+    expect(mockNavigate).not.toHaveBeenCalledWith("CompletionFlow", {
+      goalId: "goal-1",
+    });
+
     setupQueries({
       steps: [
         {
@@ -803,7 +862,7 @@ describe("FocusModeScreen", () => {
         },
       ],
     });
-    renderWithProviders(<FocusModeScreen {...routeProps} />);
+    view.rerender(<FocusModeScreen {...routeProps} />);
     jest.advanceTimersByTime(400);
     expect(mockNavigate).toHaveBeenCalledWith("CompletionFlow", {
       goalId: "goal-1",


### PR DESCRIPTION
## Summary
Five independent Android-surfaced fixes from a single triage pass, plus the rebake-on-reopen follow-up filed separately as #15.

- **Video capture**: record + flip buttons no longer hide under the lifted `FocusPillTabBar`.
- **Voice memo**: duration timer ticks every 200ms during recording instead of staying at `00:00`.
- **Badge fallback**: the solid-blue `generateBadgeImagePNG` fallback is gone. `createDefaultBadgeDesign` now produces a rounded-rect with the title's first-letter monogram (matching the placeholder in `BadgeCard` tiles), and `CompletionFlowScreen` auto-captures that default offscreen via `captureBadge()` whenever `pendingDesignStore` is empty.
- **Photo capture**: `allowsEditing: false` — no more forced crop after every shot.
- **Reopen-goal loop**: `FocusModeScreen`'s auto-nav to `CompletionFlow` now only fires on an observed pending→complete transition (new `sawIncomplete` lifecycle flag), so reopening a goal no longer bounces the user straight back to the stale `BadgeEarnedModal`. The Reopen button also uses `navigation.replace` so a back gesture can't drop the user back into the just-left celebration screen.

Plan: [`apps/native-rd/docs/plans/2026-05-14-android-bug-triage.md`](../blob/fix/native-rd-android-bug-triage/apps/native-rd/docs/plans/2026-05-14-android-bug-triage.md)
Follow-up issue: #15 (rebake with confirmation on reopen + update + re-complete)

## Test plan
- [x] `bun run type-check`
- [x] `bun run lint`
- [x] `npx jest --no-coverage` (143 suites / 8,052 tests pass)
- [x] Manual on Android device — user verified video, audio, badge, photo, and reopen flows
- [x] iOS regression spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)