### PR TITLE
ci(dco): skip bot-authored commits in Signed-off-by check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -29,16 +29,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          # List non-merge commits in the PR
-          commits=$(git log --no-merges --format='%H' "${BASE_SHA}..${HEAD_SHA}")
+          # List non-merge commits in the PR (hash<TAB>author-email)
+          commits=$(git log --no-merges --format='%H%x09%ae' "${BASE_SHA}..${HEAD_SHA}")
           missing=""
 
-          for sha in $commits; do
+          # Bot author-email patterns we exempt from the DCO trailer requirement.
+          # GitHub bot accounts use *+<bot>@users.noreply.github.com or *[bot]@users.noreply.github.com.
+          bot_re='(^[0-9]+\+(Copilot|dependabot|github-actions)(\[bot\])?@users\.noreply\.github\.com$|^[^@]+\[bot\]@users\.noreply\.github\.com$)'
+
+          while IFS=$'\t' read -r sha author_email; do
+            [ -z "$sha" ] && continue
+            if echo "$author_email" | grep -qE "$bot_re"; then
+              echo "Skipping bot-authored commit $sha ($author_email)"
+              continue
+            fi
             if ! git show -s --format=%B "$sha" | grep -qE "^Signed-off-by: .+ <.+@.+>$"; then
               subject=$(git show -s --format=%s "$sha")
               missing="${missing}${sha} ${subject}"$'\n'
             fi
-          done
+          done <<< "$commits"
 
           if [ -n "$missing" ]; then
             echo "::error::The following commits are missing a 'Signed-off-by:' trailer (DCO)."


### PR DESCRIPTION
## Summary

- Exempt GitHub bot-authored commits from the DCO Signed-off-by trailer requirement.
- Bot patterns covered: `*+Copilot@users.noreply.github.com`, `*+dependabot[bot]@…`, `*+github-actions[bot]@…`, and the generic `*[bot]@users.noreply.github.com` (catches CodeRabbit, etc.).
- Human commits still must carry `Signed-off-by:` — DCO policy unchanged for contributors.

## Why

PR #18 (and any PR that picks up a Copilot Autofix suggestion via GitHub UI) currently fails `Verify Signed-off-by` because the bot-authored commits don't carry the trailer. There's no way to make GitHub UI add it. Skipping bot commits in the check restores DCO to its intended scope — verifying human attestation — without forcing maintainers to either reject every bot suggestion or rewrite history on every PR.

## Test plan

- [x] Regex tested locally against real bot emails (Copilot, dependabot, github-actions, CodeRabbit) and human emails — bots match, humans don't.
- [ ] CI run on this PR passes `Verify Signed-off-by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)