### PR TITLE
feat(native-rd): release testing-notes pipeline

### DIFF
--- a/apps/native-rd/.gitignore
+++ b/apps/native-rd/.gitignore
@@ -40,6 +40,13 @@ yarn-error.*
 # Google Play service account key (developer-local; required by `eas submit -p android`)
 play-service-account.json
 
+# EAS Metadata store config — generated per-release from
+# docs/release/testing-notes/<version>.md via release-notes:split
+store.config.json
+
+# Generated release artifacts (Play changelog, what-to-test text)
+.release-artifacts/
+
 # TypeScript
 *.tsbuildinfo
 

--- a/apps/native-rd/docs/release/testing-notes/README.md
+++ b/apps/native-rd/docs/release/testing-notes/README.md
@@ -123,19 +123,20 @@ eas submit --platform ios --profile production \
 2. **Fastlane Supply** — requires Ruby. Reads `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`. Heavier dependency.
 3. **Play Developer API push** (planned) — a small Bun script using `googleapis` to call `androidpublisher.edits.tracks.update` with `releases[0].releaseNotes`. Same service account credentials as `eas submit --platform android`; no additional permissions needed.
 
-## Open blockers before the iOS half can actually run
+## Static App Store metadata
 
-The `store.config.json` produced by the splitter currently contains only `apple.info.en-US.releaseNotes`. EAS Metadata's schema also requires:
+EAS Metadata's `apple.info.en-US` block requires `title` and `privacyPolicyUrl` alongside `releaseNotes`. These stable values live in `apps/native-rd/store.config.base.json` (committed), and the splitter merges them with the per-release `releaseNotes` to produce the generated `store.config.json` that `eas metadata:push` consumes.
 
-- `apple.info.en-US.title` — the app name as it appears on the App Store
-- `apple.info.en-US.privacyPolicyUrl` — a publicly-hosted privacy policy URL
+Current values:
 
-Neither is in the splitter output yet because:
+| Field              | Value                               | Source of record                                      |
+| ------------------ | ----------------------------------- | ----------------------------------------------------- |
+| `title`            | `Rollercoaster.dev`                 | `apps/native-rd/app.json` (`expo.name`)               |
+| `privacyPolicyUrl` | `https://rollercoaster.dev/privacy` | `apps/native-rd/docs/launch/app-store-launch-plan.md` |
 
-1. The privacy policy at `apps/native-rd/docs/launch/privacy-policy.md` is **not yet hosted at a public URL** (still an open item in `docs/launch/production-release-plan.md`).
-2. Pushing a placeholder URL via `eas metadata:push` would overwrite whatever's currently set in App Store Connect — including any URL that's already been entered manually.
+Update `store.config.base.json` through a normal PR. Schema is validated by `eas metadata:lint --profile production`.
 
-**Until those are resolved, run `eas metadata:push` only after manually verifying the static fields in App Store Connect, or extend the splitter to merge a committed `store.config.base.json` with the per-release release notes.**
+> The privacy policy page must be live at the URL above before `eas metadata:push` runs in production. Follow the launch-readiness item in `apps/native-rd/docs/launch/production-release-plan.md` (issue #976).
 
 ## Reference: store fields and limits
 

--- a/apps/native-rd/docs/release/testing-notes/README.md
+++ b/apps/native-rd/docs/release/testing-notes/README.md
@@ -60,14 +60,87 @@ The linter measures the **trimmed body between the markers**, in JavaScript `Str
 
 ## Localization
 
-Currently `en-US` only. When additional locales are added (see `apps/native-rd/docs/i18n.md`), this format will grow per-locale slices (`play:en-US:start`, `play:de-DE:start`, etc.) and the Fastlane metadata layout will mirror that.
+Currently `en-US` only. When additional locales are added (see `apps/native-rd/docs/i18n.md`), this format will grow per-locale slices (`play:en-US:start`, `play:de-DE:start`, etc.).
 
-## Flow into stores
+## End-to-end flow
 
-The hand-written notes here are the **source of truth**. Downstream automation (planned, not yet built — see `docs/release.md`) will:
+The hand-written notes here are the **source of truth**. Three scripts move them through the pipeline:
 
-1. Copy the `play` body into `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
-2. Copy the `appstore` body into `fastlane/metadata/ios/en-US/release_notes.txt`.
-3. Pass the `testflight` body to the App Store Connect API as the build's `whatToTest` localization.
+### 1. Scaffold a new version
 
-Until that automation lands, copy/paste manually when promoting a build.
+```sh
+bun run release-notes:generate 0.1.5
+```
+
+Parses `CHANGELOG.md` for the version, pre-fills each slice with `TODO: ` bullets, writes `0.1.5.md`. Internal-scope commits (`ci:`, `chore:`, `build:`, `deps:`, `release:`) are filtered out of user-facing slices.
+
+### 2. Edit each slice
+
+Open `0.1.5.md` and rewrite every line that starts with `TODO:`:
+
+- **play** / **appstore**: user-facing copy. No jargon, no PR numbers.
+- **testflight**: tester instructions. Steps to exercise → expected result.
+
+Internal terms and PR numbers are fine in `testflight` only.
+
+### 3. Validate length and absence of TODOs
+
+```sh
+bun run release-notes:lint
+```
+
+Fails if any slice exceeds its store limit, is missing markers, or still contains `TODO`. Wire this into CI on the release-please PR to gate merge.
+
+### 4. Split into store-bound artifacts
+
+```sh
+bun run release-notes:split 0.1.5
+```
+
+Produces:
+
+| Output                                                       | Purpose                                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `apps/native-rd/store.config.json`                           | EAS Metadata config — read by `eas metadata:push` to set App Store "What's New" |
+| `apps/native-rd/.release-artifacts/play-changelog-en-US.txt` | Raw text for Play Console "What's new" (manual paste or future API push)        |
+| `apps/native-rd/.release-artifacts/what-to-test.txt`         | Raw text for `eas submit --what-to-test "$(cat ...)"`                           |
+
+The splitter refuses to write any output if the notes file still contains `TODO` markers — same check as `release-notes:lint`, enforced again here so CI can't sneak past it.
+
+### 5. Push to stores
+
+**iOS App Store + TestFlight:**
+
+```sh
+eas metadata:push --profile production
+eas submit --platform ios --profile production \
+  --what-to-test "$(cat apps/native-rd/.release-artifacts/what-to-test.txt)"
+```
+
+**Android Play "What's new":** there is no `eas submit` flag for this. Three options, in increasing order of automation:
+
+1. **Manual paste** — open Play Console → Production → "What's new in this version" → paste the contents of `play-changelog-en-US.txt`. Fine for now.
+2. **Fastlane Supply** — requires Ruby. Reads `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`. Heavier dependency.
+3. **Play Developer API push** (planned) — a small Bun script using `googleapis` to call `androidpublisher.edits.tracks.update` with `releases[0].releaseNotes`. Same service account credentials as `eas submit --platform android`; no additional permissions needed.
+
+## Open blockers before the iOS half can actually run
+
+The `store.config.json` produced by the splitter currently contains only `apple.info.en-US.releaseNotes`. EAS Metadata's schema also requires:
+
+- `apple.info.en-US.title` — the app name as it appears on the App Store
+- `apple.info.en-US.privacyPolicyUrl` — a publicly-hosted privacy policy URL
+
+Neither is in the splitter output yet because:
+
+1. The privacy policy at `apps/native-rd/docs/launch/privacy-policy.md` is **not yet hosted at a public URL** (still an open item in `docs/launch/production-release-plan.md`).
+2. Pushing a placeholder URL via `eas metadata:push` would overwrite whatever's currently set in App Store Connect — including any URL that's already been entered manually.
+
+**Until those are resolved, run `eas metadata:push` only after manually verifying the static fields in App Store Connect, or extend the splitter to merge a committed `store.config.base.json` with the per-release release notes.**
+
+## Reference: store fields and limits
+
+| Section in this doc | Store field                                      | Limit             | API                                                                     |
+| ------------------- | ------------------------------------------------ | ----------------- | ----------------------------------------------------------------------- |
+| `play`              | Play Console → "What's new in this version"      | 500 chars/locale  | Play Developer API: `edits.tracks.update` → `releases[].releaseNotes[]` |
+| `appstore`          | App Store Connect → "What's New in This Version" | 4000 chars/locale | EAS Metadata: `apple.info.<locale>.releaseNotes`                        |
+| `testflight`        | TestFlight → "What to Test"                      | 4000 chars        | `eas submit --what-to-test`                                             |

--- a/apps/native-rd/docs/release/testing-notes/README.md
+++ b/apps/native-rd/docs/release/testing-notes/README.md
@@ -1,0 +1,73 @@
+# Release Testing Notes
+
+One file per released version, named `<version>.md` (e.g. `0.1.5.md`). Each file feeds **three different store fields**, each with its own audience and hard length limit. The linter (`bun run release-notes:lint`) enforces the limits in CI.
+
+## The three fields
+
+| Section in this doc | Where it ships                                                         | Audience                                 | Hard limit                     |
+| ------------------- | ---------------------------------------------------------------------- | ---------------------------------------- | ------------------------------ |
+| `play`              | Google Play Console → "What's new in this version" (per `versionCode`) | End users browsing the Play listing      | **500 characters** per locale  |
+| `appstore`          | App Store Connect → "What's New in This Version" (per version)         | End users browsing the App Store listing | **4000 characters** per locale |
+| `testflight`        | App Store Connect → TestFlight → "What to Test" (per build)            | Internal + external TestFlight testers   | **4000 characters**            |
+
+The Play and App Store fields are **user-facing release notes** — write them as marketing copy ("Goals now show your next step on the home card"). The TestFlight field is **tester instructions** — write it as a QA brief ("Create a goal, tap into it, verify the next-step text appears on the card and matches the first incomplete step").
+
+Do not put internal jargon, PR numbers, or commit hashes in `play` or `appstore`. They are fine in `testflight`.
+
+## File format
+
+Each version file uses HTML comment markers to delimit the three slices. The headings around them are documentation; the markers are what the linter parses.
+
+```md
+---
+version: 0.1.5
+versionCode: 12
+date: 2026-05-25
+---
+
+# Testing notes — 0.1.5
+
+## Google Play — What's new (en-US, max 500 chars)
+
+<!-- play:start -->
+
+Free-form text here.
+
+<!-- play:end -->
+
+## App Store — Release notes (en-US, max 4000 chars)
+
+<!-- appstore:start -->
+
+Free-form text here.
+
+<!-- appstore:end -->
+
+## TestFlight — What to test (max 4000 chars)
+
+<!-- testflight:start -->
+
+Free-form text here.
+
+<!-- testflight:end -->
+```
+
+`_template.md` is the canonical starting point — copy it to `<next-version>.md` when starting a release.
+
+## Character counting
+
+The linter measures the **trimmed body between the markers**, in JavaScript `String.length` units (UTF-16 code units). This matches how App Store Connect and Play Console count, which both treat each character as one regardless of byte width — but emoji and combining marks may count as 2+ code units. Avoid emoji in the `play` slice especially; the 500-char budget is tight.
+
+## Localization
+
+Currently `en-US` only. When additional locales are added (see `apps/native-rd/docs/i18n.md`), this format will grow per-locale slices (`play:en-US:start`, `play:de-DE:start`, etc.) and the Fastlane metadata layout will mirror that.
+
+## Flow into stores
+
+The hand-written notes here are the **source of truth**. Downstream automation (planned, not yet built — see `docs/release.md`) will:
+
+1. Copy the `play` body into `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
+2. Copy the `appstore` body into `fastlane/metadata/ios/en-US/release_notes.txt`.
+3. Pass the `testflight` body to the App Store Connect API as the build's `whatToTest` localization.
+
+Until that automation lands, copy/paste manually when promoting a build.

--- a/apps/native-rd/docs/release/testing-notes/README.md
+++ b/apps/native-rd/docs/release/testing-notes/README.md
@@ -1,6 +1,6 @@
 # Release Testing Notes
 
-One file per released version, named `<version>.md` (e.g. `0.1.5.md`). Each file feeds **three different store fields**, each with its own audience and hard length limit. The linter (`bun run release-notes:lint`) enforces the limits in CI.
+One file per released version, named `<version>.md` (e.g. `0.1.5.md`). Each file feeds **three different store fields**, each with its own audience and hard length limit. The linter (`bun run release-notes:lint`) is designed to gate the release-please PR — wire it into CI when ready. It is not currently invoked by `ci-native-rd.yml` (which excludes `apps/native-rd/docs/**`); run it manually before tagging.
 
 ## The three fields
 

--- a/apps/native-rd/docs/release/testing-notes/_template.md
+++ b/apps/native-rd/docs/release/testing-notes/_template.md
@@ -24,15 +24,15 @@ End-user copy. Same voice as Play, but you have room for more detail. Group as F
 
 **New**
 
-- TODO
+- TODO: user-facing copy for a new feature
 
 **Improved**
 
-- TODO
+- TODO: user-facing copy for an enhancement
 
 **Fixed**
 
-- TODO
+- TODO: user-facing copy for a bug fix
 <!-- appstore:end -->
 
 ## TestFlight — What to test (max 4000 chars)

--- a/apps/native-rd/docs/release/testing-notes/_template.md
+++ b/apps/native-rd/docs/release/testing-notes/_template.md
@@ -1,0 +1,55 @@
+---
+version: X.Y.Z
+versionCode: NNN
+date: YYYY-MM-DD
+---
+
+# Testing notes — X.Y.Z
+
+## Google Play — What's new (en-US, max 500 chars)
+
+End-user copy. Lead with the user benefit, not the implementation. No PR numbers, no jargon. Tight — 500 chars goes fast.
+
+<!-- play:start -->
+
+TODO: 2–4 short bullets or a single paragraph describing what improved for the user in plain language.
+
+<!-- play:end -->
+
+## App Store — Release notes (en-US, max 4000 chars)
+
+End-user copy. Same voice as Play, but you have room for more detail. Group as Features / Improvements / Fixes if helpful.
+
+<!-- appstore:start -->
+
+**New**
+
+- TODO
+
+**Improved**
+
+- TODO
+
+**Fixed**
+
+- TODO
+<!-- appstore:end -->
+
+## TestFlight — What to test (max 4000 chars)
+
+Tester-facing QA brief. For each notable change: what to do, what to expect, what edge cases matter. PR numbers and internal terms are fine here.
+
+<!-- testflight:start -->
+
+**Focus areas this build**
+
+- TODO: feature → steps to exercise → expected result
+
+**Known issues / skip these**
+
+- TODO: anything that's broken-on-purpose or out of scope
+
+**Reporting**
+
+- File anything weird in GitHub issues with the build number from Settings → About.
+<!-- testflight:end -->

--- a/apps/native-rd/eas.json
+++ b/apps/native-rd/eas.json
@@ -55,7 +55,8 @@
         "appleTeamId": "86VL756N99",
         "ascApiKeyPath": "../../secrets/asc-api-key.p8",
         "ascApiKeyId": "$APPLE_ASC_KEY_ID",
-        "ascApiKeyIssuerId": "$APPLE_ASC_ISSUER_ID"
+        "ascApiKeyIssuerId": "$APPLE_ASC_ISSUER_ID",
+        "metadataPath": "./store.config.json"
       },
       "android": {
         "serviceAccountKeyPath": "../../secrets/play-service-account.json",

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -33,7 +33,8 @@
     "testflight:ios": "bash scripts/testflight-ios.sh",
     "gen:pseudo": "bun run scripts/generate-pseudo-locale.ts",
     "verify:badge": "bun run scripts/verify-badge.ts",
-    "release-notes:lint": "bun run scripts/release-notes-lint.ts"
+    "release-notes:lint": "bun run scripts/release-notes-lint.ts",
+    "release-notes:generate": "bun run scripts/release-notes-generate.ts"
   },
   "dependencies": {
     "@evolu/common": "^7.4.1",

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -34,7 +34,8 @@
     "gen:pseudo": "bun run scripts/generate-pseudo-locale.ts",
     "verify:badge": "bun run scripts/verify-badge.ts",
     "release-notes:lint": "bun run scripts/release-notes-lint.ts",
-    "release-notes:generate": "bun run scripts/release-notes-generate.ts"
+    "release-notes:generate": "bun run scripts/release-notes-generate.ts",
+    "release-notes:split": "bun run scripts/release-notes-split.ts"
   },
   "dependencies": {
     "@evolu/common": "^7.4.1",

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -32,7 +32,8 @@
     "test:a11y:json": "bash scripts/a11y-audit.sh --json",
     "testflight:ios": "bash scripts/testflight-ios.sh",
     "gen:pseudo": "bun run scripts/generate-pseudo-locale.ts",
-    "verify:badge": "bun run scripts/verify-badge.ts"
+    "verify:badge": "bun run scripts/verify-badge.ts",
+    "release-notes:lint": "bun run scripts/release-notes-lint.ts"
   },
   "dependencies": {
     "@evolu/common": "^7.4.1",

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -12,7 +12,7 @@
     "android": "bash scripts/run-android.sh",
     "android:device": "ANDROID_DEVICE_ID=\"${ANDROID_DEVICE_ID:?Set ANDROID_DEVICE_ID}\" bash scripts/run-android.sh",
     "web": "expo start --web",
-    "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p tsconfig.scripts.json",
     "build": "echo 'Expo app — no build step'",
     "eas-build-post-install": "cd ../.. && bun x turbo build --filter=native-rd^...",
     "lint": "expo lint",

--- a/apps/native-rd/scripts/release-notes-generate.ts
+++ b/apps/native-rd/scripts/release-notes-generate.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env bun
+/**
+ * Scaffolds docs/release/testing-notes/<version>.md from CHANGELOG.md.
+ *
+ * Parses the release-please-generated CHANGELOG.md for the target version,
+ * pulls the `### Features` and `### Bug Fixes` bullets, strips conventional-
+ * commit scope prefixes and trailing PR/commit link groups, then writes a
+ * marker-delimited testing-notes file with each bullet prefixed `TODO: ` so
+ * the release-notes:lint check forces a human edit before merge.
+ *
+ * The scaffold is INTENTIONALLY linter-failing. The "TODO" check catches
+ * unedited entries; the human must rewrite each bullet as user-facing copy
+ * (play/appstore) or a tester instruction (testflight) before tagging.
+ *
+ * Version defaults to the current apps/native-rd/package.json version
+ * (i.e. the version release-please just bumped to). Pass a version arg
+ * to override: `bun run scripts/release-notes-generate.ts 0.1.5`.
+ *
+ * Run: bun run release-notes:generate
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const APP_ROOT = join(import.meta.dir, "..");
+const CHANGELOG_PATH = join(APP_ROOT, "CHANGELOG.md");
+const PACKAGE_JSON_PATH = join(APP_ROOT, "package.json");
+const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
+
+type ChangelogEntry = {
+  scope: string | null;
+  title: string;
+};
+
+type ChangelogSection = {
+  features: ChangelogEntry[];
+  fixes: ChangelogEntry[];
+};
+
+// Scopes whose entries are internal-only (build infra, CI, dependency bumps,
+// release-please chores). They stay in CHANGELOG.md but don't belong in any
+// user-facing or tester-facing release notes.
+const INTERNAL_SCOPES = new Set(["ci", "chore", "build", "deps", "release"]);
+
+function resolveVersion(arg: string | undefined): string {
+  if (arg && arg.length > 0) return arg;
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+    version?: string;
+  };
+  if (!pkg.version) {
+    throw new Error(`No version in ${PACKAGE_JSON_PATH}`);
+  }
+  return pkg.version;
+}
+
+function parseBullet(line: string): ChangelogEntry {
+  let text = line.replace(/^[*-]\s+/, "");
+  // Extract the conventional-commit scope ("**scope:**") before stripping it,
+  // so downstream filters can act on scope rather than cleaned title text.
+  const scopeMatch = /^\*\*([^*]+):\*\*\s+/.exec(text);
+  const scope = scopeMatch ? scopeMatch[1].trim() : null;
+  if (scopeMatch) text = text.slice(scopeMatch[0].length);
+  // Strip trailing parenthetical link groups like ` ([#12](url))` or ` ([hash](url))`,
+  // including release-please's ", closes [#NN](url)" suffix. Iterate to peel them off.
+  while (true) {
+    const stripped = text
+      .replace(/,?\s+closes\s+\[[^\]]+\]\([^)]+\)\s*$/, "")
+      .replace(/\s+\(\[[^\]]+\]\([^)]+\)\)\s*$/, "");
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return { scope, title: text.trim() };
+}
+
+function extractVersionSection(changelog: string, version: string): string {
+  // Match heading lines: "## [X.Y.Z]..." or "## X.Y.Z..." — release-please uses the linked form.
+  const escaped = version.replace(/\./g, "\\.");
+  const headingRe = new RegExp(`^##\\s+\\[${escaped}\\][^\\n]*$`, "m");
+  const match = headingRe.exec(changelog);
+  if (!match) {
+    throw new Error(
+      `Could not find version ${version} in CHANGELOG.md (looked for "## [${version}]..."). ` +
+        `If release-please has not run yet, pass the version explicitly.`,
+    );
+  }
+  const start = match.index + match[0].length;
+  const nextHeadingRe = /^##\s+\[/m;
+  nextHeadingRe.lastIndex = 0;
+  const rest = changelog.slice(start);
+  const nextMatch = nextHeadingRe.exec(rest);
+  return nextMatch ? rest.slice(0, nextMatch.index) : rest;
+}
+
+function parseSection(section: string): ChangelogSection {
+  const result: ChangelogSection = { features: [], fixes: [] };
+  const lines = section.split("\n");
+  let bucket: "features" | "fixes" | null = null;
+  for (const line of lines) {
+    if (/^###\s+Features\b/.test(line)) {
+      bucket = "features";
+      continue;
+    }
+    if (/^###\s+Bug\s+Fixes\b/.test(line)) {
+      bucket = "fixes";
+      continue;
+    }
+    if (/^###\s+/.test(line)) {
+      bucket = null;
+      continue;
+    }
+    if (bucket && /^[*-]\s+/.test(line)) {
+      result[bucket].push(parseBullet(line));
+    }
+  }
+  return result;
+}
+
+function todoList(items: ChangelogEntry[]): string {
+  if (items.length === 0) return "- TODO: (none in this release)";
+  return items.map((item) => `- TODO: ${item.title}`).join("\n");
+}
+
+function isUserFacing(entry: ChangelogEntry): boolean {
+  if (entry.scope === null) return true;
+  return !INTERNAL_SCOPES.has(entry.scope.toLowerCase());
+}
+
+function buildScaffold(version: string, section: ChangelogSection): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const userFacingFeatures = section.features.filter(isUserFacing);
+  const userFacingFixes = section.fixes.filter(isUserFacing);
+
+  return `---
+version: ${version}
+versionCode: TODO
+date: ${today}
+---
+
+# Testing notes — ${version}
+
+> Scaffold generated from CHANGELOG.md. Rewrite each \`TODO: \` line:
+> - **play** / **appstore**: user-facing copy (no jargon, no PR numbers)
+> - **testflight**: tester instructions (steps to exercise + expected result)
+>
+> The release-notes:lint check fails while any \`TODO\` remains.
+
+## Google Play — What's new (en-US, max 500 chars)
+
+End-user copy. Lead with the user benefit. Tight — 500 chars goes fast.
+
+<!-- play:start -->
+
+TODO: 2–4 short bullets or a single paragraph describing what improved for the user in plain language.
+
+<!-- play:end -->
+
+## App Store — Release notes (en-US, max 4000 chars)
+
+End-user copy. Same voice as Play, but more room.
+
+<!-- appstore:start -->
+
+**New**
+
+${todoList(userFacingFeatures)}
+
+**Fixed**
+
+${todoList(userFacingFixes)}
+
+<!-- appstore:end -->
+
+## TestFlight — What to test (max 4000 chars)
+
+Tester-facing QA brief. Rewrite each line as: what to do → expected result.
+
+<!-- testflight:start -->
+
+**Focus areas this build**
+
+${todoList(userFacingFeatures)}
+
+**Recent fixes worth a sanity check**
+
+${todoList(userFacingFixes)}
+
+**Reporting**
+
+- File anything weird in GitHub issues with the build number from Settings → About.
+
+<!-- testflight:end -->
+`;
+}
+
+function main(): number {
+  const version = resolveVersion(process.argv[2]);
+  const outPath = join(NOTES_DIR, `${version}.md`);
+  if (existsSync(outPath)) {
+    console.error(
+      `release-notes-generate: ${outPath} already exists. Delete it or pick another version.`,
+    );
+    return 1;
+  }
+  const changelog = readFileSync(CHANGELOG_PATH, "utf8");
+  const section = extractVersionSection(changelog, version);
+  const parsed = parseSection(section);
+  if (parsed.features.length === 0 && parsed.fixes.length === 0) {
+    console.error(
+      `release-notes-generate: no Features or Bug Fixes found in CHANGELOG.md for ${version}.`,
+    );
+    return 1;
+  }
+  const content = buildScaffold(version, parsed);
+  writeFileSync(outPath, content);
+  const userFacingFeatures = parsed.features.filter(isUserFacing).length;
+  const userFacingFixes = parsed.fixes.filter(isUserFacing).length;
+  const filteredFeatures = parsed.features.length - userFacingFeatures;
+  const filteredFixes = parsed.fixes.length - userFacingFixes;
+  console.log(
+    `release-notes-generate: wrote ${outPath}\n` +
+      `  features: ${userFacingFeatures} user-facing` +
+      (filteredFeatures > 0 ? ` (+${filteredFeatures} internal hidden)` : "") +
+      `\n` +
+      `  fixes: ${userFacingFixes} user-facing` +
+      (filteredFixes > 0 ? ` (+${filteredFixes} internal hidden)` : "") +
+      `\n` +
+      `  next: edit the TODO lines, then \`bun run release-notes:lint\` to verify.`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/apps/native-rd/scripts/release-notes-generate.ts
+++ b/apps/native-rd/scripts/release-notes-generate.ts
@@ -62,19 +62,28 @@ function parseBullet(line: string): ChangelogEntry {
 }
 
 function extractVersionSection(changelog: string, version: string): string {
-  // Match heading lines: "## [X.Y.Z]..." or "## X.Y.Z..." — release-please uses the linked form.
+  // Match heading lines: "## [X.Y.Z]..." (release-please linked form) or
+  // "## X.Y.Z..." (older hand-written entries — CHANGELOG.md mixes both).
   const escaped = version.replace(/\./g, "\\.");
-  const headingRe = new RegExp(`^##\\s+\\[${escaped}\\][^\\n]*$`, "m");
+  // Use \b on the unlinked alternative so "## 0.1.4" does not match "## 0.1.41".
+  // The bracketed form is already self-delimiting via the closing "]".
+  const headingRe = new RegExp(
+    `^##\\s+(?:\\[${escaped}\\]|${escaped}\\b)[^\\n]*$`,
+    "m",
+  );
   const match = headingRe.exec(changelog);
   if (!match) {
     throw new Error(
-      `Could not find version ${version} in CHANGELOG.md (looked for "## [${version}]..."). ` +
+      `Could not find version ${version} in CHANGELOG.md ` +
+        `(looked for "## [${version}]..." or "## ${version}..."). ` +
         `If release-please has not run yet, pass the version explicitly.`,
     );
   }
   const start = match.index + match[0].length;
-  const nextHeadingRe = /^##\s+\[/m;
-  nextHeadingRe.lastIndex = 0;
+  // Next heading is the start of the previous (older) release section. Match
+  // both linked ("## [x.y.z]") and unlinked ("## x.y.z") forms so we stop at
+  // the first older entry regardless of which form CHANGELOG.md uses there.
+  const nextHeadingRe = /^##\s+(?:\[|\d)/m;
   const rest = changelog.slice(start);
   const nextMatch = nextHeadingRe.exec(rest);
   return nextMatch ? rest.slice(0, nextMatch.index) : rest;

--- a/apps/native-rd/scripts/release-notes-generate.ts
+++ b/apps/native-rd/scripts/release-notes-generate.ts
@@ -22,9 +22,9 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const APP_ROOT = join(import.meta.dir, "..");
+import { APP_ROOT, resolveVersion } from "./release-notes-shared";
+
 const CHANGELOG_PATH = join(APP_ROOT, "CHANGELOG.md");
-const PACKAGE_JSON_PATH = join(APP_ROOT, "package.json");
 const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 
 type ChangelogEntry = {
@@ -41,17 +41,6 @@ type ChangelogSection = {
 // release-please chores). They stay in CHANGELOG.md but don't belong in any
 // user-facing or tester-facing release notes.
 const INTERNAL_SCOPES = new Set(["ci", "chore", "build", "deps", "release"]);
-
-function resolveVersion(arg: string | undefined): string {
-  if (arg && arg.length > 0) return arg;
-  const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
-    version?: string;
-  };
-  if (!pkg.version) {
-    throw new Error(`No version in ${PACKAGE_JSON_PATH}`);
-  }
-  return pkg.version;
-}
 
 function parseBullet(line: string): ChangelogEntry {
   let text = line.replace(/^[*-]\s+/, "");
@@ -125,12 +114,19 @@ function isUserFacing(entry: ChangelogEntry): boolean {
   return !INTERNAL_SCOPES.has(entry.scope.toLowerCase());
 }
 
-function buildScaffold(version: string, section: ChangelogSection): string {
+type Scaffold = {
+  content: string;
+  userFacingFeatureCount: number;
+  userFacingFixCount: number;
+  internalFeatureCount: number;
+  internalFixCount: number;
+};
+
+function buildScaffold(version: string, section: ChangelogSection): Scaffold {
   const today = new Date().toISOString().slice(0, 10);
   const userFacingFeatures = section.features.filter(isUserFacing);
   const userFacingFixes = section.fixes.filter(isUserFacing);
-
-  return `---
+  const content = `---
 version: ${version}
 versionCode: TODO
 date: ${today}
@@ -190,6 +186,13 @@ ${todoList(userFacingFixes)}
 
 <!-- testflight:end -->
 `;
+  return {
+    content,
+    userFacingFeatureCount: userFacingFeatures.length,
+    userFacingFixCount: userFacingFixes.length,
+    internalFeatureCount: section.features.length - userFacingFeatures.length,
+    internalFixCount: section.fixes.length - userFacingFixes.length,
+  };
 }
 
 function main(): number {
@@ -210,23 +213,25 @@ function main(): number {
     );
     return 1;
   }
-  const content = buildScaffold(version, parsed);
-  writeFileSync(outPath, content);
-  const userFacingFeatures = parsed.features.filter(isUserFacing).length;
-  const userFacingFixes = parsed.fixes.filter(isUserFacing).length;
-  const filteredFeatures = parsed.features.length - userFacingFeatures;
-  const filteredFixes = parsed.fixes.length - userFacingFixes;
+  const scaffold = buildScaffold(version, parsed);
+  writeFileSync(outPath, scaffold.content);
+  const hiddenFeatures =
+    scaffold.internalFeatureCount > 0
+      ? ` (+${scaffold.internalFeatureCount} internal hidden)`
+      : "";
+  const hiddenFixes =
+    scaffold.internalFixCount > 0
+      ? ` (+${scaffold.internalFixCount} internal hidden)`
+      : "";
   console.log(
     `release-notes-generate: wrote ${outPath}\n` +
-      `  features: ${userFacingFeatures} user-facing` +
-      (filteredFeatures > 0 ? ` (+${filteredFeatures} internal hidden)` : "") +
-      `\n` +
-      `  fixes: ${userFacingFixes} user-facing` +
-      (filteredFixes > 0 ? ` (+${filteredFixes} internal hidden)` : "") +
-      `\n` +
+      `  features: ${scaffold.userFacingFeatureCount} user-facing${hiddenFeatures}\n` +
+      `  fixes: ${scaffold.userFacingFixCount} user-facing${hiddenFixes}\n` +
       `  next: edit the TODO lines, then \`bun run release-notes:lint\` to verify.`,
   );
   return 0;
 }
 
-process.exit(main());
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/apps/native-rd/scripts/release-notes-generate.ts
+++ b/apps/native-rd/scripts/release-notes-generate.ts
@@ -64,7 +64,10 @@ function parseBullet(line: string): ChangelogEntry {
 function extractVersionSection(changelog: string, version: string): string {
   // Match heading lines: "## [X.Y.Z]..." (release-please linked form) or
   // "## X.Y.Z..." (older hand-written entries — CHANGELOG.md mixes both).
-  const escaped = version.replace(/\./g, "\\.");
+  // `version` is already sanitized to strict semver by resolveVersion, but we
+  // still apply the MDN-canonical full regex-meta escape here so CodeQL's
+  // "incomplete string escaping" heuristic doesn't trip on a partial escape.
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   // Use \b on the unlinked alternative so "## 0.1.4" does not match "## 0.1.41".
   // The bracketed form is already self-delimiting via the closing "]".
   const headingRe = new RegExp(

--- a/apps/native-rd/scripts/release-notes-lint.ts
+++ b/apps/native-rd/scripts/release-notes-lint.ts
@@ -6,9 +6,6 @@
  * starting with "_" (templates). For each file, parses the three marker-delimited
  * slices and asserts the trimmed body fits the per-store character budget.
  *
- * Limits are hard ceilings from Google Play / App Store Connect. See README.md
- * in the same directory for the source of those numbers.
- *
  * Exits 0 on success, 1 on any violation. Designed for CI.
  *
  * Run: bun run release-notes:lint
@@ -17,74 +14,27 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { basename, join } from "node:path";
 
-type SliceName = "play" | "appstore" | "testflight";
+import {
+  APP_ROOT,
+  checkSlice,
+  extractSlice,
+  SLICES,
+  type SliceViolation,
+} from "./release-notes-shared";
 
-const LIMITS: Record<SliceName, number> = {
-  play: 500,
-  appstore: 4000,
-  testflight: 4000,
-};
+const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 
-const SLICES: readonly SliceName[] = ["play", "appstore", "testflight"];
+type FileViolation = SliceViolation & { file: string };
 
-const NOTES_DIR = join(
-  import.meta.dir,
-  "..",
-  "docs",
-  "release",
-  "testing-notes",
-);
-
-type Violation = {
-  file: string;
-  slice: SliceName;
-  reason: string;
-};
-
-function extractSlice(source: string, slice: SliceName): string | null {
-  const start = `<!-- ${slice}:start -->`;
-  const end = `<!-- ${slice}:end -->`;
-  const startIdx = source.indexOf(start);
-  const endIdx = source.indexOf(end);
-  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null;
-  return source.slice(startIdx + start.length, endIdx).trim();
-}
-
-function lintFile(path: string): Violation[] {
+function lintFile(path: string): FileViolation[] {
   const source = readFileSync(path, "utf8");
   const file = basename(path);
-  const violations: Violation[] = [];
-
+  const violations: FileViolation[] = [];
   for (const slice of SLICES) {
     const body = extractSlice(source, slice);
-    if (body === null) {
-      violations.push({
-        file,
-        slice,
-        reason: `missing <!-- ${slice}:start --> / <!-- ${slice}:end --> markers`,
-      });
-      continue;
-    }
-    if (body.length === 0) {
-      violations.push({ file, slice, reason: "empty body between markers" });
-      continue;
-    }
-    if (body.includes("TODO")) {
-      violations.push({
-        file,
-        slice,
-        reason: "contains TODO — fill in before tagging the release",
-      });
-    }
-    if (body.length > LIMITS[slice]) {
-      violations.push({
-        file,
-        slice,
-        reason: `${body.length} chars exceeds limit of ${LIMITS[slice]}`,
-      });
-    }
+    const v = checkSlice(slice, body);
+    if (v) violations.push({ ...v, file });
   }
-
   return violations;
 }
 
@@ -98,9 +48,10 @@ function main(): number {
   }
 
   const files = entries
-    .filter((name) => name.endsWith(".md"))
-    .filter((name) => name !== "README.md")
-    .filter((name) => !name.startsWith("_"))
+    .filter(
+      (name) =>
+        name.endsWith(".md") && name !== "README.md" && !name.startsWith("_"),
+    )
     .map((name) => join(NOTES_DIR, name));
 
   if (files.length === 0) {
@@ -124,4 +75,6 @@ function main(): number {
   return 1;
 }
 
-process.exit(main());
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/apps/native-rd/scripts/release-notes-lint.ts
+++ b/apps/native-rd/scripts/release-notes-lint.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env bun
+/**
+ * Validates release testing-notes against store length limits.
+ *
+ * Lints every file in docs/release/testing-notes/ except README.md and files
+ * starting with "_" (templates). For each file, parses the three marker-delimited
+ * slices and asserts the trimmed body fits the per-store character budget.
+ *
+ * Limits are hard ceilings from Google Play / App Store Connect. See README.md
+ * in the same directory for the source of those numbers.
+ *
+ * Exits 0 on success, 1 on any violation. Designed for CI.
+ *
+ * Run: bun run release-notes:lint
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+type SliceName = "play" | "appstore" | "testflight";
+
+const LIMITS: Record<SliceName, number> = {
+  play: 500,
+  appstore: 4000,
+  testflight: 4000,
+};
+
+const SLICES: readonly SliceName[] = ["play", "appstore", "testflight"];
+
+const NOTES_DIR = join(
+  import.meta.dir,
+  "..",
+  "docs",
+  "release",
+  "testing-notes",
+);
+
+type Violation = {
+  file: string;
+  slice: SliceName;
+  reason: string;
+};
+
+function extractSlice(source: string, slice: SliceName): string | null {
+  const start = `<!-- ${slice}:start -->`;
+  const end = `<!-- ${slice}:end -->`;
+  const startIdx = source.indexOf(start);
+  const endIdx = source.indexOf(end);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null;
+  return source.slice(startIdx + start.length, endIdx).trim();
+}
+
+function lintFile(path: string): Violation[] {
+  const source = readFileSync(path, "utf8");
+  const file = basename(path);
+  const violations: Violation[] = [];
+
+  for (const slice of SLICES) {
+    const body = extractSlice(source, slice);
+    if (body === null) {
+      violations.push({
+        file,
+        slice,
+        reason: `missing <!-- ${slice}:start --> / <!-- ${slice}:end --> markers`,
+      });
+      continue;
+    }
+    if (body.length === 0) {
+      violations.push({ file, slice, reason: "empty body between markers" });
+      continue;
+    }
+    if (body.includes("TODO")) {
+      violations.push({
+        file,
+        slice,
+        reason: "contains TODO — fill in before tagging the release",
+      });
+    }
+    if (body.length > LIMITS[slice]) {
+      violations.push({
+        file,
+        slice,
+        reason: `${body.length} chars exceeds limit of ${LIMITS[slice]}`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function main(): number {
+  let entries: string[];
+  try {
+    entries = readdirSync(NOTES_DIR);
+  } catch {
+    console.error(`testing-notes directory not found at ${NOTES_DIR}`);
+    return 1;
+  }
+
+  const files = entries
+    .filter((name) => name.endsWith(".md"))
+    .filter((name) => name !== "README.md")
+    .filter((name) => !name.startsWith("_"))
+    .map((name) => join(NOTES_DIR, name));
+
+  if (files.length === 0) {
+    console.log(
+      "release-notes-lint: no version notes to check (only template/README present).",
+    );
+    return 0;
+  }
+
+  const allViolations = files.flatMap(lintFile);
+
+  if (allViolations.length === 0) {
+    console.log(`release-notes-lint: ${files.length} file(s) OK.`);
+    return 0;
+  }
+
+  console.error(`release-notes-lint: ${allViolations.length} violation(s):`);
+  for (const v of allViolations) {
+    console.error(`  ${v.file} [${v.slice}]: ${v.reason}`);
+  }
+  return 1;
+}
+
+process.exit(main());

--- a/apps/native-rd/scripts/release-notes-shared.ts
+++ b/apps/native-rd/scripts/release-notes-shared.ts
@@ -65,8 +65,22 @@ export function checkSlice(
   return null;
 }
 
+// Strict semver shape (with optional prerelease/build) — see semver.org.
+// Used to sanitize `version` before it flows into a RegExp constructor in
+// release-notes-generate.ts, so CLI argv can't smuggle regex meta-chars in.
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
 export function resolveVersion(arg: string | undefined): string {
-  if (arg && arg.length > 0) return arg;
+  const candidate = arg && arg.length > 0 ? arg : readPackageVersion();
+  if (!SEMVER_RE.test(candidate)) {
+    throw new Error(
+      `Invalid version "${candidate}" — expected semver like 0.1.4 or 0.1.4-rc.1.`,
+    );
+  }
+  return candidate;
+}
+
+function readPackageVersion(): string {
   const pkgPath = join(APP_ROOT, "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
   if (!pkg.version) throw new Error(`No version in ${pkgPath}`);

--- a/apps/native-rd/scripts/release-notes-shared.ts
+++ b/apps/native-rd/scripts/release-notes-shared.ts
@@ -48,10 +48,12 @@ export function checkSlice(
   if (body.length === 0) {
     return { slice, reason: "empty body between markers" };
   }
-  if (body.includes("TODO")) {
+  // Match the literal "TODO:" marker the scaffold emits, not any substring,
+  // so legitimate prose like "TODO list" doesn't false-positive.
+  if (/\bTODO:/.test(body)) {
     return {
       slice,
-      reason: "contains TODO — fill in before tagging the release",
+      reason: "contains TODO: marker — fill in before tagging the release",
     };
   }
   if (body.length > LIMITS[slice]) {

--- a/apps/native-rd/scripts/release-notes-shared.ts
+++ b/apps/native-rd/scripts/release-notes-shared.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types and helpers for the release-notes-{lint,generate,split} scripts.
+ *
+ * The slice limits here are the hard ceilings from Google Play / App Store
+ * Connect — see docs/release/testing-notes/README.md for the source.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const APP_ROOT = join(import.meta.dir, "..");
+
+export type SliceName = "play" | "appstore" | "testflight";
+
+export const SLICES: readonly SliceName[] = ["play", "appstore", "testflight"];
+
+export const LIMITS: Record<SliceName, number> = {
+  play: 500,
+  appstore: 4000,
+  testflight: 4000,
+};
+
+export type SliceViolation = {
+  slice: SliceName;
+  reason: string;
+};
+
+export function extractSlice(source: string, slice: SliceName): string | null {
+  const start = `<!-- ${slice}:start -->`;
+  const end = `<!-- ${slice}:end -->`;
+  const startIdx = source.indexOf(start);
+  if (startIdx === -1) return null;
+  const endIdx = source.indexOf(end, startIdx + start.length);
+  if (endIdx === -1) return null;
+  return source.slice(startIdx + start.length, endIdx).trim();
+}
+
+export function checkSlice(
+  slice: SliceName,
+  body: string | null,
+): SliceViolation | null {
+  if (body === null) {
+    return {
+      slice,
+      reason: `missing <!-- ${slice}:start --> / <!-- ${slice}:end --> markers`,
+    };
+  }
+  if (body.length === 0) {
+    return { slice, reason: "empty body between markers" };
+  }
+  if (body.includes("TODO")) {
+    return {
+      slice,
+      reason: "contains TODO — fill in before tagging the release",
+    };
+  }
+  if (body.length > LIMITS[slice]) {
+    return {
+      slice,
+      reason: `${body.length} chars exceeds limit of ${LIMITS[slice]}`,
+    };
+  }
+  return null;
+}
+
+export function resolveVersion(arg: string | undefined): string {
+  if (arg && arg.length > 0) return arg;
+  const pkgPath = join(APP_ROOT, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
+  if (!pkg.version) throw new Error(`No version in ${pkgPath}`);
+  return pkg.version;
+}

--- a/apps/native-rd/scripts/release-notes-split.ts
+++ b/apps/native-rd/scripts/release-notes-split.ts
@@ -1,29 +1,19 @@
 #!/usr/bin/env bun
 /**
- * Splits docs/release/testing-notes/<version>.md into the three store-bound
- * artifacts:
+ * Splits docs/release/testing-notes/<version>.md into three store-bound artifacts:
  *
  *   1. store.config.json (EAS Metadata) — apple.info.en-US.releaseNotes
- *      → consumed by `eas metadata:push --profile production` to set the
- *        App Store "What's New in This Version" field.
+ *      → `eas metadata:push --profile production` for App Store "What's New"
+ *   2. .release-artifacts/play-changelog-en-US.txt
+ *      → Play Console "What's new" (manual paste or future API push)
+ *   3. .release-artifacts/what-to-test.txt
+ *      → `eas submit --what-to-test "$(cat ...)"` for TestFlight "What to Test"
  *
- *   2. .release-artifacts/play-changelog-en-US.txt — raw text of the play slice
- *      → consumed by the (future) Play Developer API push, or copied into
- *        Play Console manually until that automation lands.
+ * Refuses to write any artifact if the testing-notes file fails the same
+ * checks release-notes:lint enforces, so the pipeline halts before partial
+ * state can reach the stores.
  *
- *   3. .release-artifacts/what-to-test.txt — raw text of the testflight slice
- *      → consumed by `eas submit --platform ios --what-to-test "$(cat ...)"`
- *        or `eas build --auto-submit --what-to-test "$(cat ...)"` to set the
- *        TestFlight "What to Test" field.
- *
- * Refuses to write any artifact if the testing-notes file still contains
- * TODO markers — that's the same check release-notes:lint enforces. The
- * intent is that this script is safe to run unattended in CI: either the
- * notes are fully edited and it produces clean artifacts, or it exits
- * non-zero and the pipeline halts before anything reaches the stores.
- *
- * Version defaults to apps/native-rd/package.json. Override with arg:
- * `bun run scripts/release-notes-split.ts 0.1.5`.
+ * Version defaults to apps/native-rd/package.json. Override with arg.
  *
  * Run: bun run release-notes:split
  */
@@ -31,40 +21,19 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const APP_ROOT = join(import.meta.dir, "..");
+import {
+  APP_ROOT,
+  checkSlice,
+  extractSlice,
+  resolveVersion,
+  SLICES,
+  type SliceName,
+} from "./release-notes-shared";
+
 const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 const ARTIFACTS_DIR = join(APP_ROOT, ".release-artifacts");
 const STORE_CONFIG_PATH = join(APP_ROOT, "store.config.json");
 const STORE_CONFIG_BASE_PATH = join(APP_ROOT, "store.config.base.json");
-const PACKAGE_JSON_PATH = join(APP_ROOT, "package.json");
-
-type SliceName = "play" | "appstore" | "testflight";
-
-const LIMITS: Record<SliceName, number> = {
-  play: 500,
-  appstore: 4000,
-  testflight: 4000,
-};
-
-function resolveVersion(arg: string | undefined): string {
-  if (arg && arg.length > 0) return arg;
-  const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
-    version?: string;
-  };
-  if (!pkg.version) throw new Error(`No version in ${PACKAGE_JSON_PATH}`);
-  return pkg.version;
-}
-
-function extractSlice(source: string, slice: SliceName): string {
-  const start = `<!-- ${slice}:start -->`;
-  const end = `<!-- ${slice}:end -->`;
-  const startIdx = source.indexOf(start);
-  const endIdx = source.indexOf(end);
-  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
-    throw new Error(`Missing ${slice} markers in testing-notes file`);
-  }
-  return source.slice(startIdx + start.length, endIdx).trim();
-}
 
 type StoreConfig = {
   configVersion?: number;
@@ -88,22 +57,6 @@ function mergeStoreConfig(
   return cloned;
 }
 
-function validate(slice: SliceName, body: string): void {
-  if (body.length === 0) {
-    throw new Error(`${slice}: empty body between markers`);
-  }
-  if (body.includes("TODO")) {
-    throw new Error(
-      `${slice}: contains TODO — rewrite all TODO lines before splitting`,
-    );
-  }
-  if (body.length > LIMITS[slice]) {
-    throw new Error(
-      `${slice}: ${body.length} chars exceeds store limit of ${LIMITS[slice]}`,
-    );
-  }
-}
-
 function main(): number {
   const version = resolveVersion(process.argv[2]);
   const notesPath = join(NOTES_DIR, `${version}.md`);
@@ -119,19 +72,21 @@ function main(): number {
     return 1;
   }
 
-  const slices: Record<SliceName, string> = {
-    play: extractSlice(source, "play"),
-    appstore: extractSlice(source, "appstore"),
-    testflight: extractSlice(source, "testflight"),
+  const bodies: Record<SliceName, string> = {
+    play: "",
+    appstore: "",
+    testflight: "",
   };
-
-  for (const name of ["play", "appstore", "testflight"] as const) {
-    try {
-      validate(name, slices[name]);
-    } catch (err) {
-      console.error(`release-notes-split: ${(err as Error).message}`);
+  for (const slice of SLICES) {
+    const body = extractSlice(source, slice);
+    const violation = checkSlice(slice, body);
+    if (violation || body === null) {
+      console.error(
+        `release-notes-split: ${slice}: ${violation?.reason ?? "missing markers"}`,
+      );
       return 1;
     }
+    bodies[slice] = body;
   }
 
   let base: unknown;
@@ -145,20 +100,20 @@ function main(): number {
     );
     return 1;
   }
-  const storeConfig = mergeStoreConfig(base, slices.appstore);
+  const storeConfig = mergeStoreConfig(base, bodies.appstore);
   writeFileSync(STORE_CONFIG_PATH, JSON.stringify(storeConfig, null, 2) + "\n");
 
   mkdirSync(ARTIFACTS_DIR, { recursive: true });
   const playPath = join(ARTIFACTS_DIR, "play-changelog-en-US.txt");
   const testflightPath = join(ARTIFACTS_DIR, "what-to-test.txt");
-  writeFileSync(playPath, slices.play + "\n");
-  writeFileSync(testflightPath, slices.testflight + "\n");
+  writeFileSync(playPath, bodies.play + "\n");
+  writeFileSync(testflightPath, bodies.testflight + "\n");
 
   console.log(
     `release-notes-split: wrote artifacts for ${version}\n` +
-      `  store.config.json (appstore release notes, ${slices.appstore.length} chars)\n` +
-      `  ${playPath} (play, ${slices.play.length} chars)\n` +
-      `  ${testflightPath} (testflight, ${slices.testflight.length} chars)\n` +
+      `  store.config.json (appstore release notes, ${bodies.appstore.length} chars)\n` +
+      `  ${playPath} (play, ${bodies.play.length} chars)\n` +
+      `  ${testflightPath} (testflight, ${bodies.testflight.length} chars)\n` +
       `  next:\n` +
       `    iOS:     eas metadata:push --profile production\n` +
       `             eas submit --platform ios --profile production --what-to-test "$(cat ${testflightPath})"\n` +
@@ -168,4 +123,6 @@ function main(): number {
   return 0;
 }
 
-process.exit(main());
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/apps/native-rd/scripts/release-notes-split.ts
+++ b/apps/native-rd/scripts/release-notes-split.ts
@@ -35,6 +35,7 @@ const APP_ROOT = join(import.meta.dir, "..");
 const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 const ARTIFACTS_DIR = join(APP_ROOT, ".release-artifacts");
 const STORE_CONFIG_PATH = join(APP_ROOT, "store.config.json");
+const STORE_CONFIG_BASE_PATH = join(APP_ROOT, "store.config.base.json");
 const PACKAGE_JSON_PATH = join(APP_ROOT, "package.json");
 
 type SliceName = "play" | "appstore" | "testflight";
@@ -63,6 +64,28 @@ function extractSlice(source: string, slice: SliceName): string {
     throw new Error(`Missing ${slice} markers in testing-notes file`);
   }
   return source.slice(startIdx + start.length, endIdx).trim();
+}
+
+type StoreConfig = {
+  configVersion?: number;
+  apple?: {
+    info?: Record<string, Record<string, unknown> | undefined>;
+  };
+};
+
+function mergeStoreConfig(
+  base: unknown,
+  appstoreReleaseNotes: string,
+): StoreConfig {
+  const cloned = JSON.parse(JSON.stringify(base ?? {})) as StoreConfig;
+  cloned.apple ??= {};
+  cloned.apple.info ??= {};
+  const locale = cloned.apple.info["en-US"] ?? {};
+  cloned.apple.info["en-US"] = {
+    ...locale,
+    releaseNotes: appstoreReleaseNotes,
+  };
+  return cloned;
 }
 
 function validate(slice: SliceName, body: string): void {
@@ -111,16 +134,18 @@ function main(): number {
     }
   }
 
-  const storeConfig = {
-    configVersion: 0,
-    apple: {
-      info: {
-        "en-US": {
-          releaseNotes: slices.appstore,
-        },
-      },
-    },
-  };
+  let base: unknown;
+  try {
+    base = JSON.parse(readFileSync(STORE_CONFIG_BASE_PATH, "utf8"));
+  } catch {
+    console.error(
+      `release-notes-split: missing or unreadable ${STORE_CONFIG_BASE_PATH}. ` +
+        `This file holds the static EAS Metadata (title, privacyPolicyUrl, etc.) ` +
+        `that release notes get merged into.`,
+    );
+    return 1;
+  }
+  const storeConfig = mergeStoreConfig(base, slices.appstore);
   writeFileSync(STORE_CONFIG_PATH, JSON.stringify(storeConfig, null, 2) + "\n");
 
   mkdirSync(ARTIFACTS_DIR, { recursive: true });

--- a/apps/native-rd/scripts/release-notes-split.ts
+++ b/apps/native-rd/scripts/release-notes-split.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+/**
+ * Splits docs/release/testing-notes/<version>.md into the three store-bound
+ * artifacts:
+ *
+ *   1. store.config.json (EAS Metadata) — apple.info.en-US.releaseNotes
+ *      → consumed by `eas metadata:push --profile production` to set the
+ *        App Store "What's New in This Version" field.
+ *
+ *   2. .release-artifacts/play-changelog-en-US.txt — raw text of the play slice
+ *      → consumed by the (future) Play Developer API push, or copied into
+ *        Play Console manually until that automation lands.
+ *
+ *   3. .release-artifacts/what-to-test.txt — raw text of the testflight slice
+ *      → consumed by `eas submit --platform ios --what-to-test "$(cat ...)"`
+ *        or `eas build --auto-submit --what-to-test "$(cat ...)"` to set the
+ *        TestFlight "What to Test" field.
+ *
+ * Refuses to write any artifact if the testing-notes file still contains
+ * TODO markers — that's the same check release-notes:lint enforces. The
+ * intent is that this script is safe to run unattended in CI: either the
+ * notes are fully edited and it produces clean artifacts, or it exits
+ * non-zero and the pipeline halts before anything reaches the stores.
+ *
+ * Version defaults to apps/native-rd/package.json. Override with arg:
+ * `bun run scripts/release-notes-split.ts 0.1.5`.
+ *
+ * Run: bun run release-notes:split
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const APP_ROOT = join(import.meta.dir, "..");
+const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
+const ARTIFACTS_DIR = join(APP_ROOT, ".release-artifacts");
+const STORE_CONFIG_PATH = join(APP_ROOT, "store.config.json");
+const PACKAGE_JSON_PATH = join(APP_ROOT, "package.json");
+
+type SliceName = "play" | "appstore" | "testflight";
+
+const LIMITS: Record<SliceName, number> = {
+  play: 500,
+  appstore: 4000,
+  testflight: 4000,
+};
+
+function resolveVersion(arg: string | undefined): string {
+  if (arg && arg.length > 0) return arg;
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+    version?: string;
+  };
+  if (!pkg.version) throw new Error(`No version in ${PACKAGE_JSON_PATH}`);
+  return pkg.version;
+}
+
+function extractSlice(source: string, slice: SliceName): string {
+  const start = `<!-- ${slice}:start -->`;
+  const end = `<!-- ${slice}:end -->`;
+  const startIdx = source.indexOf(start);
+  const endIdx = source.indexOf(end);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    throw new Error(`Missing ${slice} markers in testing-notes file`);
+  }
+  return source.slice(startIdx + start.length, endIdx).trim();
+}
+
+function validate(slice: SliceName, body: string): void {
+  if (body.length === 0) {
+    throw new Error(`${slice}: empty body between markers`);
+  }
+  if (body.includes("TODO")) {
+    throw new Error(
+      `${slice}: contains TODO — rewrite all TODO lines before splitting`,
+    );
+  }
+  if (body.length > LIMITS[slice]) {
+    throw new Error(
+      `${slice}: ${body.length} chars exceeds store limit of ${LIMITS[slice]}`,
+    );
+  }
+}
+
+function main(): number {
+  const version = resolveVersion(process.argv[2]);
+  const notesPath = join(NOTES_DIR, `${version}.md`);
+
+  let source: string;
+  try {
+    source = readFileSync(notesPath, "utf8");
+  } catch {
+    console.error(
+      `release-notes-split: no testing-notes file at ${notesPath}. ` +
+        `Run \`bun run release-notes:generate ${version}\` first, then edit the TODO lines.`,
+    );
+    return 1;
+  }
+
+  const slices: Record<SliceName, string> = {
+    play: extractSlice(source, "play"),
+    appstore: extractSlice(source, "appstore"),
+    testflight: extractSlice(source, "testflight"),
+  };
+
+  for (const name of ["play", "appstore", "testflight"] as const) {
+    try {
+      validate(name, slices[name]);
+    } catch (err) {
+      console.error(`release-notes-split: ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  const storeConfig = {
+    configVersion: 0,
+    apple: {
+      info: {
+        "en-US": {
+          releaseNotes: slices.appstore,
+        },
+      },
+    },
+  };
+  writeFileSync(STORE_CONFIG_PATH, JSON.stringify(storeConfig, null, 2) + "\n");
+
+  mkdirSync(ARTIFACTS_DIR, { recursive: true });
+  const playPath = join(ARTIFACTS_DIR, "play-changelog-en-US.txt");
+  const testflightPath = join(ARTIFACTS_DIR, "what-to-test.txt");
+  writeFileSync(playPath, slices.play + "\n");
+  writeFileSync(testflightPath, slices.testflight + "\n");
+
+  console.log(
+    `release-notes-split: wrote artifacts for ${version}\n` +
+      `  store.config.json (appstore release notes, ${slices.appstore.length} chars)\n` +
+      `  ${playPath} (play, ${slices.play.length} chars)\n` +
+      `  ${testflightPath} (testflight, ${slices.testflight.length} chars)\n` +
+      `  next:\n` +
+      `    iOS:     eas metadata:push --profile production\n` +
+      `             eas submit --platform ios --profile production --what-to-test "$(cat ${testflightPath})"\n` +
+      `    Android: eas submit --platform android --profile production\n` +
+      `             (then push play changelog via Play Developer API — see docs/release/testing-notes/README.md)`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/apps/native-rd/store.config.base.json
+++ b/apps/native-rd/store.config.base.json
@@ -1,0 +1,11 @@
+{
+  "configVersion": 0,
+  "apple": {
+    "info": {
+      "en-US": {
+        "title": "Rollercoaster.dev",
+        "privacyPolicyUrl": "https://rollercoaster.dev/privacy"
+      }
+    }
+  }
+}

--- a/apps/native-rd/tsconfig.scripts.json
+++ b/apps/native-rd/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

- Adds a structured, length-validated source of truth for the three store-bound release-note fields (Play "What's new" ≤500c, App Store "Release Notes" ≤4000c, TestFlight "What to Test" ≤4000c) under \`apps/native-rd/docs/release/testing-notes/\`
- Adds three Bun scripts that move notes through the pipeline: \`release-notes:generate\` scaffolds from CHANGELOG, \`release-notes:lint\` validates, \`release-notes:split\` emits store-bound artifacts (EAS Metadata \`store.config.json\`, Play changelog \`.txt\`, TestFlight what-to-test \`.txt\`)
- Wires EAS Metadata for iOS: commits \`store.config.base.json\` with the canonical \`title\` + \`privacyPolicyUrl\`, adds \`metadataPath\` to the production iOS submit profile. Verified locally with \`eas metadata:lint --profile production\` → "Store configuration is valid."

## What this unblocks

Once landed, the next release lifecycle is:

\`\`\`sh
bun run release-notes:generate 0.1.5    # scaffold from CHANGELOG
# edit docs/release/testing-notes/0.1.5.md by hand
bun run release-notes:lint              # validate length / markers / TODO
bun run release-notes:split 0.1.5       # emit store-bound files
eas metadata:push --profile production  # → App Store "What's New"
eas submit --platform ios --profile production \\
  --what-to-test \"\$(cat apps/native-rd/.release-artifacts/what-to-test.txt)\"
\`\`\`

Play "What's new" is still a manual paste from the generated \`.txt\` for now — \`eas submit\` has no Android equivalent of \`--what-to-test\`. A follow-up will add a Play Developer API push using the existing service-account credentials.

## Design notes

- **Marker contract over headings.** Each notes file uses HTML comment markers (\`<!-- play:start -->\` etc.) to delimit slices. Headings are documentation; markers are the contract. Survives editor/prettier reformatting that headings don't.
- **The scaffold is intentionally lint-failing.** Generator emits \`TODO: \` bullets for every line; \`release-notes:lint\` fails on the TODO marker, forcing a human to rewrite each bullet as user-facing copy or a QA brief before the file passes. Validation is enforced again in the splitter so CI can't sneak past it.
- **EAS Metadata is iOS-only by design.** Verified against current \`eas-cli\` (18.13.0) docs + \`eas metadata --help\`. The Android path needs custom Play Developer API code (planned as a follow-up); for now the splitter emits a \`.txt\` for manual paste.
- **Shared module.** \`scripts/release-notes-shared.ts\` holds \`SliceName\`, \`SLICES\`, \`LIMITS\`, \`extractSlice\`, \`checkSlice\`, \`resolveVersion\` so the three CLI scripts share one source of truth for the slice contract and length limits.

## Open follow-ups (not in this PR)

- Wire \`release-notes:lint\` into the release-please PR job in CI
- Build the Play Developer API push (uses existing \`secrets/play-service-account.json\` — same scope as \`eas submit\`)
- Privacy policy at \`https://rollercoaster.dev/privacy\` must be live before \`eas metadata:push\` runs in production (pre-existing launch-readiness item, issue #976)

## Test plan

- [x] \`bun run --filter=native-rd type-check\` passes
- [x] \`bun run release-notes:lint\` passes with only template/README present
- [x] \`bun run release-notes:lint\` correctly fails on each violation class (length / missing markers / TODO)
- [x] \`bun run release-notes:generate <version>\` produces a file that fails the lint check (TODOs intentional)
- [x] \`bun run release-notes:split <version>\` writes valid artifacts; \`eas metadata:lint --profile production\` reports "Store configuration is valid"
- [ ] Used in anger on the next real release
- [ ] CI gating added in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)