### PR TITLE
fix(native-rd): register only product themes

### DIFF
--- a/apps/native-rd/docs/architecture/design-token-system.md
+++ b/apps/native-rd/docs/architecture/design-token-system.md
@@ -167,26 +167,27 @@ design-tokens package
   src/themes/tokens.ts     ← re-exports space, size, radius, etc.
   src/themes/colorModes.ts ← wraps colors into ColorModeConfig shape
   src/themes/variants.ts   ← variant overrides + mood labels
-  src/themes/compose.ts    ← composeTheme() → 14 ComposedThemes
+  src/themes/compose.ts    ← composeTheme() + 7 registered product themes
 ```
 
 ---
 
 ## Theme Composition
 
-native-rd composes **2 color modes × 7 variants = 14 themes** via `compose.ts`:
+native-rd exposes **7 product themes** via `compose.ts`. `composeTheme(colorMode, variant)` can still build any color-mode/variant pair for previews and focused tests, but only the product themes are registered with Unistyles at runtime:
 
 ```typescript
 // compose.ts
 const themes = Object.fromEntries(
-  colorModeList.flatMap((cm) =>
-    variants.map((v) => [`${cm}-${v}`, composeTheme(cm, v)]),
-  ),
+  productThemeEntries.map(([name, colorMode, variant]) => [
+    name,
+    composeTheme(colorMode, variant),
+  ]),
 ) as Record<ThemeName, ComposedTheme>;
 ```
 
-Theme names follow the pattern `{colorMode}-{variant}`:
-`light-default`, `light-highContrast`, `dark-dyslexia`, `dark-lowVision`, etc.
+Registered theme names are:
+`light-default`, `dark-default`, `light-highContrast`, `light-dyslexia`, `light-autismFriendly`, `light-lowVision`, and `light-lowInfo`.
 
 See [ND Themes](../design/nd-themes.md) for the full theme reference.
 
@@ -212,5 +213,5 @@ The package includes HTML visual reference pages at `overview/` that render all 
 ## Related Documents
 
 - [Design Language](../design/design-language.md) — how tokens translate to React Native
-- [ND Themes](../design/nd-themes.md) — all 14 composed theme definitions
+- [ND Themes](../design/nd-themes.md) — neurodiversity theme definitions
 - [Design Principles](../vision/design-principles.md) — the themes as day-one requirements

--- a/apps/native-rd/docs/architecture/theme-persistence.md
+++ b/apps/native-rd/docs/architecture/theme-persistence.md
@@ -57,15 +57,23 @@ App
 
 ## Validation surface
 
-`VALID_THEME_NAMES` is a `Set<ThemeName>` derived from the 7 exposed `themeOptions`. Both read and write paths gate on `isValidThemeName()`. This is intentionally **narrower** than the typed `ThemeName` union (14 values from `compose.ts`) — see _Known mismatch_ below.
+`VALID_THEME_NAMES` is a `Set<ThemeName>` derived from the 7 exposed `themeOptions`. Both read and write paths gate on `isValidThemeName()`. `ThemeName`, `themeNames`, and the Unistyles runtime registry now share the same 7-value product theme set.
 
 ---
 
-## Known mismatch with `compose.ts`
+## Runtime Registry
 
-`src/themes/compose.ts:278-289` registers all 14 combinations of `colorMode × variant`. The settings UI exposes only the 7 in `themeOptions`. Issue [#940](https://github.com/rollercoaster-dev/openbadges-monorepo/issues/940) intended to collapse the registry to 7 but the cleanup did not land.
+`src/themes/compose.ts` keeps `composeTheme(colorMode, variant)` flexible enough to build unsupported combinations for previews and tests, but only seven product themes are registered with Unistyles:
 
-The persistence layer treats the 7 as canonical: writes are restricted to that set, and reads outside the set fall back. We did **not** delete the extra 7 from the registry because hooks like `useDensity.ts:11` iterate `themeNames` to push per-theme density updates and shrinking the registry would silently drop coverage. Reopen #940 if/when that consolidation is wanted.
+- `light-default`
+- `dark-default`
+- `light-highContrast`
+- `light-dyslexia`
+- `light-autismFriendly`
+- `light-lowVision`
+- `light-lowInfo`
+
+The persistence layer treats those 7 as canonical: writes are restricted to that set, and reads outside the set fall back. `useDensity.ts` iterates the same `themeNames`, so density updates no longer touch unregistered or unsupported dark/accessibility combinations.
 
 ---
 
@@ -109,4 +117,4 @@ The E2E restart flow uses a combined `id="selected-theme"` + `text="Night Ride"`
 - `App.tsx` — provider nesting (outer + inner `ThemeProvider`).
 - `src/db/schema.ts:154-156` — `userSettings.theme` column.
 - `src/db/queries.ts:1123-1136` — `updateUserSettings` theme branch.
-- `src/themes/compose.ts:278-289` — 14-theme registry (see _Known mismatch_).
+- `src/themes/compose.ts:278-300` — 7-theme runtime registry plus flexible `composeTheme()`.

--- a/apps/native-rd/src/__tests__/mocks/unistyles.ts
+++ b/apps/native-rd/src/__tests__/mocks/unistyles.ts
@@ -40,8 +40,6 @@ const StyleSheet = {
   configure: jest.fn(),
 };
 
-const useUnistyles = jest.fn(() => ({ theme: mockTheme }));
-
 const UnistylesRuntime = {
   themeName: "light-default",
   setTheme: jest.fn(),
@@ -53,5 +51,10 @@ const UnistylesRuntime = {
   statusBar: { height: 0 },
   navigationBar: { height: 0 },
 };
+
+const useUnistyles = jest.fn(() => ({
+  theme: mockTheme,
+  rt: UnistylesRuntime,
+}));
 
 module.exports = { StyleSheet, useUnistyles, UnistylesRuntime, mockTheme };

--- a/apps/native-rd/src/components/ThemeChipGrid/ThemeChipGrid.tsx
+++ b/apps/native-rd/src/components/ThemeChipGrid/ThemeChipGrid.tsx
@@ -33,13 +33,6 @@ const stripeWidths: Record<ThemeName, [number, number]> = {
   "light-autismFriendly": [35, 30],
   "light-lowVision": [60, 20],
   "light-lowInfo": [40, 25],
-  "dark-highContrast": [50, 25],
-  "dark-dyslexia": [30, 25],
-  "dark-autismFriendly": [35, 30],
-  "dark-lowVision": [60, 20],
-  "dark-lowInfo": [40, 25],
-  "light-largeText": [30, 25],
-  "dark-largeText": [30, 25],
 };
 
 export function ThemeChipGrid() {

--- a/apps/native-rd/src/hooks/__tests__/useTheme.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react-native";
+import { UnistylesRuntime } from "react-native-unistyles";
+
+import { useTheme } from "../useTheme";
+import { themes } from "../../themes/compose";
+
+const mockRuntime = UnistylesRuntime as unknown as {
+  themeName: string;
+};
+
+function setMockRuntimeThemeName(themeName: string) {
+  mockRuntime.themeName = themeName;
+}
+
+beforeEach(() => {
+  setMockRuntimeThemeName("light-default");
+});
+
+describe("useTheme", () => {
+  it("reads the current runtime theme from Unistyles rt", () => {
+    setMockRuntimeThemeName("dark-default");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.themeName).toBe("dark-default");
+    expect(result.current.theme).toBe(themes["dark-default"]);
+    expect(result.current.isDark).toBe(true);
+    expect(result.current.variant).toBe("default");
+  });
+
+  it("falls back when the runtime theme name is unsupported", () => {
+    setMockRuntimeThemeName("dark-dyslexia");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.themeName).toBe("light-default");
+    expect(result.current.theme).toBe(themes["light-default"]);
+  });
+});

--- a/apps/native-rd/src/hooks/__tests__/useTheme.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useTheme.test.ts
@@ -1,8 +1,8 @@
 import { renderHook } from "@testing-library/react-native";
 import { UnistylesRuntime } from "react-native-unistyles";
 
-import { useTheme } from "../useTheme";
-import { themes } from "../../themes/compose";
+import { themeOptions, useTheme } from "../useTheme";
+import { themeNames, themes } from "../../themes/compose";
 
 const mockRuntime = UnistylesRuntime as unknown as {
   themeName: string;
@@ -17,6 +17,10 @@ beforeEach(() => {
 });
 
 describe("useTheme", () => {
+  it("keeps UI theme options aligned with the runtime registry", () => {
+    expect(themeOptions.map((option) => option.id)).toEqual(themeNames);
+  });
+
   it("reads the current runtime theme from Unistyles rt", () => {
     setMockRuntimeThemeName("dark-default");
 

--- a/apps/native-rd/src/hooks/useDensity.ts
+++ b/apps/native-rd/src/hooks/useDensity.ts
@@ -4,12 +4,12 @@ import { updateUserSettings } from "../db";
 import { useUserSettingsRow } from "./useUserSettingsRow";
 import { scaleSpacing, type DensityLevel } from "../utils/density";
 import { space as baseSpace } from "../themes/tokens";
-import { themeNames, type ThemeName } from "../themes/compose";
+import { themeNames } from "../themes/compose";
 
 function applyDensityToAllThemes(level: DensityLevel) {
   const scaled = scaleSpacing(baseSpace, level);
   for (const name of themeNames) {
-    UnistylesRuntime.updateTheme(name as ThemeName, (current) => ({
+    UnistylesRuntime.updateTheme(name, (current) => ({
       ...current,
       space: scaled,
     }));

--- a/apps/native-rd/src/hooks/useTheme.ts
+++ b/apps/native-rd/src/hooks/useTheme.ts
@@ -12,15 +12,15 @@ import type { Variant } from "../themes/variants";
  * The 7 peer themes from @rollercoaster-dev/design-tokens.
  * Dark mode ("Night Ride") is one of the 7 — not a separate axis.
  *
- * Note: the Unistyles registry still composes all 14 colorMode × variant
- * combinations (see themes/compose.ts). The 7 below are the only values
- * the persistence layer accepts on read or write. See issue #940.
+ * These are the seven product themes registered with Unistyles and accepted
+ * by persistence. composeTheme can still build unsupported combinations for
+ * previews/tests, but they are not runtime theme names.
  */
-export const themeOptions: Array<{
+export const themeOptions: {
   id: ThemeName;
   label: string;
   description: string;
-}> = [
+}[] = [
   {
     id: "light-default",
     label: "The Full Ride",

--- a/apps/native-rd/src/hooks/useTheme.ts
+++ b/apps/native-rd/src/hooks/useTheme.ts
@@ -95,10 +95,15 @@ export function useThemeContext(): ThemeContextValue {
  * Call once at App root, then share via ThemeProvider.
  */
 export function useTheme() {
-  useUnistyles();
+  const { rt } = useUnistyles();
 
-  const themeName =
-    (UnistylesRuntime.themeName as ThemeName) || "light-default";
+  // Reading `rt.themeName` subscribes this hook to Unistyles theme-name
+  // changes. Reading `UnistylesRuntime.themeName` directly does not trigger a
+  // React re-render, which leaves selected-state UI stale after setTheme().
+  const runtimeThemeName = rt.themeName;
+  const themeName = isValidThemeName(runtimeThemeName)
+    ? runtimeThemeName
+    : FALLBACK_THEME_NAME;
   const theme = themes[themeName];
   const isDark = themeName.startsWith("dark");
   const { variant } = parseThemeName(themeName);

--- a/apps/native-rd/src/themes/__tests__/compose.test.ts
+++ b/apps/native-rd/src/themes/__tests__/compose.test.ts
@@ -1,0 +1,21 @@
+import { themeNames, themes, composeTheme } from "../compose";
+
+describe("theme registry", () => {
+  it("registers only the seven product themes exposed by the app", () => {
+    expect(themeNames).toEqual([
+      "light-default",
+      "dark-default",
+      "light-highContrast",
+      "light-dyslexia",
+      "light-autismFriendly",
+      "light-lowVision",
+      "light-lowInfo",
+    ]);
+    expect(Object.keys(themes)).toEqual(themeNames);
+  });
+
+  it("still supports composing unsupported combinations for previews", () => {
+    const theme = composeTheme("dark", "dyslexia");
+    expect(theme.variant).toBe("dyslexia");
+  });
+});

--- a/apps/native-rd/src/themes/compose.ts
+++ b/apps/native-rd/src/themes/compose.ts
@@ -1,10 +1,10 @@
 /**
- * Theme composition - combines colorModes with variants
- * Generates all 14 theme combinations (2 colorModes × 7 variants)
+ * Theme composition. composeTheme can build any pair for previews/tests, but
+ * the runtime registry includes only the seven exposed product themes.
  */
 
 import { colorModes, type ColorMode, type Colors } from "./colorModes";
-import { variantOverrides, variants, type Variant } from "./variants";
+import { variantOverrides, type Variant } from "./variants";
 import {
   space,
   size,
@@ -173,7 +173,6 @@ export function composeTheme(
 
   // Build typography presets using resolved scales
   const s = sizeScale as Record<string, number>;
-  const lh = lineHeightScale as Record<string, number>;
   const textStyles: TextStyles = {
     display: {
       fontSize: s["4xl"] ?? 40,
@@ -249,20 +248,14 @@ export function composeTheme(
   };
 }
 
-/**
- * Generate theme name from colorMode and variant
- */
 export function getThemeName(
   colorMode: ColorMode,
   variant: Variant,
-): ThemeName {
-  return `${colorMode}-${variant}` as ThemeName;
+): AllThemeName {
+  return `${colorMode}-${variant}` as AllThemeName;
 }
 
-/**
- * Parse theme name into colorMode and variant
- */
-export function parseThemeName(themeName: ThemeName): {
+export function parseThemeName(themeName: AllThemeName): {
   colorMode: ColorMode;
   variant: Variant;
 } {
@@ -272,20 +265,32 @@ export function parseThemeName(themeName: ThemeName): {
   return { colorMode, variant };
 }
 
-/** All possible theme names - derived from colorMode × variant */
-export type ThemeName = `${ColorMode}-${Variant}`;
+/** All possible generated theme names, including unsupported combinations. */
+export type AllThemeName = `${ColorMode}-${Variant}`;
 
-const colorModeList: ColorMode[] = ["light", "dark"];
+const productThemeEntries = [
+  ["light-default", "light", "default"],
+  ["dark-default", "dark", "default"],
+  ["light-highContrast", "light", "highContrast"],
+  ["light-dyslexia", "light", "dyslexia"],
+  ["light-autismFriendly", "light", "autismFriendly"],
+  ["light-lowVision", "light", "lowVision"],
+  ["light-lowInfo", "light", "lowInfo"],
+] as const satisfies readonly (readonly [AllThemeName, ColorMode, Variant])[];
 
-export const themeNames: ThemeName[] = colorModeList.flatMap((cm) =>
-  variants.map((v) => `${cm}-${v}` as ThemeName),
+/** Runtime-supported theme names exposed by product UI and persistence. */
+export type ThemeName = (typeof productThemeEntries)[number][0];
+
+export const themeNames: ThemeName[] = productThemeEntries.map(
+  ([name]) => name,
 );
 
-/** All 14 composed themes - derived from colorMode × variant */
+/** The seven composed themes registered with Unistyles at runtime. */
 export const themes = Object.fromEntries(
-  colorModeList.flatMap((cm) =>
-    variants.map((v) => [`${cm}-${v}`, composeTheme(cm, v)]),
-  ),
+  productThemeEntries.map(([name, colorMode, variant]) => [
+    name,
+    composeTheme(colorMode, variant),
+  ]),
 ) as Record<ThemeName, ComposedTheme>;
 
 export type Themes = typeof themes;

--- a/apps/native-rd/src/themes/index.ts
+++ b/apps/native-rd/src/themes/index.ts
@@ -19,6 +19,7 @@ export {
   parseThemeName,
 } from "./compose";
 export type {
+  AllThemeName,
   ThemeName,
   ComposedTheme,
   Themes,


### PR DESCRIPTION
## Summary

- Collapse the native-rd Unistyles runtime registry to the seven product themes exposed by Settings/persistence.
- Keep `composeTheme()` and `AllThemeName` available for previews/tests that need unsupported color-mode/variant combinations.
- Update theme persistence/design-token docs and add coverage for the registered theme list.

## Validation

- `bun --filter native-rd test src/themes/__tests__/compose.test.ts`
- commit hook ran `bun run turbo type-check`
