### PR TITLE
ci(release): wire push-button release via draft-release model

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,6 +5,7 @@
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "draft": true,
   "packages": {
     "apps/native-rd": {
       "package-name": "native-rd",

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -1,9 +1,15 @@
 name: build-production
 
-# Manual only. Production builds + store submits must be human-triggered:
-# click "Run workflow" from the Actions UI (or `gh workflow run`) and supply
-# a tag/SHA via the `ref` input.
+# Two triggers — both human-gated:
+#  - `release: published` — release-please creates GitHub Releases as drafts
+#    (see .github/release-please-config.json: "draft": true). The "ship button"
+#    is clicking **Publish release** on the draft in the Releases UI. That click
+#    is the moment you decide to ship; this workflow does the rest.
+#  - `workflow_dispatch` — escape hatch for rebuilding a past tag or shipping
+#    from a non-release ref. Supply `ref` via the Actions UI or `gh workflow run`.
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary

Two surgical edits give us a real "ship button" without auto-shipping every release-please release:

- **`.github/release-please-config.json`** — add `"draft": true`. release-please continues to open release-PRs and tag versions, but the GitHub Release lands as a **draft** instead of going live immediately.
- **`.github/workflows/build-production.yml`** — add `release: published` trigger. Clicking **Publish release** on a draft fires `_release-validate` → EAS build (iOS + Android) → store submit → Sentry finalize. `workflow_dispatch` stays as the escape hatch for rebuilding past tags.

## Why

release-please opens release-PRs more often than we actually want to ship to App Store / Play. The previous state had no automated link between "release-please made a release" and "build runs" — `build-production.yml` was `workflow_dispatch`-only, so the "release button" effectively didn't exist. This wires a semantic button: the **Publish release** click on a draft is the moment we decide to ship.

## Resulting flow

1. Push to `main` → release-please updates its release-PR (unchanged).
2. Merge release-PR → release-please tags `vX.Y.Z`, creates GitHub Release **as draft**, nothing builds.
3. Drafts accumulate on `/releases` as a visible queue of unshipped versions.
4. When ready to ship → open the draft → **Publish release** → `release: published` fires → build + submit.

## Coordinated with #117

PR #117 (`chore(main): release 0.1.7`) is open. Merging it **after** this PR lands means 0.1.7 will be created as a draft and won't ship until we click Publish. That's the intended ordering.

## Test plan

- [ ] Merge this PR.
- [ ] Verify release-please-action re-runs on push to main and updates PR #117 without error.
- [ ] Merge PR #117 and confirm the resulting GitHub Release appears as **Draft** on `/releases`.
- [ ] Confirm `build-production.yml` does **not** auto-run on draft creation.
- [ ] Click **Publish release** on the 0.1.7 draft and confirm `build-production` fires from the `release` event.
- [ ] Confirm `workflow_dispatch` still works as an escape hatch (no need to actually run a build — just check the workflow page still shows the Run workflow button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)