### PR TITLE
ci: make production build & submit manual-only

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -1,13 +1,9 @@
 name: build-production
 
-# Manual / click only:
-# - "release: published" fires when a GitHub Release is published from the
-#   Releases page (release-please does this automatically when its PR merges,
-#   or a human can click "Publish release" in the UI).
-# - "workflow_dispatch" lets us re-run a release against a specific tag/SHA.
+# Manual only. Production builds + store submits must be human-triggered:
+# click "Run workflow" from the Actions UI (or `gh workflow run`) and supply
+# a tag/SHA via the `ref` input.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,21 +8,12 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-
-      - name: Dispatch production build
-        if: ${{ steps.release.outputs['apps/native-rd--release_created'] == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs['apps/native-rd--tag_name'] }}
-        run: gh workflow run build-production.yml -f ref="$TAG" -f platform=all


### PR DESCRIPTION
## Summary
Production builds run `eas submit --profile production` to TestFlight and Play Store with no `if:` gate, so they must be human-triggered, not auto-fired off a release tag. This PR removes both auto-trigger paths and keeps `workflow_dispatch` as the only entrypoint.

## Changes
- **`.github/workflows/release-please.yml`** — removed the `Dispatch production build` step (and the now-unused `actions: write` permission + step `id`). release-please now just tags the release and stops.
- **`.github/workflows/build-production.yml`** — dropped `on: release: types: [published]`. Only `workflow_dispatch` remains.

## Context
Two auto-trigger paths existed, both currently broken:
- `release-please.yml` dispatched via `gh workflow run`, but the action step has no checkout, so `gh` couldn't infer the repo (failed for v0.1.5, [run 26038969745](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/26038969745)).
- `build-production.yml` listened on `release: published`, but that event doesn't fire from releases created by `GITHUB_TOKEN` — which is precisely why the explicit dispatch was added on top.

The system was fail-closed by accident; this PR makes manual-only the intent in code. `build-internal` and `build-play-internal` were already manual-only and are unaffected.

## Test plan
- [ ] On next `chore(main): release` merge: `release-please` job tags the release, `build-production` does **not** appear in the run list.
- [ ] `gh workflow run build-production.yml -f ref=v0.1.x -f platform=ios` still works from a local checkout (manual path intact).
- [ ] (Separate, not part of this PR) decide whether to manually dispatch `build-production` for `v0.1.5` to recover today's missed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)