### PR TITLE
docs(native-rd): first Android build → Play Console plan + store listing drafts

### DIFF
--- a/apps/native-rd/docs/launch/store-listing-copy.md
+++ b/apps/native-rd/docs/launch/store-listing-copy.md
@@ -1,0 +1,229 @@
+# Store Listing & Tester Copy — Drafts
+
+**Date:** 2026-05-15
+**Status:** Drafts for Joe to edit before pasting into App Store Connect / Play Console.
+**Voice source:** `landing/docs/BRAND_LANGUAGE.md` v1.2, `landing/docs/APP_COPY.md` v3.
+
+---
+
+## 1. What to test / release notes (per build)
+
+**Used in:**
+
+- TestFlight → "What to Test" (4000 char limit — plenty of room)
+- Play Console → release notes (500 chars per locale — tighter constraint)
+
+Drafted to fit the 500-char Play Console limit so the same text works on both stores.
+
+```
+First build. Most things work. Some don't yet.
+
+What's here:
+- Set a goal. Break it into steps.
+- Attach evidence — photo, video, voice memo, note, link, or file.
+- Design your own badge when a goal is done.
+- Task view: one next step per goal, always one screen away.
+- 7 themes in light or dark — high-contrast, dyslexia, large text, low-vision, autism-friendly, low-info, standard.
+- Works offline. Nothing leaves your phone.
+
+Tell me what crashes, what feels wrong, and what's missing.
+
+— Joe
+```
+
+**Character count:** ~485 / 500.
+
+---
+
+## 2. App description
+
+### 2a. Short description (Android only, 80 char limit)
+
+```
+A goal tracker for brains like mine. Local-first. No streaks. No nags.
+```
+
+**Character count:** 70 / 80.
+
+### 2b. Apple App Store fields
+
+iOS doesn't have a "short description" — it has:
+
+- **Subtitle** (30 chars max) — appears under the app name in the App Store.
+- **Promotional Text** (170 chars) — editable any time without resubmission.
+
+**Subtitle candidates** (pick one):
+
+| Option                            | Chars         |
+| --------------------------------- | ------------- |
+| `Goals at your own pace.`         | 23            |
+| `Goals, your own pace.`           | 21            |
+| `For brains like mine.`           | 21            |
+| `A tracker for non-linear paths.` | 31 — **OVER** |
+| `Track goals at your own pace.`   | 29            |
+
+Recommend: `Goals at your own pace.` — declarative, matches refusal-of-streaks framing, no marketing punctuation.
+
+**Promotional text draft** (170 chars max):
+
+```
+Local-first goal tracker. No accounts, no streaks, no daily nags. Built by one bipolar + ADHD person for brains that don't move in straight lines.
+```
+
+**Character count:** 148 / 170.
+
+### 2c. Full description (Android full description AND Apple App Store description — both 4000 chars)
+
+```
+Hi. I built this because I needed it.
+
+Other goal apps made me feel worse, not better. They counted streaks I broke. They asked me to "engage daily." They turned my brain's worst weeks into a number that went down.
+
+I'm bipolar and ADHD. My path doesn't go in a straight line. I wanted something that didn't punish me for that.
+
+So I'm making one. Local-first. No account. No streaks. No daily nags. Yours from the moment you open it.
+
+— Joe
+
+
+WHAT IT IS
+
+A goal tracker for brains like mine.
+
+You set a goal — something you're working toward. You break it into steps. You do the work in your own time. The app waits.
+
+To mark a step done, you attach something to it — a photo, video, voice memo, note, link, or file. Whatever shows it actually happened. Choosing what to attach makes you stop and notice the work.
+
+When the steps are done, you make a badge for yourself. Everything you attached is baked in. The badge isn't a sticker. It's a record of the work itself.
+
+
+ONE NEXT STEP. THE SCREEN FOR THIRTY SECONDS.
+
+Most goal apps show you everything at once. For executive dysfunction that's paralysing.
+
+This one inverts it. One screen. One next step per active goal. That's it. The depth is there if you want it — drill into any goal for the full picture.
+
+
+WHAT THIS APP WON'T DO
+
+- No accounts. No signup. No email needed.
+- No streaks. No "you've been away X days" guilt.
+- No daily nags. No notifications you didn't ask for.
+- No ads. No upsells.
+- No data leaves your phone unless you say so.
+- No social feed. No likes. No follower counts.
+
+If you want streaks, gamification, and engagement metrics — this won't be that.
+
+
+WHAT WORKS TODAY
+
+- Set goals. Break them into steps.
+- Six ways to attach evidence — photo, video, voice memo, note, link, file.
+- Task view — one next step per goal.
+- Designed for non-linear paths. Pause for weeks if you need to. Your work is still there.
+- 7 themes in light or dark: standard, high-contrast, dyslexia-friendly, large text, low-vision, autism-friendly, low-info.
+- Badge designer with shape, colour, icon, frame generators, and curved text.
+- Earned-badge view with all your evidence in order.
+- Works fully offline.
+
+
+WHAT YOU OWN
+
+Local-first. Everything stays on your phone. No server copy. No database. Yours.
+
+Badges use the Open Badges open standard. Signed on your phone with a key only your phone has. Even if this project disappears tomorrow, your badges still work.
+
+Export anything. Leave anytime.
+
+The code is on GitHub.
+
+
+EARLY. HONEST.
+
+This is in closed testing. Some pieces aren't built yet. You can still use it.
+
+If you're neurodivergent, or have accessibility needs, or just want something that doesn't punish your worst weeks — you're who I built this for.
+
+— Joe
+```
+
+**Character count:** ~2900 / 4000.
+
+---
+
+## 3. Tester invitation / welcome message
+
+### 3a. Full email version (no length limit)
+
+For DM'ing or emailing prospective testers directly.
+
+```
+Subject: would you test my app?
+
+Hi,
+
+I'm building a goal tracker for neurodivergent brains. It's called rollercoaster.dev. Local-first, no accounts, no streaks, no daily nags. I'm bipolar and ADHD and I built it because the alternatives made me feel worse.
+
+I'm looking for testers for the closed beta. Both iOS (via TestFlight) and Android (via Google Play). Google Play needs 12 people testing for two weeks straight before I can publish, so Android testers especially help me unlock the release.
+
+What testing means: you install it, you use it, you tell me what works and what doesn't. In your own words. On your own schedule. Mostly I want to know — does this feel right for your brain?
+
+If you're in, reply with:
+- Device (iOS or Android)
+- The email you use for the App Store or Play Store
+
+I'll send the invite.
+
+The app is for neurodivergent people and people with accessibility needs. Self-identification only. No diagnosis, no proof, nothing to qualify for.
+
+Two weeks is a real commitment, especially with ADHD or chronic illness. If you fall off, tell me what got in the way. That helps me too.
+
+— Joe
+hello@rollercoaster.dev
+```
+
+### 3b. TestFlight Beta App Description (500 char limit)
+
+Shown to testers when they tap the TestFlight invite link before installing.
+
+```
+A goal tracker for neurodivergent brains. Local-first, no accounts, no streaks, no daily nags. I'm bipolar and ADHD and I built it because the alternatives made me feel worse.
+
+Use it however suits you. Tell me what works, what doesn't, what's missing. Mostly I want to know — does this feel right for your brain?
+
+If you fall off, tell me what got in the way. That helps me too.
+
+— Joe
+```
+
+**Character count:** ~415 / 500.
+
+### 3c. Play Console internal testing tester instructions (no fixed limit, but shorter is better)
+
+Shown in the tester opt-in flow when someone clicks your testing track URL.
+
+```
+Thanks for testing rollercoaster.dev.
+
+You're helping me unlock a Google Play release — 12 people for two weeks. After you install:
+
+1. Open the app.
+2. Use it however suits you.
+3. Email me at hello@rollercoaster.dev with anything you notice — bugs, weirdness, things that feel off, things that work.
+
+Mostly I want to know — does it feel right for your brain?
+
+— Joe
+```
+
+---
+
+## Notes for editing
+
+- Lowercase moments are intentional (parentheticals, subject line). Don't auto-capitalise.
+- No exclamation points anywhere except real in-app strings like `"One last thing!"` if you use them.
+- Em-dashes (`—`) are deliberate. Keep them, don't substitute with hyphens.
+- Replace `hello@rollercoaster.dev` if you want to use a different inbox.
+- The GitHub line in the full description is intentionally one parenthetical-style mention, not a flag-wave. Keep it understated.
+- If you want to swap the bipolar+ADHD line for something less personally-identifying in the public store description, the alternative voice move is to keep it identity-first but third-person: `The maker is bipolar and ADHD.` — slightly more arms-length but still named-maker. The first-person version is stronger.

--- a/apps/native-rd/docs/plans/2026-05-15-first-android-build-play-console.md
+++ b/apps/native-rd/docs/plans/2026-05-15-first-android-build-play-console.md
@@ -1,0 +1,154 @@
+# First Android Build → Play Console (Manual First Upload)
+
+**Date:** 2026-05-15
+**Branch:** `adding-first-android-build-to-play-console`
+**Status:** Pre-flight checklist — execution gated on Play Console account verification
+
+## Context
+
+This branch is the container for cutting the first Android AAB and walking it through the Play Console manually. The very first upload for a brand-new app must be done through the Play Console UI so Play App Signing can be opted into; after that, `eas submit` can take over via the service account.
+
+The EAS pipeline, Android build profile, and submit profile are all already configured in `apps/native-rd/eas.json` and `apps/native-rd/app.json`. The preview APK route is `[VERIFIED 2026-05-07]` per the `native-rd-build` skill. The production AAB path is still `[UNTESTED]`.
+
+**Known gap (confirmed with Joe):** `SENTRY_AUTH_TOKEN` is missing from EAS env. Without it, sourcemap upload during a production build is skipped silently — every store-released crash would arrive in Sentry as obfuscated minified frames. Sentry-blind production is the failure mode this plan blocks first.
+
+## Critical files
+
+| File                                                        | Role                                                                                                                                                                                           |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/native-rd/eas.json`                                   | EAS build/submit profiles. `appVersionSource: "remote"`, `production.autoIncrement: true`, `submit.production.android.track: "internal"`.                                                      |
+| `apps/native-rd/app.json`                                   | Expo config. `android.package: "dev.rollercoaster.app"`, permissions: `RECORD_AUDIO`, `MODIFY_AUDIO_SETTINGS`, `CAMERA`. Sentry plugin wired with org `rollercoasterdev`, project `native-rd`. |
+| `apps/native-rd/.gitignore`                                 | Line 41 ignores `play-service-account.json`. Also ignores `*.jks`, `*.keystore`, `*.p8/.p12/.key/.pem`. Verified 2026-05-15.                                                                   |
+| `apps/native-rd/.claude/skills/native-rd-build/SKILL.md`    | Build matrix + gotchas. Promote status tags after Android production AAB succeeds.                                                                                                             |
+| `apps/native-rd/docs/launch/app-store-launch-plan.md`       | Phase 7 (Android) — current source of truth for Play Console rollout.                                                                                                                          |
+| `apps/native-rd/docs/plans/2026-05-02-user-testing-prep.md` | Closed testing tracker (12 testers × 14 days).                                                                                                                                                 |
+
+## Pre-flight checklist (must be done before `eas build -p android --profile production`)
+
+### 1. `SENTRY_AUTH_TOKEN` as EAS env secret — THE missing item
+
+The `@sentry/react-native/expo` plugin runs a postbuild sourcemap upload step via `sentry-cli`. EAS only injects env vars it knows about.
+
+**Use an Organization Auth Token, not a personal User Auth Token.** Org tokens are scoped to the organization (not your personal account), survive personnel changes, and have a purpose-built scope for this exact use case.
+
+- Create at: https://sentry.io/orgredirect/organizations/rollercoasterdev/settings/auth-tokens/
+- Single scope required: **`org:ci`** — "CI/deployment workflows including source maps, releases, code mappings"
+- (Legacy fallback if you create a User Auth Token instead: `project:releases` + `org:read`. Not recommended for CI.)
+
+Store it via the EAS env system. **All `eas` commands must run from `apps/native-rd/`** — that's where `eas.json` and the EAS project link live. Running from the worktree root gives `EAS project not configured`.
+
+Note: `eas secret:*` is deprecated in EAS CLI ≥16. Use `eas env:*` instead. The `production` environment matches the `production` build profile.
+
+Run it interactively — the CLI walks you through every choice (environment, name, value, type, visibility) and you can't mis-flag it:
+
+```bash
+cd apps/native-rd
+eas env:create
+# Answer prompts:
+#   Environment:  production    (also add to preview if you want debug symbolication)
+#   Name:         SENTRY_AUTH_TOKEN
+#   Value:        <paste org auth token>
+#   Type:         string
+#   Visibility:   secret        (hidden everywhere, can't be read back after creation)
+
+eas env:list --environment production   # verify SENTRY_AUTH_TOKEN appears, value masked as ***
+```
+
+**Important caveat for autonomous agents:** `eas env:create` is interactive and will hang in a non-TTY shell. Joe runs this himself; an agent invoking it via Bash will deadlock per the `apps/native-rd/CLAUDE.md` "never run interactive CLI commands" rule.
+
+If you want the token available to `preview` builds too (so debug crashes also symbolicate), repeat with `--environment preview`.
+
+**Verification:** after the next production build, the build log should contain a `Sentry: Uploading source maps` line and the Sentry release page should show artifacts. No token → log says "skipping" and Sentry releases stay empty.
+
+### 2. Privacy Policy URL
+
+Google Play blocks publishing for any app declaring sensitive permissions (this app declares all three: camera, mic, audio settings) without a publicly hosted privacy policy URL. The URL goes into the Play Console listing — it does not have to live in `app.json`. Action: host the policy (GitHub Pages on `rollercoaster.dev` is fine) and have the URL ready before opening the Play Console store listing form. Reusable for the iOS App Store listing too.
+
+### 3. `versionCode` baseline
+
+`eas.json` uses `appVersionSource: "remote"`. EAS owns the canonical `versionCode` and bumps it because `production.autoIncrement: true`. For the first build there is no remote value yet, so EAS defaults to `1`. If you've ever run a preview that pushed a remote value, run `eas build:version:get -p android` (from `apps/native-rd/`) to confirm what EAS will use. No code change required — just verify.
+
+### 4. Store listing assets (gates submission, not the build itself)
+
+Required by Play Console at upload time, not by Gradle:
+
+- App icon (already at `apps/native-rd/assets/icon.png`)
+- Feature graphic — 1024×500 PNG, no transparency
+- 2–8 phone screenshots (16:9 or 9:16, min 320px short side)
+- Short description (≤80 chars)
+- Full description (≤4000 chars)
+- App category, content rating questionnaire, target audience declaration
+- Data safety form (declare RECORD_AUDIO, CAMERA, microphone/photo collection if data leaves device)
+
+Stage these in `apps/native-rd/docs/launch/` as text + image files before opening Play Console so the form-filling pass is mechanical.
+
+### 5. `play-service-account.json` (known blocker, tracked)
+
+Not required for the **first** upload because that one is manual. It IS required before the second build can be promoted via `eas submit -p android --profile production`. Generate from Play Console → Setup → API Access → Create Service Account → grant "Release manager" role → download JSON → drop at `apps/native-rd/play-service-account.json` (already gitignored — confirmed 2026-05-15 via `git check-ignore -v`).
+
+## Build procedure (first AAB)
+
+```bash
+cd apps/native-rd   # REQUIRED — eas needs to see eas.json here
+
+# 1. Confirm env var exists in the production environment
+eas env:list --environment production | grep SENTRY_AUTH_TOKEN
+
+# 2. Sanity-check the production profile would resolve correctly
+eas build:inspect -p android --profile production --stage pre-install
+
+# 3. Trigger the production build (cloud, ~20-30 min)
+eas build -p android --profile production
+
+# 4. When build finishes, download the .aab from the EAS dashboard
+#    (URL is printed in the build summary)
+```
+
+Promote the `native-rd-build` skill entry for "Android production AAB" from `[UNTESTED]` to `[VERIFIED <date>]` after this succeeds.
+
+## Manual upload procedure (Play Console UI — first AAB only)
+
+1. Play Console → Create app → enter name, default language, app/game, free/paid, declarations.
+2. Set up → App content:
+   - Privacy policy (paste URL from pre-flight #2)
+   - Ads, App access, Content rating, Target audience, News app, Data safety, Government apps, Financial features
+3. Grow → Store listing: name, short description, full description, graphics (icon, feature graphic, screenshots).
+4. Release → Testing → **Internal testing** → Create new release.
+5. App integrity → opt into **Play App Signing** (Google generates and holds the app signing key; the AAB you upload is signed with the EAS-generated upload key — that's the correct flow).
+6. Upload the `.aab` downloaded from EAS.
+7. Add internal testers list (your own Google account at minimum).
+8. Save → Review release → Start rollout to Internal testing.
+9. Accept the tester invite link in a browser logged into a tester Google account, then install via Play Store on a real device.
+
+## Post-first-upload (closed testing requirement)
+
+For personal Google Play developer accounts created after Nov 2023, Google requires:
+
+- **Closed testing track** (not internal)
+- **≥12 testers opted in**
+- **≥14 continuous days** of testing
+- Then "Apply for production access" form
+
+Plan: after the manual internal-track upload succeeds, create a **Closed testing** track, recruit 12 testers, start the 14-day clock. This is already tracked in `docs/plans/2026-05-02-user-testing-prep.md` — no plan change here, just don't try to skip to production.
+
+After production access is granted, change `submit.production.android.track` in `eas.json` from `"internal"` to `"production"` (or add a separate `production-public` submit profile and keep `internal` for staging).
+
+## Verification
+
+End-to-end signals that this plan succeeded:
+
+| Check                      | How                                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sourcemaps uploaded        | Sentry → Releases → most recent release has artifacts                                                                                                |
+| AAB signed correctly       | Play Console "App integrity" shows both upload key fingerprint AND app signing key fingerprint after first upload                                    |
+| Permissions match manifest | Play Console "App content" → Permissions matches the three in `app.json`                                                                             |
+| Tester install works       | Install via Play Store internal track link on a real Android device, launch the app, record voice memo, take photo (exercises all three permissions) |
+| Crash symbolicates         | Force a JS crash in the installed build (e.g. dev menu shake → throw), confirm Sentry shows readable component stack                                 |
+| Build skill updated        | `apps/native-rd/.claude/skills/native-rd-build/SKILL.md` promotes `[UNTESTED]` → `[VERIFIED <date>]` for the Android production AAB row              |
+
+## Out of scope
+
+- Wiring CI to auto-submit (`ci-release.yml` already exists; first build is intentionally manual)
+- iOS App Store submission (separate `appleId`/`ascAppId` already configured)
+- OTA updates / `expo-updates` runtimeVersion policy
+- Promoting closed testing → production (gated on the 14-day clock)


### PR DESCRIPTION
## Summary

- Adds the pre-flight plan for cutting the first production Android AAB and walking it through Play Console manually (required for the initial Play App Signing opt-in before `eas submit` can take over).
- Adds store listing + tester copy drafts (release notes, short/full description, tester onboarding) sized to the Play Console 500-char and 80-char limits so the same text works across stores.
- Docs-only — no code, no CI surface changes.

## Files

- `apps/native-rd/docs/plans/2026-05-15-first-android-build-play-console.md` — pre-flight checklist; gates production build on `SENTRY_AUTH_TOKEN` being added as an EAS env secret (`org:ci` scope) so sourcemaps actually upload and store-released crashes don't arrive as minified frames.
- `apps/native-rd/docs/launch/store-listing-copy.md` — drafts for "what to test" release notes, short + full descriptions, and tester-facing copy. Voice sourced from `landing/docs/BRAND_LANGUAGE.md` v1.2 and `landing/docs/APP_COPY.md` v3.

## Test plan

- [ ] Skim both docs render correctly on GitHub (tables, code blocks, char counts visible).
- [ ] Confirm the plan's referenced paths still exist (`eas.json`, `app.json`, `native-rd-build` skill, `app-store-launch-plan.md`).
- [ ] No follow-up code changes required from this PR; execution of the plan happens separately once Play Console verification clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)