### PR TITLE
fix(native-rd): drop KAV vertical offset that left white strip above keyboard

### DIFF
--- a/apps/native-rd/src/utils/keyboard.ts
+++ b/apps/native-rd/src/utils/keyboard.ts
@@ -2,11 +2,16 @@ import { Platform } from "react-native";
 
 /**
  * Shared KeyboardAvoidingView props for screens with text inputs.
- * The 88pt iOS offset accounts for the SafeAreaView top inset + header.
+ *
+ * No vertical offset is needed: every consumer renders ScreenSubHeader as a JS
+ * sibling above the KAV (navigators use `headerShown: false`), so the KAV's
+ * onLayout already reflects the post-header screen position. Setting a non-zero
+ * offset would double-count the header and leave a visible white strip above
+ * the keyboard.
  */
 export const KEYBOARD_AVOIDING_PROPS = {
   behavior: (Platform.OS === "ios" ? "padding" : "height") as
     | "padding"
     | "height",
-  keyboardVerticalOffset: Platform.OS === "ios" ? 88 : 0,
+  keyboardVerticalOffset: 0,
 };


### PR DESCRIPTION
## Summary

- `KEYBOARD_AVOIDING_PROPS` was setting `keyboardVerticalOffset: 88` on iOS, intended to compensate for the SafeAreaView top inset + header.
- But all three consumers (`CompletionFlowScreen`, `FocusModeScreen`, `CaptureTextNote`) render `ScreenSubHeader` as a JS sibling above the KAV inside a `headerShown: false` native-stack screen — so the KAV's `onLayout` frame already accounts for the header. Adding 88 double-counted it, padding the KAV bottom by `keyboard_height + 88pt` and producing a visible white strip between the input field and the keyboard's predictive-text bar.
- Set offset to `0` and rewrite the comment with the correct rationale.

## Repro (before)

On the Complete screen (`CompletionFlowScreen` in `evidence-prompt` phase), tap "Write about what you accomplished" → keyboard opens → ~88pt of white space sits between the input field and the predictive-text bar; the absolutely-positioned `ModeIndicator` at `bottom: 0` of the container peeks through.

## Test plan

- [x] `bun run type-check` clean
- [x] `bash scripts/jest-node.sh --testPathPatterns "CompletionFlowScreen|FocusModeScreen|CaptureTextNote"` — 96/96 pass
- [x] `bun run lint` — no new errors
- [ ] Visual on iOS: focus the text input on the Complete screen; input field sits flush against the keyboard predictive-text bar with no white strip
- [ ] Visual on iOS: same check for `FocusModeScreen` quick-note input
- [ ] Visual on iOS: same check for `CaptureTextNote` screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)