### PR TITLE
feat(native-rd): horizontal badge card with overflow-aware height

### DIFF
--- a/apps/native-rd/docs/plans/2026-05-16-badge-card-horizontal-layout.md
+++ b/apps/native-rd/docs/plans/2026-05-16-badge-card-horizontal-layout.md
@@ -1,0 +1,224 @@
+# Badge Card Horizontal Layout
+
+**Status:** Planned
+**Created:** 2026-05-16
+**Branch:** `badge-tiles-layout-rework-id-like-to-clarify-a-few/maximum-height-constraint-2.-responsive-behavior`
+**Related:** [2026-02-27-badge-design-system-plan.md](./2026-02-27-badge-design-system-plan.md) — the source of the `BadgeRenderer` + design data model used here.
+
+## Context
+
+`BadgeCard` (apps/native-rd/src/components/BadgeCard/BadgeCard.tsx) currently renders a vertical stack:
+
+```
+[BadgeRenderer 64x64]
+Title
+Date
+(evidenceCount, optional)
+```
+
+This wastes the right half of the tile on the Badges screen (`apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx`). With the design path the card is ~146px tall; in the initials-fallback path ~174px.
+
+We also have no place to surface the goal's description on the Badges list. The data exists (`goal.description` in `apps/native-rd/src/db/schema.ts:92`) but isn't selected by `badgesWithGoalsQuery` (`apps/native-rd/src/db/queries.ts:914`).
+
+## Desired layout
+
+Horizontal: badge on the left at "full content height", text column on the right.
+
+```
+┌──────────────────────────────────────────┐
+│ ┌─────────┐  Title (headline, 1 line)   │
+│ │         │  Description line 1          │
+│ │  Badge  │  Description line 2…         │
+│ │  ~112px │  May 16, 2026 (caption,      │
+│ │         │                muted)        │
+│ └─────────┘                              │
+└──────────────────────────────────────────┘
+```
+
+Behaviour:
+
+- **Title** — `theme.textStyles.headline`, `numberOfLines={1}`, `ellipsizeMode="tail"`.
+- **Description** — `theme.textStyles.body`, `numberOfLines={2}`, `ellipsizeMode="tail"`. Hidden when the goal has no description.
+- **Date** — `theme.textStyles.caption`, colour `theme.colors.textMuted`. Already small + muted; "lighter" comes from colour, not weight (no `fontWeight.light` token exists today).
+- **Badge** — square; size derived from the text-column height so it visually fills the card across themes and accessibility variants (see Responsiveness below).
+- **Whole card** — pressable, accessible (existing a11y label preserved).
+
+## Responsiveness
+
+The branch name calls out a max-height constraint and responsive behaviour. The plan covers four axes:
+
+| Axis                                                           | Approach                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Theme variant** (default, largeText, lowVision, dyslexia, …) | Read `textStyles` from the active theme via `useUnistyles()` and compute the badge size from the same `lineHeight` values used in the text column. The badge stays proportional to whatever the theme dictates. No `onLayout` measurement, no first-frame flicker. |
+| **iOS Dynamic Type / Android font scale**                      | Snapshot `PixelRatio.getFontScale()` at render and multiply into the computed badge size. Mirrors what RN will do to the `<Text>` heights, so the badge tracks the text. Stale on a system-setting change until the screen re-mounts; acceptable for a list view.  |
+| **Phone width**                                                | Card already uses `flex: 1` from the FlatList row; the text column gets `flex: 1` and absorbs extra width. Badge stays square at the computed size. No special breakpoint needed for phones.                                                                       |
+| **Tablet / large screens**                                     | Not in scope for this plan. Left as a follow-up — would convert the FlatList to `numColumns={2}` above a width threshold.                                                                                                                                          |
+
+The badge size is computed once per render as:
+
+```ts
+const fontScale = PixelRatio.getFontScale();
+const { headline, body, caption } = theme.textStyles;
+const textColumnHeight =
+  headline.lineHeight + // 1 line title
+  theme.space[1] +
+  body.lineHeight * 2 + // 2-line description (always reserved, even if absent)
+  theme.space[2] +
+  caption.lineHeight; // 1 line date
+const badgeSize = Math.round(textColumnHeight * fontScale);
+```
+
+For the default light theme at `fontScale = 1` this resolves to: `31 + 4 + 52 + 8 + 19 = 114` → badge ≈ **114px square**, card total ≈ **150px**.
+
+For `largeText` at `fontScale = 1`: `~39 + 4 + ~66 + 8 + ~24 ≈ 141` → badge ≈ **141px square**, card total ≈ **177px**.
+
+For default theme + system text-size XXL (`fontScale ≈ 1.3`): `114 × 1.3 ≈ 148` → badge ≈ **148px square**, card total ≈ **180px**.
+
+### Max-height constraint
+
+We rely on the `numberOfLines` clamps to bound height. Specifically:
+
+- Title `numberOfLines={1}` — a long goal title cannot push the card taller.
+- Description `numberOfLines={2}` — the second line ellipsises.
+- Date is always 1 line.
+
+That means the card height is fully determined by `textColumnHeight × fontScale + padding + border`. No `maxHeight` style is needed — the line clamps are the constraint. We deliberately do **not** also enforce a numeric `maxHeight`, because at very large font scales (e.g. lowVision + system XXXL) a hard cap would crop accessibility-relevant text. The line clamps already give a predictable upper bound while respecting the user's chosen font scale.
+
+### Description reserves space even when absent
+
+The badge size depends on a 2-line description. If a goal has no description, we still allow the badge size to assume two body lines so that:
+
+1. Cards in a list have a uniform height (better scan, no jumpy heights).
+2. A future description doesn't shrink/grow the badge.
+
+The description `<Text>` simply isn't rendered when `description == null`; the space it would have occupied is left as visual breathing room.
+
+## Open design decisions
+
+| Question                               | Recommended                                                                                                                    | Alternative                                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Where does description come from?      | `goal.description` joined via `badgesWithGoalsQuery`. **Decided 2026-05-16.**                                                  | Credential narrative / badge class description — neither is populated on creation today. |
+| Description line count                 | **2 lines** (decided 2026-05-16).                                                                                              | 3 lines — taller card, ~176px. Re-evaluate if descriptions skew long.                    |
+| Badge sizing strategy                  | Computed from active theme + font scale (this plan).                                                                           | Fixed literal e.g. `112` — simpler, but goes "short" on largeText / Dynamic Type.        |
+| Lighter weight for date                | Use existing `textMuted` colour.                                                                                               | Add a `fontWeight.light` token to design-tokens. Out of scope here.                      |
+| `evidenceCount` slot                   | Render after date in the right column when provided. The Badges list doesn't pass it; only BadgeDetail-style call sites would. | Drop the prop. Punted — keeps existing API.                                              |
+| `size` variants (`compact`/`spacious`) | Keep — they still scale container padding. Badge size is unaffected.                                                           | Remove. Out of scope.                                                                    |
+| Tablet multi-column                    | Out of scope.                                                                                                                  | Follow-up: FlatList `numColumns={2}` above a width breakpoint.                           |
+
+## Implementation sketch
+
+### 1. Data: `apps/native-rd/src/db/queries.ts`
+
+`badgesWithGoalsQuery` (line 914):
+
+```ts
+.select([
+  "badge.id",
+  "badge.goalId",
+  "badge.imageUri",
+  "badge.design",
+  "badge.createdAt",
+  "goal.title as goalTitle",
+  "goal.description as goalDescription",   // NEW
+  "goal.completedAt",
+])
+```
+
+No schema change — `goal.description` already exists (`schema.ts:92`).
+
+### 2. Component: `apps/native-rd/src/components/BadgeCard/BadgeCard.tsx`
+
+- Add `description?: string | null` to `BadgeCardProps`.
+- Import `useUnistyles` from `react-native-unistyles` and `PixelRatio` from `react-native`.
+- Compute `badgeSize` per the formula above.
+- Pass `size={badgeSize}` to `BadgeRenderer`; size the initials fallback `View` to the same dimension.
+- Restructure JSX into a two-column row:
+
+```tsx
+<Pressable …>
+  <View style={styles.container(size)}>
+    <View style={styles.badgeWrapper(badgeSize)}>
+      {design
+        ? <BadgeRenderer design={design} size={badgeSize} showShadow={false} />
+        : <View style={styles.initials(badgeSize)}>
+            <Text style={styles.initialsText}>{(title.charAt(0) || "?").toUpperCase()}</Text>
+          </View>}
+    </View>
+    <View style={styles.textColumn}>
+      <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">{title}</Text>
+      {description ? (
+        <Text style={styles.description} numberOfLines={2} ellipsizeMode="tail">{description}</Text>
+      ) : null}
+      <Text style={styles.date}>{earnedDate}</Text>
+      {evidenceCount !== undefined && (
+        <Text style={styles.evidenceCount}>
+          {evidenceCount} {evidenceCount === 1 ? "piece" : "pieces"} of evidence
+        </Text>
+      )}
+    </View>
+  </View>
+</Pressable>
+```
+
+Accessibility label stays `Badge: ${title}, earned ${earnedDate}` — description is decorative repetition of `title` in the most common case (short goals) and shouldn't bloat the screen-reader announcement. Re-evaluate if user feedback says otherwise.
+
+### 3. Styles: `apps/native-rd/src/components/BadgeCard/BadgeCard.styles.ts`
+
+- `container`: add `flexDirection: 'row'`, `alignItems: 'flex-start'`.
+- `badgeWrapper(size)`: factory style returning `{ width: size, height: size, marginRight: theme.space[4] }`.
+- `initials(size)`: replaces the current static `image` style; same visual but parametric width/height; keep `borderRadius`, border, background.
+- `initialsText`: scale `fontSize` to `size * 0.4` so a single uppercase letter looks right at any badge size.
+- `textColumn`: `flex: 1`, `minWidth: 0` (RN doesn't strictly need it but keeps text shrinkable).
+- `title`: drop `marginBottom: space[1]`, move spacing to the description's `marginTop`.
+- `description`: `marginTop: space[1]`, `color: theme.colors.text`, `…theme.textStyles.body`.
+- `date`: `marginTop: space[2]`, unchanged otherwise.
+- `evidenceCount`: `marginTop: space[2]` (unchanged).
+
+### 4. Screen call site: `apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx`
+
+```tsx
+<BadgeCard
+  title={(item.goalTitle as string) ?? "Untitled"}
+  description={item.goalDescription as string | null}   // NEW
+  earnedDate={formatDate(/* … */)}
+  design={parseBadgeDesign(item.design as string | null)}
+  onPress={…}
+/>
+```
+
+### 5. Stories: `apps/native-rd/src/components/BadgeCard/BadgeCard.stories.tsx`
+
+Add stories:
+
+- `WithDescription` — short description, fits in 2 lines.
+- `WithLongDescription` — overflows, asserts ellipsis visually.
+- `WithoutDescription` — null, confirms the badge still sizes correctly.
+- `LargeText` — wrap in the `largeText` theme to visually verify the badge grows with the text column.
+
+## Tests
+
+`apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx`:
+
+- Keep existing onPress, accessibility, evidence-count tests untouched.
+- Add: description text renders when provided.
+- Add: description is not rendered when prop is null/undefined.
+- Add: description `<Text>` has `numberOfLines={2}` and `ellipsizeMode="tail"`.
+- Add: title `<Text>` has `numberOfLines={1}`.
+- Snapshot or prop-assertion that `BadgeRenderer` is called with a `size > 0` derived from theme (mock theme and assert; don't hard-code `112`).
+
+`apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx`:
+
+- If it asserts on rendered text, extend to include description from a fixture.
+
+Visual verification:
+
+- `npx expo run:ios` and confirm against the photo on file.
+- Toggle `largeText` and `lowVision` accessibility themes to confirm the badge grows.
+- iOS Settings → Display → Text Size: drag to XXL and reopen the app to confirm the badge tracks system Dynamic Type.
+
+## Follow-ups (not in this plan)
+
+- Tablet multi-column grid for the Badges screen.
+- A `fontWeight.light` token in `@rollercoaster-dev/design-tokens` if we want the date visually lighter beyond colour alone.
+- A11y label for the description if user testing shows screen-reader users miss context.
+- Decide whether `evidenceCount` is still a useful prop after the redesign, or whether it moves to `BadgeDetailScreen` only.

--- a/apps/native-rd/src/components/BadgeCard/BadgeCard.stories.tsx
+++ b/apps/native-rd/src/components/BadgeCard/BadgeCard.stories.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { View } from "react-native";
 import { BadgeCard } from "./BadgeCard";
+import type { BadgeDesign } from "../../badges/types";
+
+const designWithBanner: BadgeDesign = {
+  shape: "shield",
+  frame: "boldBorder",
+  color: "#a78bfa",
+  iconName: "Trophy",
+  iconWeight: "bold",
+  title: "Marathon",
+  centerMode: "icon",
+  banner: { text: "FINISHER", position: "top" },
+  bottomLabel: "2026",
+};
 
 export default {
   title: "Components/BadgeCard",
@@ -68,6 +81,58 @@ export function Spacious() {
         earnedDate="Jan 1, 2026"
         evidenceCount={2}
         size="spacious"
+        onPress={() => console.log("Badge pressed")}
+      />
+    </View>
+  );
+}
+
+export function WithDescription() {
+  return (
+    <View style={{ padding: 16 }}>
+      <BadgeCard
+        title="Read 30 Books"
+        description="A year of reading widely across fiction, history, and tech."
+        earnedDate="May 16, 2026"
+        onPress={() => console.log("Badge pressed")}
+      />
+    </View>
+  );
+}
+
+export function WithLongDescription() {
+  return (
+    <View style={{ padding: 16 }}>
+      <BadgeCard
+        title="Marathon Training"
+        description="Sixteen weeks of progressively longer runs, easy days, intervals, hills, and one very rainy long run that nearly turned into a swim — and a great deal of stretching in between."
+        earnedDate="May 16, 2026"
+        onPress={() => console.log("Badge pressed")}
+      />
+    </View>
+  );
+}
+
+export function WithBannerAndLabel() {
+  return (
+    <View style={{ padding: 16 }}>
+      <BadgeCard
+        title="Marathon Training"
+        description="Finished a 26.2 mile run after 16 weeks of training."
+        earnedDate="May 16, 2026"
+        design={designWithBanner}
+        onPress={() => console.log("Badge pressed")}
+      />
+    </View>
+  );
+}
+
+export function WithoutDescription() {
+  return (
+    <View style={{ padding: 16 }}>
+      <BadgeCard
+        title="No Description Set"
+        earnedDate="May 16, 2026"
         onPress={() => console.log("Badge pressed")}
       />
     </View>

--- a/apps/native-rd/src/components/BadgeCard/BadgeCard.stories.tsx
+++ b/apps/native-rd/src/components/BadgeCard/BadgeCard.stories.tsx
@@ -15,126 +15,114 @@ const designWithBanner: BadgeDesign = {
   bottomLabel: "2026",
 };
 
+const logPress = () => console.log("Badge pressed");
+
+const Wrap = ({ children }: { children: React.ReactNode }) => (
+  <View style={{ padding: 16 }}>{children}</View>
+);
+
 export default {
   title: "Components/BadgeCard",
   component: BadgeCard,
 };
 
-export function Default() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="First Goal Completed"
-        earnedDate="Jan 28, 2026"
-        evidenceCount={3}
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const Default = () => (
+  <Wrap>
+    <BadgeCard
+      title="First Goal Completed"
+      earnedDate="Jan 28, 2026"
+      evidenceCount={3}
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function SingleEvidence() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Quick Learner"
-        earnedDate="Feb 1, 2026"
-        evidenceCount={1}
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const SingleEvidence = () => (
+  <Wrap>
+    <BadgeCard
+      title="Quick Learner"
+      earnedDate="Feb 1, 2026"
+      evidenceCount={1}
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function LongTitle() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Completed an incredibly challenging learning journey"
-        earnedDate="Dec 15, 2025"
-        evidenceCount={12}
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const LongTitle = () => (
+  <Wrap>
+    <BadgeCard
+      title="Completed an incredibly challenging learning journey"
+      earnedDate="Dec 15, 2025"
+      evidenceCount={12}
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function Compact() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Badge"
-        earnedDate="Jan 1, 2026"
-        evidenceCount={2}
-        size="compact"
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const Compact = () => (
+  <Wrap>
+    <BadgeCard
+      title="Badge"
+      earnedDate="Jan 1, 2026"
+      evidenceCount={2}
+      size="compact"
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function Spacious() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Badge"
-        earnedDate="Jan 1, 2026"
-        evidenceCount={2}
-        size="spacious"
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const Spacious = () => (
+  <Wrap>
+    <BadgeCard
+      title="Badge"
+      earnedDate="Jan 1, 2026"
+      evidenceCount={2}
+      size="spacious"
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function WithDescription() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Read 30 Books"
-        description="A year of reading widely across fiction, history, and tech."
-        earnedDate="May 16, 2026"
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const WithDescription = () => (
+  <Wrap>
+    <BadgeCard
+      title="Read 30 Books"
+      description="A year of reading widely across fiction, history, and tech."
+      earnedDate="May 16, 2026"
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function WithLongDescription() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Marathon Training"
-        description="Sixteen weeks of progressively longer runs, easy days, intervals, hills, and one very rainy long run that nearly turned into a swim — and a great deal of stretching in between."
-        earnedDate="May 16, 2026"
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const WithLongDescription = () => (
+  <Wrap>
+    <BadgeCard
+      title="Marathon Training"
+      description="Sixteen weeks of progressively longer runs, easy days, intervals, hills, and one very rainy long run that nearly turned into a swim — and a great deal of stretching in between."
+      earnedDate="May 16, 2026"
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function WithBannerAndLabel() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="Marathon Training"
-        description="Finished a 26.2 mile run after 16 weeks of training."
-        earnedDate="May 16, 2026"
-        design={designWithBanner}
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const WithBannerAndLabel = () => (
+  <Wrap>
+    <BadgeCard
+      title="Marathon Training"
+      description="Finished a 26.2 mile run after 16 weeks of training."
+      earnedDate="May 16, 2026"
+      design={designWithBanner}
+      onPress={logPress}
+    />
+  </Wrap>
+);
 
-export function WithoutDescription() {
-  return (
-    <View style={{ padding: 16 }}>
-      <BadgeCard
-        title="No Description Set"
-        earnedDate="May 16, 2026"
-        onPress={() => console.log("Badge pressed")}
-      />
-    </View>
-  );
-}
+export const WithoutDescription = () => (
+  <Wrap>
+    <BadgeCard
+      title="No Description Set"
+      earnedDate="May 16, 2026"
+      onPress={logPress}
+    />
+  </Wrap>
+);

--- a/apps/native-rd/src/components/BadgeCard/BadgeCard.styles.ts
+++ b/apps/native-rd/src/components/BadgeCard/BadgeCard.styles.ts
@@ -16,6 +16,8 @@ export const styles = StyleSheet.create((theme) => ({
     minHeight: 48,
   },
   container: (size: CardSize = "normal") => ({
+    flexDirection: "row",
+    alignItems: "flex-start",
     backgroundColor: theme.colors.backgroundSecondary,
     borderWidth: theme.borderWidth.medium,
     borderColor: theme.colors.border,
@@ -23,32 +25,45 @@ export const styles = StyleSheet.create((theme) => ({
     padding: theme.space[sizeMap[size]],
     ...shadowStyle(theme, "cardElevation"),
   }),
-  image: {
-    width: 80,
-    height: 80,
+  badgeWrapper: (width: number, height: number) => ({
+    width,
+    height,
+    marginRight: theme.space[4],
+  }),
+  initials: (badgeSize: number) => ({
+    width: badgeSize,
+    height: badgeSize,
     borderRadius: theme.radius.sm,
     borderWidth: theme.borderWidth.medium,
     borderColor: theme.colors.border,
     backgroundColor: theme.colors.accentPurple,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: theme.space[3],
-  },
-  imageText: {
+  }),
+  initialsText: (badgeSize: number) => ({
     color: palette.white,
-    fontSize: theme.size["3xl"],
-    lineHeight: theme.size["3xl"] * 1.3,
+    fontSize: Math.round(badgeSize * 0.4),
+    lineHeight: Math.round(badgeSize * 0.4 * 1.1),
     fontWeight: theme.fontWeight.black,
     fontFamily: theme.fontFamily.headline,
+  }),
+  textColumn: {
+    flex: 1,
+    minWidth: 0,
   },
   title: {
-    ...theme.textStyles.title,
+    ...theme.textStyles.headline,
     color: theme.colors.text,
-    marginBottom: theme.space[1],
+  },
+  description: {
+    ...theme.textStyles.body,
+    color: theme.colors.text,
+    marginTop: theme.space[1],
   },
   date: {
     ...theme.textStyles.caption,
     color: theme.colors.textMuted,
+    marginTop: theme.space[2],
   },
   evidenceCount: {
     ...theme.textStyles.caption,

--- a/apps/native-rd/src/components/BadgeCard/BadgeCard.tsx
+++ b/apps/native-rd/src/components/BadgeCard/BadgeCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { View, Text, Pressable, PixelRatio } from "react-native";
 import { useUnistyles } from "react-native-unistyles";
 import { BadgeRenderer } from "../../badges/BadgeRenderer";
@@ -10,7 +11,7 @@ export type BadgeCardSize = "compact" | "normal" | "spacious";
 export interface BadgeCardProps {
   title: string;
   earnedDate: string;
-  description?: string | null;
+  description?: string;
   evidenceCount?: number;
   design?: BadgeDesign | null;
   size?: BadgeCardSize;
@@ -37,12 +38,11 @@ export function BadgeCard({
     caption.lineHeight;
   const badgeSize = Math.round(textColumnHeight * fontScale);
 
-  // When a design has a banner and/or a bottom label, the BadgeRenderer's
-  // viewBox is taller than the badge's square — let the wrapper match that
-  // natural height so the card grows instead of clipping.
-  const badgeViewBox = design ? getBadgeLayoutBoxes(design, badgeSize) : null;
-  const badgeRenderedHeight = badgeViewBox?.viewBox.h ?? badgeSize;
-  const badgeRenderedWidth = badgeViewBox?.viewBox.w ?? badgeSize;
+  // Banner/bottomLabel overflow the badge square — size to the SVG viewBox so the card grows instead of clipping.
+  const viewBox = useMemo(
+    () => (design ? getBadgeLayoutBoxes(design, badgeSize).viewBox : null),
+    [design, badgeSize],
+  );
 
   return (
     <Pressable
@@ -54,7 +54,10 @@ export function BadgeCard({
     >
       <View style={styles.container(size)}>
         <View
-          style={styles.badgeWrapper(badgeRenderedWidth, badgeRenderedHeight)}
+          style={styles.badgeWrapper(
+            viewBox?.w ?? badgeSize,
+            viewBox?.h ?? badgeSize,
+          )}
         >
           {design ? (
             <BadgeRenderer

--- a/apps/native-rd/src/components/BadgeCard/BadgeCard.tsx
+++ b/apps/native-rd/src/components/BadgeCard/BadgeCard.tsx
@@ -1,5 +1,7 @@
-import { View, Text, Pressable } from "react-native";
+import { View, Text, Pressable, PixelRatio } from "react-native";
+import { useUnistyles } from "react-native-unistyles";
 import { BadgeRenderer } from "../../badges/BadgeRenderer";
+import { getBadgeLayoutBoxes } from "../../badges/layoutBoxes";
 import type { BadgeDesign } from "../../badges/types";
 import { styles } from "./BadgeCard.styles";
 
@@ -8,6 +10,7 @@ export type BadgeCardSize = "compact" | "normal" | "spacious";
 export interface BadgeCardProps {
   title: string;
   earnedDate: string;
+  description?: string | null;
   evidenceCount?: number;
   design?: BadgeDesign | null;
   size?: BadgeCardSize;
@@ -17,11 +20,30 @@ export interface BadgeCardProps {
 export function BadgeCard({
   title,
   earnedDate,
+  description,
   evidenceCount,
   design,
   size = "normal",
   onPress,
 }: BadgeCardProps) {
+  const { theme } = useUnistyles();
+  const fontScale = PixelRatio.getFontScale();
+  const { headline, body, caption } = theme.textStyles;
+  const textColumnHeight =
+    headline.lineHeight +
+    theme.space[1] +
+    body.lineHeight * 2 +
+    theme.space[2] +
+    caption.lineHeight;
+  const badgeSize = Math.round(textColumnHeight * fontScale);
+
+  // When a design has a banner and/or a bottom label, the BadgeRenderer's
+  // viewBox is taller than the badge's square — let the wrapper match that
+  // natural height so the card grows instead of clipping.
+  const badgeViewBox = design ? getBadgeLayoutBoxes(design, badgeSize) : null;
+  const badgeRenderedHeight = badgeViewBox?.viewBox.h ?? badgeSize;
+  const badgeRenderedWidth = badgeViewBox?.viewBox.w ?? badgeSize;
+
   return (
     <Pressable
       onPress={onPress}
@@ -31,23 +53,44 @@ export function BadgeCard({
       style={styles.pressable}
     >
       <View style={styles.container(size)}>
-        {design ? (
-          <BadgeRenderer design={design} size={64} showShadow={false} />
-        ) : (
-          <View style={styles.image}>
-            <Text style={styles.imageText}>
-              {(title.charAt(0) || "?").toUpperCase()}
-            </Text>
-          </View>
-        )}
-        <Text style={styles.title}>{title}</Text>
-        <Text style={styles.date}>{earnedDate}</Text>
-        {evidenceCount !== undefined && (
-          <Text style={styles.evidenceCount}>
-            {evidenceCount} {evidenceCount === 1 ? "piece" : "pieces"} of
-            evidence
+        <View
+          style={styles.badgeWrapper(badgeRenderedWidth, badgeRenderedHeight)}
+        >
+          {design ? (
+            <BadgeRenderer
+              design={design}
+              size={badgeSize}
+              showShadow={false}
+            />
+          ) : (
+            <View style={styles.initials(badgeSize)}>
+              <Text style={styles.initialsText(badgeSize)}>
+                {(title.charAt(0) || "?").toUpperCase()}
+              </Text>
+            </View>
+          )}
+        </View>
+        <View style={styles.textColumn}>
+          <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
+            {title}
           </Text>
-        )}
+          {description ? (
+            <Text
+              style={styles.description}
+              numberOfLines={2}
+              ellipsizeMode="tail"
+            >
+              {description}
+            </Text>
+          ) : null}
+          <Text style={styles.date}>{earnedDate}</Text>
+          {evidenceCount !== undefined && (
+            <Text style={styles.evidenceCount}>
+              {evidenceCount} {evidenceCount === 1 ? "piece" : "pieces"} of
+              evidence
+            </Text>
+          )}
+        </View>
       </View>
     </Pressable>
   );

--- a/apps/native-rd/src/components/BadgeCard/BadgeCard.tsx
+++ b/apps/native-rd/src/components/BadgeCard/BadgeCard.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { View, Text, Pressable, PixelRatio } from "react-native";
 import { useUnistyles } from "react-native-unistyles";
-import { BadgeRenderer } from "../../badges/BadgeRenderer";
+import {
+  BadgeRenderer,
+  getRendererLayoutOptions,
+} from "../../badges/BadgeRenderer";
 import { getBadgeLayoutBoxes } from "../../badges/layoutBoxes";
 import type { BadgeDesign } from "../../badges/types";
 import { styles } from "./BadgeCard.styles";
@@ -39,9 +42,14 @@ export function BadgeCard({
   const badgeSize = Math.round(textColumnHeight * fontScale);
 
   // Banner/bottomLabel overflow the badge square — size to the SVG viewBox so the card grows instead of clipping.
+  // Pass the same layout options the renderer uses (no shadow, theme-aware strokeWidth) so the wrapper matches the mounted SVG.
+  const rendererOptions = getRendererLayoutOptions(theme, false);
   const viewBox = useMemo(
-    () => (design ? getBadgeLayoutBoxes(design, badgeSize).viewBox : null),
-    [design, badgeSize],
+    () =>
+      design
+        ? getBadgeLayoutBoxes(design, badgeSize, rendererOptions).viewBox
+        : null,
+    [design, badgeSize, rendererOptions.strokeWidth, rendererOptions.hasShadow],
   );
 
   return (
@@ -50,6 +58,7 @@ export function BadgeCard({
       accessible
       accessibilityRole={onPress ? "button" : undefined}
       accessibilityLabel={`Badge: ${title}, earned ${earnedDate}`}
+      accessibilityHint={description}
       style={styles.pressable}
     >
       <View style={styles.container(size)}>

--- a/apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx
+++ b/apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx
@@ -68,13 +68,6 @@ describe("BadgeCard", () => {
       expect(screen.queryByText(/Read/)).toBeNull();
     });
 
-    it("does not render description when null", () => {
-      renderWithProviders(<BadgeCard {...baseProps} description={null} />);
-      // No description element should exist. Title and date are the only Texts
-      // alongside the initials letter.
-      expect(screen.queryByText(/.{20,}/)).toBeNull();
-    });
-
     it("clamps description to 2 lines with tail ellipsis", () => {
       renderWithProviders(
         <BadgeCard {...baseProps} description="some long description text" />,
@@ -110,9 +103,6 @@ describe("BadgeCard", () => {
       expect(props.size).toBeGreaterThan(0);
     });
 
-    // Contract assertion: BadgeCard relies on getBadgeLayoutBoxes to expand
-    // its badge wrapper when a banner or bottom label overflows the square.
-    // If this contract ever breaks, the card will clip the banner/label.
     it("layout boxes grow viewBox.h when a banner is present", () => {
       const size = 100;
       const plain: BadgeDesign = {

--- a/apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx
+++ b/apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx
@@ -14,6 +14,7 @@ jest.mock("../../../badges/BadgeRenderer", () => ({
     mockBadgeRenderer(props);
     return "BadgeRenderer";
   },
+  getRendererLayoutOptions: () => ({ strokeWidth: 3, hasShadow: false }),
 }));
 
 beforeEach(() => {
@@ -173,6 +174,24 @@ describe("BadgeCard", () => {
       expect(
         screen.getByLabelText("Badge: First Steps, earned Jan 1, 2025"),
       ).toBeOnTheScreen();
+    });
+
+    it("threads description into accessibilityHint", () => {
+      renderWithProviders(
+        <BadgeCard {...baseProps} description="Read 30 books in 2025" />,
+      );
+      const pressable = screen.getByLabelText(
+        "Badge: First Steps, earned Jan 1, 2025",
+      );
+      expect(pressable.props.accessibilityHint).toBe("Read 30 books in 2025");
+    });
+
+    it("omits accessibilityHint when no description", () => {
+      renderWithProviders(<BadgeCard {...baseProps} />);
+      const pressable = screen.getByLabelText(
+        "Badge: First Steps, earned Jan 1, 2025",
+      );
+      expect(pressable.props.accessibilityHint).toBeUndefined();
     });
   });
 });

--- a/apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx
+++ b/apps/native-rd/src/components/BadgeCard/__tests__/BadgeCard.test.tsx
@@ -6,10 +6,19 @@ import {
 } from "../../../__tests__/test-utils";
 import { BadgeCard } from "../BadgeCard";
 import type { BadgeDesign } from "../../../badges/types";
+import { getBadgeLayoutBoxes } from "../../../badges/layoutBoxes";
 
+const mockBadgeRenderer = jest.fn();
 jest.mock("../../../badges/BadgeRenderer", () => ({
-  BadgeRenderer: () => "BadgeRenderer",
+  BadgeRenderer: (props: { size: number }) => {
+    mockBadgeRenderer(props);
+    return "BadgeRenderer";
+  },
 }));
+
+beforeEach(() => {
+  mockBadgeRenderer.mockClear();
+});
 
 const baseProps = {
   title: "First Steps",
@@ -44,6 +53,102 @@ describe("BadgeCard", () => {
   it("renders initials fallback when design is not provided", () => {
     renderWithProviders(<BadgeCard {...baseProps} />);
     expect(screen.getByText("F")).toBeOnTheScreen();
+  });
+
+  describe("description", () => {
+    it("renders description when provided", () => {
+      renderWithProviders(
+        <BadgeCard {...baseProps} description="Read 30 books in 2025" />,
+      );
+      expect(screen.getByText("Read 30 books in 2025")).toBeOnTheScreen();
+    });
+
+    it("does not render description when omitted", () => {
+      renderWithProviders(<BadgeCard {...baseProps} />);
+      expect(screen.queryByText(/Read/)).toBeNull();
+    });
+
+    it("does not render description when null", () => {
+      renderWithProviders(<BadgeCard {...baseProps} description={null} />);
+      // No description element should exist. Title and date are the only Texts
+      // alongside the initials letter.
+      expect(screen.queryByText(/.{20,}/)).toBeNull();
+    });
+
+    it("clamps description to 2 lines with tail ellipsis", () => {
+      renderWithProviders(
+        <BadgeCard {...baseProps} description="some long description text" />,
+      );
+      const desc = screen.getByText("some long description text");
+      expect(desc.props.numberOfLines).toBe(2);
+      expect(desc.props.ellipsizeMode).toBe("tail");
+    });
+
+    it("clamps title to 1 line with tail ellipsis", () => {
+      renderWithProviders(<BadgeCard {...baseProps} />);
+      const title = screen.getByText("First Steps");
+      expect(title.props.numberOfLines).toBe(1);
+      expect(title.props.ellipsizeMode).toBe("tail");
+    });
+  });
+
+  describe("badge sizing", () => {
+    it("passes a positive size derived from the theme to BadgeRenderer", () => {
+      const design: BadgeDesign = {
+        shape: "circle",
+        frame: "none",
+        color: "#a78bfa",
+        iconName: "Trophy",
+        iconWeight: "regular",
+        title: "First Steps",
+        centerMode: "icon",
+      };
+      renderWithProviders(<BadgeCard {...baseProps} design={design} />);
+      expect(mockBadgeRenderer).toHaveBeenCalledTimes(1);
+      const props = mockBadgeRenderer.mock.calls[0][0];
+      expect(typeof props.size).toBe("number");
+      expect(props.size).toBeGreaterThan(0);
+    });
+
+    // Contract assertion: BadgeCard relies on getBadgeLayoutBoxes to expand
+    // its badge wrapper when a banner or bottom label overflows the square.
+    // If this contract ever breaks, the card will clip the banner/label.
+    it("layout boxes grow viewBox.h when a banner is present", () => {
+      const size = 100;
+      const plain: BadgeDesign = {
+        shape: "circle",
+        frame: "none",
+        color: "#a78bfa",
+        iconName: "Trophy",
+        iconWeight: "regular",
+        title: "T",
+        centerMode: "icon",
+      };
+      const withBanner: BadgeDesign = {
+        ...plain,
+        banner: { text: "ACHIEVED", position: "top" },
+      };
+      const plainBox = getBadgeLayoutBoxes(plain, size);
+      const bannerBox = getBadgeLayoutBoxes(withBanner, size);
+      expect(bannerBox.viewBox.h).toBeGreaterThan(plainBox.viewBox.h);
+    });
+
+    it("layout boxes grow viewBox.h when a bottom label is present", () => {
+      const size = 100;
+      const plain: BadgeDesign = {
+        shape: "circle",
+        frame: "none",
+        color: "#a78bfa",
+        iconName: "Trophy",
+        iconWeight: "regular",
+        title: "T",
+        centerMode: "icon",
+      };
+      const withLabel: BadgeDesign = { ...plain, bottomLabel: "v1" };
+      const plainBox = getBadgeLayoutBoxes(plain, size);
+      const labelBox = getBadgeLayoutBoxes(withLabel, size);
+      expect(labelBox.viewBox.h).toBeGreaterThan(plainBox.viewBox.h);
+    });
   });
 
   describe("evidence count", () => {

--- a/apps/native-rd/src/db/queries.ts
+++ b/apps/native-rd/src/db/queries.ts
@@ -926,6 +926,7 @@ export const badgesWithGoalsQuery = evolu.createQuery((db) =>
       "badge.design",
       "badge.createdAt",
       "goal.title as goalTitle",
+      "goal.description as goalDescription",
       "goal.completedAt",
     ])
     .where("badge.isDeleted", "is", null)

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
@@ -58,7 +58,7 @@ function BadgeList() {
       renderItem={({ item }: { item: BadgeRow }) => (
         <BadgeCard
           title={(item.goalTitle as string) ?? "Untitled"}
-          description={item.goalDescription as string | null}
+          description={(item.goalDescription as string | null) ?? undefined}
           earnedDate={formatDate(
             (item.completedAt ?? item.createdAt) as string | null,
           )}

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
@@ -58,6 +58,7 @@ function BadgeList() {
       renderItem={({ item }: { item: BadgeRow }) => (
         <BadgeCard
           title={(item.goalTitle as string) ?? "Untitled"}
+          description={item.goalDescription as string | null}
           earnedDate={formatDate(
             (item.completedAt ?? item.createdAt) as string | null,
           )}


### PR DESCRIPTION
## Summary

- Reworks `BadgeCard` from a vertical stack to a horizontal row: badge on the left, title + description + date on the right. Badge size scales from the active theme's text styles × `PixelRatio.getFontScale()` so it tracks theme variants and Dynamic Type — no `onLayout` measurement, no first-frame flicker.
- Surfaces `goal.description` on the Badges list (2-line clamp, ellipsis). Adds `goalDescription` to `badgesWithGoalsQuery` — column already existed in the schema.
- **Overflow fix:** the badge wrapper now sizes to the SVG's natural `viewBox` (via `getBadgeLayoutBoxes`), so cards with a banner or `bottomLabel` grow vertically instead of clipping the ribbon/label.

Plan: `apps/native-rd/docs/plans/2026-05-16-badge-card-horizontal-layout.md`.

## Notes & trade-offs

- `× fontScale` is a heuristic — RN doesn't auto-scale explicit `lineHeight`, so at very large font scales the badge can outrun the text column by a few pixels. Acceptable per the plan; the alternative (`onLayout`) would flicker on first frame.
- Cards in the list now have **non-uniform heights** when some designs have banners/labels and others don't. This is the price of the overflow fix. If we want uniform rows back, the alternative is to scale the SVG *down* so `viewBox.h ≤ badgeSize` — happy to swap in a follow-up.
- `LargeText` story skipped: `largeText` isn't a registered runtime theme (only `lowVision` from that family is). Use the Storybook theme toolbar with `light-lowVision` to verify scaling.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun run lint` — 0 errors (warnings pre-existing)
- [x] `bun test BadgeCard|BadgesScreen|queries` — 159 tests pass
- [x] New unit tests: description rendered/omitted, `numberOfLines` clamps, `BadgeRenderer` receives a computed positive `size`, contract assertion that `viewBox.h` grows with banner and with bottom label
- [ ] **Visual verification on simulator** (`npx expo run:ios`):
  - [ ] Default theme — card ≈ 150px tall, 2-line description ellipsises, badge ≈ 114px square
  - [ ] `light-lowVision` theme — badge grows with the larger text styles
  - [ ] iOS Settings → Display → Text Size → XXL — badge tracks Dynamic Type after reopening the app
  - [ ] A badge with a banner ribbon — card grows; ribbon is not clipped
  - [ ] A badge with `bottomLabel` — card grows; label is not clipped
  - [ ] An untextured badge (no banner/label) — card stays compact
  - [ ] Initials fallback (no `design`) — square placeholder still renders correctly

## Follow-ups (out of scope)

- Tablet multi-column grid for the Badges screen
- `fontWeight.light` token if we want the date visually lighter beyond colour
- Decide whether `evidenceCount` still belongs on `BadgeCard` after the redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)