### PR TITLE
ci(dco): auto-sign commits via prepare-commit-msg hook

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+# Auto-append Signed-off-by trailer (DCO) to every commit.
+# Equivalent to passing `-s` on every `git commit`. The workflow at
+# .github/workflows/dco.yml requires this trailer on non-merge commits.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Merge commits are excluded by the DCO workflow (--no-merges); don't add.
+case "$COMMIT_SOURCE" in
+  merge) exit 0 ;;
+esac
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+  exit 0
+fi
+
+git interpret-trailers \
+  --trailer "Signed-off-by: $NAME <$EMAIL>" \
+  --in-place "$COMMIT_MSG_FILE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Workspace root. The app and the rules that govern it live one level down.
 
 - **Never** add a workspace dependency on `@rollercoaster-dev/openbadges-types`, `@rollercoaster-dev/rd-logger`, or `@rollercoaster-dev/shared-config` — those are registry deps in this repo, not workspace packages.
 - **Never** restore CI references to removed monorepo apps (`openbadges-system`, `openbadges-modular-server`, `openbadges-ui`).
+- **DCO is mandatory.** Every non-merge commit on a PR to `main` needs a `Signed-off-by: <name> <email>` trailer (enforced by `.github/workflows/dco.yml`; rationale in `LICENSING.md`). The husky hook at `.husky/prepare-commit-msg` adds it automatically — run `bun install` after clone so husky activates. If you ever bypass hooks (`--no-verify`, amends in editors that strip trailers, web-UI suggestions), append the trailer manually before pushing. `format.signOff = true` in git config does **not** do this — it only affects `git format-patch`.
 - Workspace commands live in root `package.json`: `bun run native:ios`, `bun run native:android`, `bun run type-check`, `bun run lint`, `bun run test`.
 
 ## Root commands


### PR DESCRIPTION
## Why

`format.signOff = true` was set globally and in this repo, but **that config only affects `git format-patch`, not `git commit`**. So nothing was appending the `Signed-off-by:` trailer on day-to-day commits — every PR failed the DCO workflow and got rebased/force-pushed to fix. The earlier bot-exemption fix (#25) handled only the bot class of failure; the human-author class was the bulk of the pain.

## What

- **New husky hook** at `.husky/prepare-commit-msg` calls `git interpret-trailers` to append `Signed-off-by: <name> <email>` on every non-merge commit. Idempotent (won't duplicate when the trailer is already present), skips merge commits (which `.github/workflows/dco.yml` already excludes via `--no-merges`).
- **Hard rule in root `CLAUDE.md`** documents the DCO mandate, points at the hook, and explicitly calls out the `format.signOff` trap so future contributors and agents don't repeat the misdiagnosis.

This self-tested on its own commit — the trailer at the bottom of `f5bf16e` was added by the hook, not by `-s`.

## Verification

Throwaway-repo test confirmed:
- Plain `git commit -m "msg"` → trailer auto-appended ✓
- Commit body that already includes `Signed-off-by: …` → not duplicated ✓
- `prepare-commit-msg` called with `COMMIT_SOURCE=merge` → no-op ✓

The DCO workflow itself is unchanged; this PR exists to make commits actually satisfy it.

## Test plan

- [ ] CI `DCO` check passes on this PR (would have failed pre-hook)
- [ ] `lint-staged` / `pre-commit` still runs (this PR triggered it on commit — see hook output in commit logs)
- [ ] After merge, follow-up commits on subsequent PRs auto-sign without `-s`

## Known follow-ups (not in this PR)

- `CONTRIBUTING.md` still tells contributors to use `git commit -s` or rely on `format.signOff`. With this hook installed (via `bun install`), plain `git commit -m` works. Worth a small docs pass — happy to do as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)