### PR TITLE
fix(ci): mirror RUNNER_TEMP fix in build-production.yml

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -68,8 +68,11 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          npx eas-cli@latest build --profile production --platform ios --non-interactive --json > eas-build-ios.json
-          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' eas-build-ios.json)"
+          # Write JSON outside the repo: `cmd > file` opens the file before
+          # eas-cli runs, and eas-cli aborts on a dirty working tree.
+          out="$RUNNER_TEMP/eas-build-ios.json"
+          npx eas-cli@latest build --profile production --platform ios --non-interactive --json > "$out"
+          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
 
@@ -108,8 +111,11 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          npx eas-cli@latest build --profile production --platform android --non-interactive --json > eas-build-android.json
-          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' eas-build-android.json)"
+          # Write JSON outside the repo: `cmd > file` opens the file before
+          # eas-cli runs, and eas-cli aborts on a dirty working tree.
+          out="$RUNNER_TEMP/eas-build-android.json"
+          npx eas-cli@latest build --profile production --platform android --non-interactive --json > "$out"
+          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Companion to #86. Same dirty-tree bug, just on \`build-production.yml\` (the workflow that auto-fires on \`release: published\`).
- Without this, the moment release-please PR #84 merges, the production workflow fires automatically and dies at the first \`Build (EAS, production profile, …)\` step with \`This operation needs to be run on a clean working tree\`.
- Fix is identical: redirect the JSON to \`\$RUNNER_TEMP/eas-build-{ios,android}.json\` so it lives outside the repo.

## Why this wasn't in #86
Two separate workflow files (\`build-internal.yml\` vs \`build-production.yml\`) with copy-pasted build steps. #86 fixed only the internal path — the production path needs the same change before #84 is merged or its first auto-run will fail.

## Test plan
- [ ] Merge before merging #84 (release-please 0.1.4).
- [ ] Verify \`build-internal\` iOS + Android still green (independent verification continuing in #84's parent flow).
- [ ] After #84 merges and \`build-production\` auto-fires, confirm both \`build-ios\` and \`build-android\` steps clear the cleanliness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)