### PR TITLE
fix(ci): write EAS build JSON to RUNNER_TEMP to avoid dirty-tree abort

### DIFF
--- a/.github/workflows/build-internal.yml
+++ b/.github/workflows/build-internal.yml
@@ -63,8 +63,11 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          npx eas-cli@latest build --profile preview --platform ios --non-interactive --json > eas-build-ios.json
-          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' eas-build-ios.json)"
+          # Write JSON outside the repo: `cmd > file` opens the file before
+          # eas-cli runs, and eas-cli aborts on a dirty working tree.
+          out="$RUNNER_TEMP/eas-build-ios.json"
+          npx eas-cli@latest build --profile preview --platform ios --non-interactive --json > "$out"
+          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
 
@@ -103,8 +106,11 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          npx eas-cli@latest build --profile preview --platform android --non-interactive --json > eas-build-android.json
-          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' eas-build-android.json)"
+          # Write JSON outside the repo: `cmd > file` opens the file before
+          # eas-cli runs, and eas-cli aborts on a dirty working tree.
+          out="$RUNNER_TEMP/eas-build-android.json"
+          npx eas-cli@latest build --profile preview --platform android --non-interactive --json > "$out"
+          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- First dispatch of \`build-internal.yml\` for iOS ([run 25998596003](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/25998596003)) failed at the \`Build (EAS, preview profile, iOS)\` step: \`Warning! Your repository working tree is dirty. ... ?? eas-build-ios.json\`.
- Cause: \`cmd > eas-build-ios.json\` opens the redirect target **before** eas-cli starts, so the empty file appears inside \`apps/native-rd/\` exactly when eas-cli runs its pre-build git-cleanliness check and aborts.
- Fix: redirect to \`\$RUNNER_TEMP/eas-build-{ios,android}.json\` so the JSON lives outside the repo. \`jq\` reads from the same temp path; \`submit-*\` jobs are unaffected (they consume \`needs.build-*.outputs.build_id\` via \`\$GITHUB_OUTPUT\`).

## Test plan
- [ ] Merge, then re-dispatch \`build-internal.yml\` with \`platform=ios\` and confirm \`build-ios\` + \`submit-ios\` both succeed.
- [ ] Re-dispatch with \`platform=android\` and confirm \`build-android\` + \`submit-android\` both succeed.
- [ ] Leave release-please PR #84 open until both above are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)