### PR TITLE
[codex] add Play internal testing pipeline

### DIFF
--- a/.github/workflows/build-play-internal.yml
+++ b/.github/workflows/build-play-internal.yml
@@ -1,0 +1,86 @@
+name: build-play-internal
+
+# Manual-only Android Play internal testing pipeline.
+# Builds a fresh store AAB with the production EAS build profile, then submits
+# that exact build to the existing Google Play "internal" test track.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (branch, tag, or commit SHA). Leave blank to use the branch picked in the 'Use workflow from' dropdown."
+        required: false
+
+concurrency:
+  group: build-play-internal-${{ inputs.ref || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    uses: ./.github/workflows/_release-validate.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+
+  build-android:
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      build_id: ${{ steps.build.outputs.build_id }}
+    defaults:
+      run:
+        working-directory: apps/native-rd
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: .
+
+      - name: Build (EAS, production profile, Android)
+        id: build
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          out="$RUNNER_TEMP/eas-build-android.json"
+          npx eas-cli@latest build --profile production --platform android --non-interactive --json > "$out"
+          build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
+          test -n "$build_id" && test "$build_id" != "null"
+          echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
+
+  submit-android:
+    needs: build-android
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/native-rd
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Write Google Play service account file
+        env:
+          ANDROID_PLAY_SA: ${{ secrets.ANDROID_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          mkdir -p ../../secrets
+          printf '%s\n' "$ANDROID_PLAY_SA" > ../../secrets/play-service-account.json
+          chmod 600 ../../secrets/play-service-account.json
+
+      - name: Submit (EAS, Google Play internal track)
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: npx eas-cli@latest submit --profile play-internal --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait

--- a/apps/native-rd/docs/launch/production-release-plan.md
+++ b/apps/native-rd/docs/launch/production-release-plan.md
@@ -1,0 +1,193 @@
+# Production Release Plan
+
+**Status:** Active planning  
+**Last updated:** 2026-05-17  
+**Scope:** `native-rd` iOS + Android public launch  
+**Related:** GitHub issue #90, `docs/release.md`, `docs/launch/app-store-launch-plan.md`
+
+## Current State
+
+The app is in beta, not production.
+
+| Platform | Current channel           | Current goal                         |
+| -------- | ------------------------- | ------------------------------------ |
+| iOS      | TestFlight                | Continue beta testing and fix issues |
+| Android  | Google Play internal test | Continue beta testing and fix issues |
+
+The repository currently has release automation that is ahead of the store
+state: `build-production.yml` can submit Android to Play production, but the
+real launch path is still beta testing first. Issue #90 tracks correcting that
+pipeline so TestFlight and Play testing tracks are first-class targets and
+production cannot fire accidentally.
+
+## Release Principles
+
+- Treat TestFlight and Android Play testing as the release-candidate proving
+  ground.
+- Do not automate production submission until both stores are ready and the
+  pipeline has a production gate.
+- Keep Play Console and App Store Connect as the source of truth for final
+  review and launch actions.
+- Prefer manual production release for the first public launch; automate only
+  after the first release proves the process.
+- Do not add features after a build is marked as a release candidate.
+
+## Phase 1: Stabilize Beta
+
+Goal: get one build on each platform that can become the release candidate.
+
+For each beta build, record:
+
+- app version and native build number
+- Git commit or tag
+- platform and store channel
+- tester count
+- change summary
+- known issues
+- Sentry top crash signatures
+- whether the build is a release candidate
+
+Minimum beta gate:
+
+- [ ] iOS TestFlight build installs and updates cleanly.
+- [ ] Android internal testing build installs and updates cleanly.
+- [ ] Onboarding works.
+- [ ] Goal creation, editing, and completion work.
+- [ ] Evidence capture works for text, photo, file, audio, and video where
+      currently supported.
+- [ ] Badge creation/export works.
+- [ ] Settings and accessibility theme switching work.
+- [ ] No known P0/P1 issues remain.
+- [ ] Sentry receives iOS events from TestFlight.
+- [ ] Android crash/error delivery is verified from a production-like Play
+      testing build.
+
+## Phase 2: Correct the Pipeline
+
+Goal: make the automation match the current store reality.
+
+Tracked by issue #90.
+
+Required changes:
+
+- [ ] Add or repurpose store-testing EAS profiles for TestFlight and Play
+      testing.
+- [ ] Android store-testing builds use AAB, not APK.
+- [ ] Android internal testing submit targets the Play `internal` track.
+- [ ] If/when moving from internal testing to formal closed testing, Android
+      submit targets the real Play closed track (`alpha` or `beta`, matching
+      Play Console).
+- [ ] `build-internal.yml` no longer submits EAS internal-distribution artifacts
+      to stores.
+- [ ] `build-production.yml` cannot submit Android to production until public
+      launch is intentionally enabled.
+- [ ] `docs/release.md` describes the current beta and production workflows.
+
+Current Android internal-testing submit profile:
+
+```json
+"play-internal": {
+  "extends": "preview"
+}
+```
+
+The profile extends `preview` because `preview.submit.android` already contains
+the Google Play `internal` track config. The separate name keeps the workflow
+readable without duplicating submit settings.
+
+Do not submit to `alpha` or `beta` until the app is intentionally moved to a
+formal closed testing track in Play Console.
+
+## Phase 3: Store Readiness
+
+### iOS
+
+- [ ] App Store metadata is complete.
+- [ ] Screenshots are current and match the app.
+- [ ] Privacy nutrition labels match shipped behavior, including Sentry crash
+      reporting.
+- [ ] Privacy policy URL is live.
+- [ ] Support URL is live.
+- [ ] Age rating is complete.
+- [ ] Export compliance is set.
+- [ ] External TestFlight group is configured.
+- [ ] Final TestFlight build has completed external beta review if required.
+- [ ] Final build is selected on the App Store version page.
+
+### Android
+
+- [ ] Store listing is complete.
+- [ ] Screenshots are current and match the app.
+- [ ] Data safety form matches shipped behavior, including Sentry crash
+      reporting.
+- [ ] Privacy policy URL is live.
+- [ ] Content rating is complete.
+- [ ] Target audience / families declarations are complete.
+- [ ] Internal testing track has the intended tester list.
+- [ ] Internal testing opt-in link has been shared with testers.
+- [ ] If moving to formal closed testing before production, the closed testing
+      track has the intended tester list or Google Group.
+- [ ] If the Play account requires it, at least 12 testers have been opted in
+      for 14 continuous days before applying for production access.
+- [ ] Production access has been granted if Play Console requires it.
+
+## Phase 4: Release Candidate
+
+Goal: select one iOS build and one Android build as the public-launch candidate.
+
+RC rules:
+
+- No feature work after RC.
+- Only release-blocking fixes may enter a new RC.
+- Each new RC resets the smoke test checklist.
+
+RC checklist:
+
+- [ ] iOS RC build identified.
+- [ ] Android RC build identified.
+- [ ] Both builds use the same app version.
+- [ ] Android version code is higher than every previous Android upload.
+- [ ] iOS build number is higher than every previous iOS upload for that app
+      version.
+- [ ] Sentry release/build data is visible for both platforms.
+- [ ] Top crash signatures from the prior beta build are triaged.
+- [ ] Privacy verification has been run if Sentry config or telemetry behavior
+      changed.
+- [ ] Known issues list is empty or explicitly accepted for launch.
+
+## Phase 5: Public Launch
+
+### iOS Launch
+
+1. In App Store Connect, select the final build for the app version.
+2. Add the app version to a draft submission.
+3. Submit for App Review.
+4. Use manual release or phased release for the first launch.
+5. After approval, release manually when ready.
+
+### Android Launch
+
+1. Confirm Play testing requirements are satisfied.
+2. Apply for production access if Play Console requires it.
+3. After production access is granted, create the first production release
+   manually in Play Console.
+4. Prefer staged rollout if available.
+5. Keep GitHub Actions production auto-submit disabled until this manual launch
+   succeeds.
+
+## Launch Monitoring
+
+For the first 48 hours after public launch:
+
+- Check Sentry at least daily.
+- Track every P0/P1 crash as a GitHub issue.
+- Do not merge feature work into a hotfix branch.
+- Prefer fix-forward releases; store rollback options are limited.
+
+Launch is considered complete when:
+
+- [ ] iOS is live on the App Store.
+- [ ] Android is live on Google Play production.
+- [ ] No unresolved P0/P1 launch issues remain after 48 hours.
+- [ ] `docs/release.md` has been updated with first-run evidence.
+- [ ] Issue #90 is closed or replaced with post-launch automation follow-ups.

--- a/apps/native-rd/docs/release.md
+++ b/apps/native-rd/docs/release.md
@@ -4,18 +4,19 @@
 
 ## Pipeline at a glance
 
-| Track      | Trigger                                                                  | Workflow               | EAS profile  | Destination                         |
-| ---------- | ------------------------------------------------------------------------ | ---------------------- | ------------ | ----------------------------------- |
-| Internal   | Manual: Actions → `build-internal` → "Run workflow"                      | `build-internal.yml`   | `preview`    | TestFlight internal + Play internal |
-| Production | GitHub Release published (release-please PR merge, or manual UI publish) | `build-production.yml` | `production` | TestFlight ext + Play prod (10%)    |
-| Production | Manual: Actions → `build-production` → "Run workflow" with `ref` input   | `build-production.yml` | `production` | TestFlight ext + Play prod (10%)    |
+| Track                 | Trigger                                                                  | Workflow                  | EAS build profile | EAS submit profile | Destination                    |
+| --------------------- | ------------------------------------------------------------------------ | ------------------------- | ----------------- | ------------------ | ------------------------------ |
+| Direct install        | Manual: Actions → `build-internal` → "Run workflow"                      | `build-internal.yml`      | `preview`         | `preview`          | EAS internal distribution      |
+| Play internal testing | Manual: Actions → `build-play-internal` → "Run workflow"                 | `build-play-internal.yml` | `production`      | `play-internal`    | Google Play internal test      |
+| Production            | GitHub Release published (release-please PR merge, or manual UI publish) | `build-production.yml`    | `production`      | `production`       | TestFlight ext + Play prod 10% |
+| Production            | Manual: Actions → `build-production` → "Run workflow" with `ref` input   | `build-production.yml`    | `production`      | `production`       | TestFlight ext + Play prod 10% |
 
 Both build workflows are deliberately click-only — no auto-build on push to
 `main`. release-please runs on every push to `main` to keep the release PR up
 to date, but it never builds anything itself; it just opens/updates a PR and,
 when merged, publishes a GitHub Release.
 
-## Cutting an internal build (for testing / dogfood)
+## Cutting a direct-install build
 
 1. Go to **Actions → build-internal → "Run workflow"**.
 2. Pick the ref you want to build. Defaults to the branch selected in GitHub's
@@ -24,9 +25,38 @@ when merged, publishes a GitHub Release.
 3. Pick `platform`: `all`, `ios`, or `android`. Use a single platform when
    smoke-testing one credential path.
 4. Click **Run workflow**.
-5. Watch release validate → per-platform EAS build → per-platform submit. Each
-   submit job uses the explicit EAS build ID produced by its build job. On
-   success the build appears in TestFlight internal and/or Play internal track.
+5. Watch release validate → per-platform EAS build → per-platform submit.
+
+Use this workflow for EAS internal distribution / direct-install testing. Do not
+use the Android preview artifact for Play Store testing: `preview` builds Android
+as an APK and uses EAS internal distribution.
+
+## Cutting an Android Play internal test build
+
+Use this for the current Android tester channel in Play Console:
+**Interner Test** / Google Play internal testing.
+
+1. Merge the workflow/config changes to the branch you want to build.
+2. Go to **Actions → build-play-internal → "Run workflow"**.
+3. Pick the ref you want to build. Leave blank to use the selected branch, or
+   enter `main`, a release branch, a tag, or a commit SHA.
+4. Click **Run workflow**.
+5. The workflow runs release validation, builds a fresh Android store AAB with
+   EAS `production`, then submits that exact build with submit profile
+   `play-internal`.
+6. On success, the build appears in Play Console → Testing → Internal testing.
+
+Why this workflow exists:
+
+- Google Play version codes are single-use once uploaded anywhere in Play
+  Console.
+- Re-submitting the same EAS build can fail with
+  `Version code has already been used`.
+- This workflow always creates a fresh Android store build first, so EAS remote
+  auto-increment assigns the next version code before submit.
+- It targets Play `internal`, matching the current tester channel. Do not use
+  `alpha` / `beta` until the app is intentionally moved to a formal closed
+  testing track.
 
 ## Cutting a production release
 

--- a/apps/native-rd/eas.json
+++ b/apps/native-rd/eas.json
@@ -76,6 +76,9 @@
         "serviceAccountKeyPath": "../../secrets/play-service-account.json",
         "track": "internal"
       }
+    },
+    "play-internal": {
+      "extends": "preview"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add a manual `build-play-internal` GitHub Actions workflow for Android Play internal testing.
- Add an explicit `play-internal` EAS submit profile targeting Google Play `internal`.
- Add a production release plan covering current beta state, pipeline cleanup, store readiness, RC gates, and public launch steps.

## Why

The active Android tester channel is Google Play **Internal testing** (`Interner Test`), not alpha/closed testing. The previous production workflow can submit to Play production, and the existing internal workflow builds preview/internal-distribution artifacts. This adds a focused manual path that builds a fresh store AAB with a new version code and submits that exact build to the existing internal testing track.

This also documents the corrected release path so TestFlight, Play internal testing, formal closed testing, and production launch are not conflated.

## Validation

- Prettier ran through the pre-commit hook.
- `bun run type-check` passed through the pre-commit hook.
