### PR TITLE
feat(native-rd): EAS local build wrapper redirecting to SpinDrive

### DIFF
--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -30,6 +30,10 @@
     "test:a11y": "bash scripts/a11y-audit.sh",
     "test:a11y:json": "bash scripts/a11y-audit.sh --json",
     "testflight:ios": "bash scripts/testflight-ios.sh",
+    "eas:local:android": "bash scripts/run-eas-local.sh android preview",
+    "eas:local:android:prod": "bash scripts/run-eas-local.sh android production",
+    "eas:local:ios": "bash scripts/run-eas-local.sh ios preview",
+    "eas:local:ios:prod": "bash scripts/run-eas-local.sh ios production",
     "gen:pseudo": "bun run scripts/generate-pseudo-locale.ts"
   },
   "dependencies": {

--- a/apps/native-rd/scripts/run-eas-local.sh
+++ b/apps/native-rd/scripts/run-eas-local.sh
@@ -110,9 +110,18 @@ echo "  workingdir: ${WORKDIR}"
 echo "  artifact:   ${artifact}"
 echo
 
-exec eas build \
+# Process substitution keeps stderr separate from stdout (a `2>&1 | redact`
+# pipeline would collapse both onto stdout, breaking callers that capture
+# them separately, e.g. CI log redirection). `|| ec=$?` captures the exit
+# code without tripping `set -e`. `wait` lets the redact subprocesses drain
+# before the script exits — otherwise the last few lines can race.
+ec=0
+eas build \
   --platform "${platform}" \
   --profile "${profile}" \
   --local \
   --non-interactive \
-  --output "${artifact}" 2>&1 | redact
+  --output "${artifact}" \
+  > >(redact) 2> >(redact >&2) || ec=$?
+wait
+exit "${ec}"

--- a/apps/native-rd/scripts/run-eas-local.sh
+++ b/apps/native-rd/scripts/run-eas-local.sh
@@ -92,11 +92,14 @@ artifact="${ARTIFACT_DIR}/native-rd-${platform}-${profile}-${sha}.${ext}"
 
 # Redact the base64 payload printed by eas-cli-local-build-plugin when its
 # subprocess exits non-zero — the payload inlines the Android keystore + key
-# passwords + alias. Pattern matches `<pkg>@<ver> <base64≥100 chars>`.
+# passwords + alias. Two passes: (1) the known leak shape if the plugin name
+# is still in the line, (2) any standalone long base64 run as defense-in-depth
+# if EAS ever changes its log format (newlines, scoped package name, etc.).
 redact() {
   awk '{
     gsub(/eas-cli-local-build-plugin@[0-9.]+ [A-Za-z0-9+\/=]{100,}/,
          "eas-cli-local-build-plugin@<ver> [REDACTED EAS PAYLOAD]");
+    gsub(/[A-Za-z0-9+\/=]{200,}/, "[REDACTED BASE64]");
     print;
     fflush();
   }'

--- a/apps/native-rd/scripts/run-eas-local.sh
+++ b/apps/native-rd/scripts/run-eas-local.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# EAS local build wrapper for native-rd. Builds APK/AAB/IPA off the system SSD
+# by pointing EAS_LOCAL_BUILD_WORKINGDIR at /Volumes/SpinDrive, fetches
+# SENTRY_AUTH_TOKEN from macOS Keychain so the Gradle Sentry-upload task can
+# authenticate, and redacts the base64 build payload (which inlines the
+# Android keystore) from stderr so a failure doesn't leak signing material
+# into terminal scrollback.
+#
+# Usage:
+#   run-eas-local.sh [platform] [profile]
+#   run-eas-local.sh android preview        # default
+#   run-eas-local.sh android production
+#   run-eas-local.sh ios preview
+#
+# Env overrides:
+#   SENTRY_DISABLE_AUTO_UPLOAD=1   Skip Sentry sourcemap upload (use when the
+#                                   keychain token is rotated/missing).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${APP_DIR}"
+
+platform="${1:-android}"
+profile="${2:-preview}"
+
+# Pre-flight: SpinDrive must be the actual external volume. If it isn't
+# mounted, /Volumes/SpinDrive can be a regular dir on the system SSD — which
+# would defeat the entire point of redirecting the workingdir.
+SPINDRIVE_MOUNT="/Volumes/SpinDrive"
+SPINDRIVE_EXPECTED_FS="/dev/disk8s1"
+
+actual_fs="$(df "${SPINDRIVE_MOUNT}" 2>/dev/null | awk 'NR==2 {print $1}')"
+if [ "${actual_fs}" != "${SPINDRIVE_EXPECTED_FS}" ]; then
+  echo "Error: ${SPINDRIVE_MOUNT} is not mounted on ${SPINDRIVE_EXPECTED_FS} (got '${actual_fs:-nothing}')." >&2
+  echo "  Mount SpinDrive before running EAS local builds." >&2
+  exit 1
+fi
+
+WORKDIR="${SPINDRIVE_MOUNT}/caches/eas-build-local"
+ARTIFACT_DIR="${WORKDIR}/artifacts"
+mkdir -p "${WORKDIR}" "${ARTIFACT_DIR}"
+export EAS_LOCAL_BUILD_WORKINGDIR="${WORKDIR}"
+
+# Bun's npm-compat env vars confuse Gradle's autolinking shell-out when EAS
+# invokes gradlew through the bun-managed PATH. Same fix as run-android.sh.
+while IFS='=' read -r env_name _; do
+  unset "${env_name}"
+done < <(env | awk -F= '/^npm_/ { print $1 }')
+
+# Fetch SENTRY_AUTH_TOKEN from Keychain. Never echoed. If neither in env nor
+# keychain AND user hasn't opted out, fail loud — silently producing a build
+# without sourcemap upload would let crashes ship unsymbolicated.
+if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+  if security find-generic-password -s SENTRY_AUTH_TOKEN -w >/dev/null 2>&1; then
+    SENTRY_AUTH_TOKEN="$(security find-generic-password -s SENTRY_AUTH_TOKEN -w)"
+    export SENTRY_AUTH_TOKEN
+  elif [ "${SENTRY_DISABLE_AUTO_UPLOAD:-0}" = "0" ]; then
+    echo "Error: SENTRY_AUTH_TOKEN not in Keychain and not in env." >&2
+    echo "  Add one: security add-generic-password -a \"\$USER\" -s SENTRY_AUTH_TOKEN -U -w" >&2
+    echo "  Or skip Sentry upload: SENTRY_DISABLE_AUTO_UPLOAD=1 $0 $*" >&2
+    exit 1
+  fi
+fi
+
+sha="$(git -C "${APP_DIR}" rev-parse --short HEAD 2>/dev/null || echo nogit)"
+case "${platform}-${profile}" in
+  android-production) ext="aab" ;;
+  android-*)          ext="apk" ;;
+  ios-*)              ext="ipa" ;;
+  *)
+    echo "Error: unsupported platform '${platform}' (expected: android, ios)." >&2
+    exit 1
+    ;;
+esac
+artifact="${ARTIFACT_DIR}/native-rd-${platform}-${profile}-${sha}.${ext}"
+
+# Redact the base64 payload printed by eas-cli-local-build-plugin when its
+# subprocess exits non-zero — the payload inlines the Android keystore + key
+# passwords + alias. Pattern matches `<pkg>@<ver> <base64≥100 chars>`.
+redact() {
+  awk '{
+    gsub(/eas-cli-local-build-plugin@[0-9.]+ [A-Za-z0-9+\/=]{100,}/,
+         "eas-cli-local-build-plugin@<ver> [REDACTED EAS PAYLOAD]");
+    print;
+    fflush();
+  }'
+}
+
+echo "▸ EAS local build: ${platform} / ${profile}"
+echo "  workingdir: ${WORKDIR}"
+echo "  artifact:   ${artifact}"
+echo
+
+exec eas build \
+  --platform "${platform}" \
+  --profile "${profile}" \
+  --local \
+  --non-interactive \
+  --output "${artifact}" 2>&1 | redact

--- a/apps/native-rd/scripts/run-eas-local.sh
+++ b/apps/native-rd/scripts/run-eas-local.sh
@@ -63,16 +63,19 @@ done < <(env | awk -F= '/^npm_/ { print $1 }')
 # Fetch SENTRY_AUTH_TOKEN from Keychain. Never echoed. If neither in env nor
 # keychain AND user hasn't opted out, fail loud — silently producing a build
 # without sourcemap upload would let crashes ship unsymbolicated.
-if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
-  if security find-generic-password -s SENTRY_AUTH_TOKEN -w >/dev/null 2>&1; then
-    SENTRY_AUTH_TOKEN="$(security find-generic-password -s SENTRY_AUTH_TOKEN -w)"
+# Skip the Keychain lookup entirely when SENTRY_DISABLE_AUTO_UPLOAD=1 — the
+# opt-out flag should not export the token into the build environment.
+if [ "${SENTRY_DISABLE_AUTO_UPLOAD:-0}" = "0" ] && [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+  if token="$(security find-generic-password -s SENTRY_AUTH_TOKEN -w 2>/dev/null)" && [ -n "${token}" ]; then
+    SENTRY_AUTH_TOKEN="${token}"
     export SENTRY_AUTH_TOKEN
-  elif [ "${SENTRY_DISABLE_AUTO_UPLOAD:-0}" = "0" ]; then
+  else
     echo "Error: SENTRY_AUTH_TOKEN not in Keychain and not in env." >&2
     echo "  Add one: security add-generic-password -a \"\$USER\" -s SENTRY_AUTH_TOKEN -U -w" >&2
     echo "  Or skip Sentry upload: SENTRY_DISABLE_AUTO_UPLOAD=1 $0 $*" >&2
     exit 1
   fi
+  unset token
 fi
 
 sha="$(git -C "${APP_DIR}" rev-parse --short HEAD 2>/dev/null || echo nogit)"

--- a/apps/native-rd/scripts/run-eas-local.sh
+++ b/apps/native-rd/scripts/run-eas-local.sh
@@ -13,6 +13,8 @@
 #   run-eas-local.sh ios preview
 #
 # Env overrides:
+#   EAS_LOCAL_BUILD_VOLUME         Mountpoint to use for the workingdir.
+#                                   Defaults to /Volumes/SpinDrive.
 #   SENTRY_DISABLE_AUTO_UPLOAD=1   Skip Sentry sourcemap upload (use when the
 #                                   keychain token is rotated/missing).
 
@@ -25,20 +27,29 @@ cd "${APP_DIR}"
 platform="${1:-android}"
 profile="${2:-preview}"
 
-# Pre-flight: SpinDrive must be the actual external volume. If it isn't
-# mounted, /Volumes/SpinDrive can be a regular dir on the system SSD — which
-# would defeat the entire point of redirecting the workingdir.
-SPINDRIVE_MOUNT="/Volumes/SpinDrive"
-SPINDRIVE_EXPECTED_FS="/dev/disk8s1"
+# Pre-flight: the target volume must be a separate mounted filesystem. If it
+# isn't, the path can resolve to a regular dir on the system SSD — which would
+# defeat the entire point of redirecting the workingdir. Compare filesystem
+# device numbers (stat -f '%d') instead of hardcoding a device path like
+# /dev/disk8s1: macOS disk identifiers are unstable across reboots and depend
+# on USB attach order.
+VOLUME_MOUNT="${EAS_LOCAL_BUILD_VOLUME:-/Volumes/SpinDrive}"
 
-actual_fs="$(df "${SPINDRIVE_MOUNT}" 2>/dev/null | awk 'NR==2 {print $1}')"
-if [ "${actual_fs}" != "${SPINDRIVE_EXPECTED_FS}" ]; then
-  echo "Error: ${SPINDRIVE_MOUNT} is not mounted on ${SPINDRIVE_EXPECTED_FS} (got '${actual_fs:-nothing}')." >&2
-  echo "  Mount SpinDrive before running EAS local builds." >&2
+if [ ! -d "${VOLUME_MOUNT}" ]; then
+  echo "Error: ${VOLUME_MOUNT} does not exist." >&2
+  echo "  Mount it (or set EAS_LOCAL_BUILD_VOLUME) before running EAS local builds." >&2
   exit 1
 fi
 
-WORKDIR="${SPINDRIVE_MOUNT}/caches/eas-build-local"
+root_fsid="$(stat -f '%d' /)"
+mount_fsid="$(stat -f '%d' "${VOLUME_MOUNT}" 2>/dev/null || true)"
+if [ -z "${mount_fsid}" ] || [ "${mount_fsid}" = "${root_fsid}" ]; then
+  echo "Error: ${VOLUME_MOUNT} is not a separate mounted filesystem (same device as /)." >&2
+  echo "  The path exists but resolves to the system disk — mount the external volume first." >&2
+  exit 1
+fi
+
+WORKDIR="${VOLUME_MOUNT}/caches/eas-build-local"
 ARTIFACT_DIR="${WORKDIR}/artifacts"
 mkdir -p "${WORKDIR}" "${ARTIFACT_DIR}"
 export EAS_LOCAL_BUILD_WORKINGDIR="${WORKDIR}"


### PR DESCRIPTION
## Summary

- New `apps/native-rd/scripts/run-eas-local.sh` wrapper around `eas build --local`.
- Four `bun run eas:local:{android,android:prod,ios,ios:prod}` script entries.
- Keeps multi-GiB build intermediates off the system SSD (46 GiB free) and on SpinDrive (535 GiB free) via `EAS_LOCAL_BUILD_WORKINGDIR`.
- Fetches `SENTRY_AUTH_TOKEN` from macOS Keychain at runtime (never echoed, never persisted to a `.env` file).
- Redacts the base64 build-job payload that `eas-cli-local-build-plugin` prints to stderr on failure — that payload inlines the Android upload keystore + passwords + alias, which would otherwise land in terminal scrollback and any captured log.
- Pre-flight verifies SpinDrive is mounted on `/dev/disk8s1` so an unmounted volume can't silently degrade into a stub dir on the system SSD.

## Context

Investigated whether `eas build --local` is viable for this project. Full pipeline works (`eas` auth, remote keystore fetch, project fingerprint, `bun install`, `expo prebuild`, post-install turbo hook, eager Metro bundle, 894 Gradle tasks including native C++ for openssl/quick-crypto/unistyles/Hermes) — only `eas` server-side **Sensitive** env vars aren't injected to `--local` builds. `SENTRY_AUTH_TOKEN` is the one this project needs; this wrapper bridges that gap from Keychain instead of inventing yet another `.env` file.

Artifacts land at `/Volumes/SpinDrive/caches/eas-build-local/artifacts/native-rd-<platform>-<profile>-<short-sha>.{apk|aab|ipa}`.

## Test plan

- [ ] `bun run eas:local:android` produces a signed APK at the expected path
- [ ] `SENTRY_DISABLE_AUTO_UPLOAD=1 bun run eas:local:android` succeeds without a valid Sentry token (current keychain entry returns 401; rotation pending)
- [ ] Wrapper bails out with a clear error if `/Volumes/SpinDrive` isn't mounted
- [ ] Wrapper bails out if `SENTRY_AUTH_TOKEN` is missing from both env and Keychain, unless `SENTRY_DISABLE_AUTO_UPLOAD=1`
- [ ] Forced failure (e.g. wrong profile name) keeps the base64 payload redacted in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)