### PR TITLE
fix(native-rd): correct ASC API key issuer field name in eas.json

### DIFF
--- a/apps/native-rd/eas.json
+++ b/apps/native-rd/eas.json
@@ -55,7 +55,7 @@
         "appleTeamId": "86VL756N99",
         "ascApiKeyPath": "../../secrets/asc-api-key.p8",
         "ascApiKeyId": "$APPLE_ASC_KEY_ID",
-        "ascApiIssuerId": "$APPLE_ASC_ISSUER_ID"
+        "ascApiKeyIssuerId": "$APPLE_ASC_ISSUER_ID"
       },
       "android": {
         "serviceAccountKeyPath": "../../secrets/play-service-account.json",
@@ -70,7 +70,7 @@
         "appleTeamId": "86VL756N99",
         "ascApiKeyPath": "../../secrets/asc-api-key.p8",
         "ascApiKeyId": "$APPLE_ASC_KEY_ID",
-        "ascApiIssuerId": "$APPLE_ASC_ISSUER_ID"
+        "ascApiKeyIssuerId": "$APPLE_ASC_ISSUER_ID"
       },
       "android": {
         "serviceAccountKeyPath": "../../secrets/play-service-account.json",


### PR DESCRIPTION
EAS schema requires `ascApiKeyIssuerId`, not `ascApiIssuerId`. The wrong field name caused `eas.json` validation to reject the file, blocking `build-internal` and `build-production` iOS builds:

```
eas.json is not valid.
- "submit.production.ios.ascApiIssuerId" is not allowed
- "submit.preview.ios.ascApiIssuerId" is not allowed
```

Two-character fix in both `submit.production.ios` and `submit.preview.ios` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)