### PR TITLE
ci(release): auto-dispatch build-production on release publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,12 +7,21 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      - name: Dispatch production build
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run build-production.yml -f ref=${{ steps.release.outputs.tag_name }} -f platform=all

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,8 @@ jobs:
           manifest-file: .github/.release-please-manifest.json
 
       - name: Dispatch production build
-        if: ${{ steps.release.outputs.release_created == 'true' }}
+        if: ${{ steps.release.outputs['apps/native-rd--release_created'] == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run build-production.yml -f ref=${{ steps.release.outputs.tag_name }} -f platform=all
+          TAG: ${{ steps.release.outputs['apps/native-rd--tag_name'] }}
+        run: gh workflow run build-production.yml -f ref="$TAG" -f platform=all

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,8 @@ apps/openbadges-system/src/client/auto-imports.d.ts
 apps/native-rd/ios/
 apps/native-rd/android/
 
-# release-please generates these; its formatting doesn't match our Prettier config
-CHANGELOG.md
-**/CHANGELOG.md
+# release-please owns this file (.github/release-please-config.json); its
+# generated formatting doesn't match our Prettier config. Other CHANGELOGs
+# (e.g. packages/*/CHANGELOG.md) are not in release-please scope and stay
+# enforced.
+apps/native-rd/CHANGELOG.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,7 @@ apps/openbadges-modular-server/keys/
 apps/openbadges-system/src/client/auto-imports.d.ts
 apps/native-rd/ios/
 apps/native-rd/android/
+
+# release-please generates these; its formatting doesn't match our Prettier config
+CHANGELOG.md
+**/CHANGELOG.md


### PR DESCRIPTION
## Summary
- Chain `build-production.yml` off release-please via `gh workflow run` so merged release PRs actually produce builds (PR #84 / v0.1.4 did not).
- Avoid a PAT — `workflow_dispatch` is one of two carve-outs from the `GITHUB_TOKEN` cascade-suppression rule, so the default token can dispatch.
- Add `actions: write` and `issues: write` to the workflow's `permissions:` block; gate the dispatch on `release_created == true`.

## Why
Merging the release-please PR creates a GitHub Release authored by `github-actions[bot]`. Events emitted under `GITHUB_TOKEN` are silently dropped by other workflows' triggers (anti-recursion safeguard), so `build-production.yml`'s `release: published` trigger never fired. v0.1.4 has no associated build run as a result.

GitHub's docs explicitly carve out `workflow_dispatch` and `repository_dispatch` from that rule, which makes chaining via `gh workflow run` from within the release-please job the lowest-friction fix — no PAT, no org approval, no extra secret to rotate.

## Test plan
- [ ] CI is green on this PR.
- [ ] After merge: cut the next release-please PR; on merge, observe `build-production.yml` runs against the new tag automatically.
- [ ] Separately, dispatch `build-production.yml -f ref=v0.1.4 -f platform=all` manually to unblock the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)