### PR TITLE
[codex] fix Play internal submit dependencies

### DIFF
--- a/.github/workflows/build-play-internal.yml
+++ b/.github/workflows/build-play-internal.yml
@@ -72,6 +72,22 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        # `eas submit` reads Expo app config before submitting. Config plugins
+        # such as react-native-edge-to-edge must be resolvable from node_modules.
+        run: bun install --frozen-lockfile
+        working-directory: .
+
       - name: Write Google Play service account file
         env:
           ANDROID_PLAY_SA: ${{ secrets.ANDROID_PLAY_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary

- Restore dependency installation in the `build-play-internal` submit job.
- Document why submit still needs `node_modules`: EAS submit reads the Expo app config, and config plugins must be resolvable.

## Why

The first `build-play-internal` run built the Android AAB successfully, but failed during submit because `eas submit` could not resolve the `react-native-edge-to-edge` config plugin without installed dependencies.

## Validation

- Prettier ran through the pre-commit hook.
- `bun run type-check` passed through the pre-commit hook.
