### PR TITLE
chore(ci): ignore release-please CHANGELOG files in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,8 @@ apps/openbadges-system/src/client/auto-imports.d.ts
 apps/native-rd/ios/
 apps/native-rd/android/
 
-# release-please generates these; its formatting doesn't match our Prettier config
-CHANGELOG.md
-**/CHANGELOG.md
+# release-please owns this file (.github/release-please-config.json); its
+# generated formatting doesn't match our Prettier config. Other CHANGELOGs
+# (e.g. packages/*/CHANGELOG.md) are not in release-please scope and stay
+# enforced.
+apps/native-rd/CHANGELOG.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,7 @@ apps/openbadges-modular-server/keys/
 apps/openbadges-system/src/client/auto-imports.d.ts
 apps/native-rd/ios/
 apps/native-rd/android/
+
+# release-please generates these; its formatting doesn't match our Prettier config
+CHANGELOG.md
+**/CHANGELOG.md


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` / `**/CHANGELOG.md` to `.prettierignore` so release-please–generated changelogs don't fail `bunx prettier --check`.
- Unblocks the release-please PR (currently #84) — its `Docs Format Check` and `Native-RD Validate › Format check` steps both fail on the bot-authored changelog.
- The knock-on `Native-RD Validate › a11y audit` failure on #84 is a side effect of `Test (coverage)` being skipped after format-check fails; it should clear once this lands and release-please rebases.

## Why ignore rather than reformat
release-please rewrites `CHANGELOG.md` on every release tick, so any manual reformat would be undone immediately. Ignoring the file is the standard remediation recommended in release-please's docs.

## Test plan
- [x] `bunx prettier --check "**/*.{ts,tsx,js,jsx,json,md}"` passes locally with the new ignore rule
- [ ] CI green on this PR
- [ ] After merge, release-please rebases #84 and its format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)