### PR TITLE
feat(claude): port graph-flow auto-issue skill set + caveman compression

### DIFF
--- a/.agents/skills/auto-issue/SKILL.md
+++ b/.agents/skills/auto-issue/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: auto-issue
+description: Fully autonomous issue-to-PR workflow for Rollercoaster.dev-mobile. Use when a worker should execute one issue end-to-end without human gates.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Task
+---
+
+# Auto-Issue Skill
+
+Runs a single issue from setup to PR creation.
+
+## Contract
+
+### Input
+
+| Field          | Type    | Required | Description                                   |
+| -------------- | ------- | -------- | --------------------------------------------- |
+| `issue_number` | number  | Yes      | GitHub issue number                           |
+| `dry_run`      | boolean | No       | Stop after research and output the plan       |
+| `skip_review`  | boolean | No       | Skip review phase and continue to finalize    |
+| `force_pr`     | boolean | No       | Allow PR creation even with unresolved issues |
+
+### Output
+
+| Field          | Type   | Description                      |
+| -------------- | ------ | -------------------------------- |
+| `issue_number` | number | Processed issue                  |
+| `branch`       | string | Branch used for implementation   |
+| `plan_path`    | string | Development plan path            |
+| `pr_number`    | number | PR number (if created)           |
+| `pr_url`       | string | PR URL (if created)              |
+| `status`       | string | `dry_run`, `completed`, `failed` |
+
+## Workflow
+
+### Phase 1: Setup
+
+Run:
+
+```text
+Skill(setup, args: { issue_number: <N> })
+```
+
+Capture `branch` and issue metadata from output.
+
+### Phase 2: Research
+
+Run issue analysis with the `issue-researcher` agent using the `Agent` tool — standalone (no `team_name`) with `run_in_background: true`. The researcher writes the dev plan to `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`.
+
+Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow.
+
+If `dry_run=true`, return the plan path and stop.
+
+### Phase 3: Implement
+
+Run:
+
+```text
+Skill(implement, args: { issue_number: <N>, plan_path: "<path>" })
+```
+
+Implementation must be incremental and committed in logical chunks.
+
+### Phase 4: Review
+
+If `skip_review=true`, skip this phase.
+
+Otherwise run:
+
+```text
+Skill(review, args: { workflow_id: "issue-<N>" })
+```
+
+The review skill includes a `/simplify` pass (Step 1.5) before spawning review agents, improving code quality before the detailed review.
+
+If unresolved critical findings remain and `force_pr` is false, stop with `failed` status.
+
+### Phase 5: Finalize
+
+Run:
+
+```text
+Skill(finalize, args: { issue_number: <N>, plan_path: "<path>", force: <force_pr> })
+```
+
+Return PR details and `completed` status.
+
+## Error Handling
+
+| Condition                                    | Behavior                            |
+| -------------------------------------------- | ----------------------------------- |
+| Setup fails                                  | Stop immediately and return failure |
+| Research fails                               | Stop and report blocker             |
+| Implement fails                              | Stop and report failing step        |
+| Review unresolved criticals + force_pr=false | Stop and escalate                   |
+| Finalize fails                               | Stop and report push/PR failure     |
+
+## Compatibility Notes
+
+- This skill exists to support worker prompts that call `Skill(auto-issue, args: "<issue>")`.
+- The canonical workflow definition is the `/auto-issue` slash command at `.claude/commands/auto-issue.md`.
+- DCO is mandatory in this repo — every commit needs a `Signed-off-by` trailer. The husky `prepare-commit-msg` hook adds it automatically. Skills must NEVER pass `--no-verify` to git commit.

--- a/.agents/skills/auto-issue/SKILL.md
+++ b/.agents/skills/auto-issue/SKILL.md
@@ -6,26 +6,26 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Task
 
 # Auto-Issue Skill
 
-Runs a single issue from setup to PR creation.
+Run one issue from setup to PR.
 
 ## Contract
 
 ### Input
 
-| Field          | Type    | Required | Description                                   |
-| -------------- | ------- | -------- | --------------------------------------------- |
-| `issue_number` | number  | Yes      | GitHub issue number                           |
-| `dry_run`      | boolean | No       | Stop after research and output the plan       |
-| `skip_review`  | boolean | No       | Skip review phase and continue to finalize    |
-| `force_pr`     | boolean | No       | Allow PR creation even with unresolved issues |
+| Field          | Type    | Required | Description                       |
+| -------------- | ------- | -------- | --------------------------------- |
+| `issue_number` | number  | Yes      | GitHub issue number               |
+| `dry_run`      | boolean | No       | Stop after research, output plan  |
+| `skip_review`  | boolean | No       | Skip review, continue to finalize |
+| `force_pr`     | boolean | No       | Allow PR with unresolved issues   |
 
 ### Output
 
 | Field          | Type   | Description                      |
 | -------------- | ------ | -------------------------------- |
 | `issue_number` | number | Processed issue                  |
-| `branch`       | string | Branch used for implementation   |
-| `plan_path`    | string | Development plan path            |
+| `branch`       | string | Implementation branch            |
+| `plan_path`    | string | Dev plan path                    |
 | `pr_number`    | number | PR number (if created)           |
 | `pr_url`       | string | PR URL (if created)              |
 | `status`       | string | `dry_run`, `completed`, `failed` |
@@ -34,68 +34,60 @@ Runs a single issue from setup to PR creation.
 
 ### Phase 1: Setup
 
-Run:
-
 ```text
 Skill(setup, args: { issue_number: <N> })
 ```
 
-Capture `branch` and issue metadata from output.
+Capture `branch` and issue metadata.
 
 ### Phase 2: Research
 
-Run issue analysis with the `issue-researcher` agent using the `Agent` tool — standalone (no `team_name`) with `run_in_background: true`. The researcher writes the dev plan to `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`.
+Run `issue-researcher` via Agent tool — standalone (no `team_name`), `run_in_background: true`. Writes plan to `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`.
 
-Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow.
+Capture `plan_path`, pass through rest of workflow.
 
-If `dry_run=true`, return the plan path and stop.
+If `dry_run=true`: return plan path, stop.
 
 ### Phase 3: Implement
-
-Run:
 
 ```text
 Skill(implement, args: { issue_number: <N>, plan_path: "<path>" })
 ```
 
-Implementation must be incremental and committed in logical chunks.
+Incremental, atomic commits.
 
 ### Phase 4: Review
 
-If `skip_review=true`, skip this phase.
-
-Otherwise run:
+`skip_review=true` → skip.
 
 ```text
 Skill(review, args: { workflow_id: "issue-<N>" })
 ```
 
-The review skill includes a `/simplify` pass (Step 1.5) before spawning review agents, improving code quality before the detailed review.
+Includes `/simplify` pass (Step 1.5) before review agents.
 
-If unresolved critical findings remain and `force_pr` is false, stop with `failed` status.
+Unresolved criticals + `force_pr=false` → stop, `failed` status.
 
 ### Phase 5: Finalize
-
-Run:
 
 ```text
 Skill(finalize, args: { issue_number: <N>, plan_path: "<path>", force: <force_pr> })
 ```
 
-Return PR details and `completed` status.
+Return PR details, `completed` status.
 
 ## Error Handling
 
-| Condition                                    | Behavior                            |
-| -------------------------------------------- | ----------------------------------- |
-| Setup fails                                  | Stop immediately and return failure |
-| Research fails                               | Stop and report blocker             |
-| Implement fails                              | Stop and report failing step        |
-| Review unresolved criticals + force_pr=false | Stop and escalate                   |
-| Finalize fails                               | Stop and report push/PR failure     |
+| Condition                                    | Behavior                     |
+| -------------------------------------------- | ---------------------------- |
+| Setup fails                                  | Stop, return failure         |
+| Research fails                               | Stop, report blocker         |
+| Implement fails                              | Stop, report failing step    |
+| Review unresolved criticals + force_pr=false | Stop, escalate               |
+| Finalize fails                               | Stop, report push/PR failure |
 
 ## Compatibility Notes
 
-- This skill exists to support worker prompts that call `Skill(auto-issue, args: "<issue>")`.
-- The canonical workflow definition is the `/auto-issue` slash command at `.claude/commands/auto-issue.md`.
-- DCO is mandatory in this repo — every commit needs a `Signed-off-by` trailer. The husky `prepare-commit-msg` hook adds it automatically. Skills must NEVER pass `--no-verify` to git commit.
+- Supports worker prompts calling `Skill(auto-issue, args: "<issue>")`.
+- Canonical workflow lives at `.claude/commands/auto-issue.md`.
+- DCO mandatory — husky `prepare-commit-msg` adds `Signed-off-by` trailer. Never pass `--no-verify` to git commit.

--- a/.agents/skills/finalize/SKILL.md
+++ b/.agents/skills/finalize/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Read, Skill
 
 # Finalize Skill
 
-Completes the workflow by creating PR and notifying.
+Push, create PR, notify.
 
 ## Contract
 
@@ -17,8 +17,8 @@ Completes the workflow by creating PR and notifying.
 | `issue_number`     | number  | Yes      | GitHub issue number                                                                                           |
 | `plan_path`        | string  | No       | Exact dev plan path to read for Intent Verification, Decisions, and Discovery Log extraction into the PR body |
 | `findings_summary` | object  | No       | Summary from review phase                                                                                     |
-| `force`            | boolean | No       | Create PR even with unresolved issues (default: false)                                                        |
-| `skip_notify`      | boolean | No       | Skip Telegram notification (default: false)                                                                   |
+| `force`            | boolean | No       | Create PR even with unresolved issues (default false)                                                         |
+| `skip_notify`      | boolean | No       | Skip Telegram notification (default false)                                                                    |
 
 ### Output
 
@@ -31,33 +31,33 @@ Completes the workflow by creating PR and notifying.
 
 ### Side Effects
 
-1. Pushes branch to remote
-2. Creates GitHub PR
-3. Sends Telegram notification with PR link
+1. Push branch to remote
+2. Create GitHub PR
+3. Send Telegram notification with PR link
 
 ## Workflow
 
 ### Step 1: Gather Context
 
-**Get issue title for PR:**
+**Issue title for PR:**
 
 ```bash
 gh issue view <issue_number> --json title -q .title
 ```
 
-**Get commit history:**
+**Commit history:**
 
 ```bash
 git log main..HEAD --oneline
 ```
 
-**Get diff stats:**
+**Diff stats:**
 
 ```bash
 git diff main --stat
 ```
 
-**Get branch name:**
+**Branch name:**
 
 ```bash
 git branch --show-current
@@ -65,7 +65,7 @@ git branch --show-current
 
 ### Step 2: Run Final Validation
 
-Run validation commands (each separately):
+Each separately:
 
 ```bash
 bun run type-check
@@ -83,11 +83,11 @@ bun test
 bun run build
 ```
 
-**Note:** `bun run build` is safe in this repo — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). If this changes in the future, drop the build step rather than running a native compile.
+**Note:** `bun run build` safe — native-rd's `build` is `echo 'Expo app — no build step'`. If this changes, drop build step rather than running native compile.
 
-**If any validation fails and `force` is false:** Return error with failure details.
+**Validation fails + `force=false`:** Return error with details.
 
-**If validation fails but `force` is true:** Note in PR body, continue.
+**Validation fails + `force=true`:** Note in PR body, continue.
 
 ### Step 3: Push Branch
 
@@ -95,30 +95,28 @@ bun run build
 git push -u origin HEAD
 ```
 
-**If push fails:** Return error (critical).
+Push fail → return error (critical).
 
 ### Step 4: Read Dev Plan (if `plan_path` provided)
 
-Before creating the PR, extract structured sections from the dev plan to enrich the PR body.
+Extract structured sections for PR body. Read file, extract:
 
-If `plan_path` is provided, read the file. Extract:
+1. **Intent Verification** — every checkbox line (`- [ ]` or `- [x]`) between `## Intent Verification` heading and next `##`. Preserve check status verbatim.
+2. **Key Decisions** — markdown table under `## Decisions` (or `## Key Decisions`). Skip header/separator rows; re-emit as two-column `| Decision | Rationale |` in PR body. Empty/absent → omit section.
+3. **Discovery Log** — timestamped entries `- [YYYY-MM-DD HH:MM] <text>` under `## Discovery Log` (may be wrapped in `<!-- … -->`; strip delimiters before parsing). No entries → omit section.
 
-1. **Intent Verification** — every checkbox line (`- [ ]` or `- [x]`) between the `## Intent Verification` heading and the next `##` heading. Preserve check status verbatim.
-2. **Key Decisions** — the markdown table under `## Decisions` (or `## Key Decisions`). Skip the header and separator rows; re-emit as a two-column `| Decision | Rationale |` table in the PR body. If the table is empty or absent, omit the section.
-3. **Discovery Log** — timestamped entries of the form `- [YYYY-MM-DD HH:MM] <text>` under the `## Discovery Log` heading (entries may be wrapped in `<!-- … -->`; strip the delimiters before parsing). If no entries exist, omit the section.
-
-If no plan file exists, omit the Intent Verification, Key Decisions, and Discovery Log sections from the PR body.
+No plan file → omit Intent Verification, Key Decisions, Discovery Log sections.
 
 ### Step 5: Create PR
 
-Determine PR type from branch name or commits:
+PR type from branch/commits:
 
 - `feat/` → "feat"
 - `fix/` → "fix"
 - `refactor/` → "refactor"
 - etc.
 
-Determine scope from primary package affected (e.g., `native-rd`, `openbadges-core`, `design-tokens`, `ci`).
+Scope from primary package affected (`native-rd`, `openbadges-core`, `design-tokens`, `ci`).
 
 **Create PR:**
 
@@ -174,11 +172,11 @@ PRBODY
 
 Extract PR number and URL from output.
 
-**DCO:** All commits on the branch should already carry `Signed-off-by` trailers from the husky `prepare-commit-msg` hook. The DCO workflow check on GitHub will verify each commit. If any commit is missing the trailer, the PR will fail the DCO check — fix locally with new commits (do **not** force-push amended history that strips trailers).
+**DCO:** All branch commits should carry `Signed-off-by` from husky `prepare-commit-msg`. DCO workflow on GitHub verifies each commit. Missing trailer → PR fails DCO check. Fix locally with new commits (do **not** force-push amended history that strips trailers).
 
 ### Step 6: Send Notification (unless skip_notify)
 
-Use the `telegram` skill (via Skill tool) to send a notification:
+Via `telegram` skill:
 
 ```
 PR Created: #<pr_number>
@@ -188,7 +186,7 @@ Commits: <count>
 Status: Awaiting review
 ```
 
-**If notification fails:** Log warning, continue.
+Notification fail → warn, continue.
 
 ### Step 7: Return Output
 
@@ -237,8 +235,6 @@ Status: Awaiting review
 ```
 
 ## Output Format
-
-After completing all steps, report:
 
 ```
 FINALIZE COMPLETE

--- a/.agents/skills/finalize/SKILL.md
+++ b/.agents/skills/finalize/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: finalize
+description: Completes issue workflow - pushes branch, creates PR, sends notification. Use at the end of any issue workflow in Rollercoaster.dev-mobile.
+allowed-tools: Bash, Read, Skill
+---
+
+# Finalize Skill
+
+Completes the workflow by creating PR and notifying.
+
+## Contract
+
+### Input
+
+| Field              | Type    | Required | Description                                                                                                   |
+| ------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `issue_number`     | number  | Yes      | GitHub issue number                                                                                           |
+| `plan_path`        | string  | No       | Exact dev plan path to read for Intent Verification, Decisions, and Discovery Log extraction into the PR body |
+| `findings_summary` | object  | No       | Summary from review phase                                                                                     |
+| `force`            | boolean | No       | Create PR even with unresolved issues (default: false)                                                        |
+| `skip_notify`      | boolean | No       | Skip Telegram notification (default: false)                                                                   |
+
+### Output
+
+| Field             | Type   | Description                            |
+| ----------------- | ------ | -------------------------------------- |
+| `pr.number`       | number | PR number                              |
+| `pr.url`          | string | PR URL                                 |
+| `pr.title`        | string | PR title                               |
+| `workflow_status` | string | "completed" or "completed_with_issues" |
+
+### Side Effects
+
+1. Pushes branch to remote
+2. Creates GitHub PR
+3. Sends Telegram notification with PR link
+
+## Workflow
+
+### Step 1: Gather Context
+
+**Get issue title for PR:**
+
+```bash
+gh issue view <issue_number> --json title -q .title
+```
+
+**Get commit history:**
+
+```bash
+git log main..HEAD --oneline
+```
+
+**Get diff stats:**
+
+```bash
+git diff main --stat
+```
+
+**Get branch name:**
+
+```bash
+git branch --show-current
+```
+
+### Step 2: Run Final Validation
+
+Run validation commands (each separately):
+
+```bash
+bun run type-check
+```
+
+```bash
+bun run lint
+```
+
+```bash
+bun test
+```
+
+```bash
+bun run build
+```
+
+**Note:** `bun run build` is safe in this repo — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). If this changes in the future, drop the build step rather than running a native compile.
+
+**If any validation fails and `force` is false:** Return error with failure details.
+
+**If validation fails but `force` is true:** Note in PR body, continue.
+
+### Step 3: Push Branch
+
+```bash
+git push -u origin HEAD
+```
+
+**If push fails:** Return error (critical).
+
+### Step 4: Read Dev Plan (if `plan_path` provided)
+
+Before creating the PR, extract structured sections from the dev plan to enrich the PR body.
+
+If `plan_path` is provided, read the file. Extract:
+
+1. **Intent Verification** — every checkbox line (`- [ ]` or `- [x]`) between the `## Intent Verification` heading and the next `##` heading. Preserve check status verbatim.
+2. **Key Decisions** — the markdown table under `## Decisions` (or `## Key Decisions`). Skip the header and separator rows; re-emit as a two-column `| Decision | Rationale |` table in the PR body. If the table is empty or absent, omit the section.
+3. **Discovery Log** — timestamped entries of the form `- [YYYY-MM-DD HH:MM] <text>` under the `## Discovery Log` heading (entries may be wrapped in `<!-- … -->`; strip the delimiters before parsing). If no entries exist, omit the section.
+
+If no plan file exists, omit the Intent Verification, Key Decisions, and Discovery Log sections from the PR body.
+
+### Step 5: Create PR
+
+Determine PR type from branch name or commits:
+
+- `feat/` → "feat"
+- `fix/` → "fix"
+- `refactor/` → "refactor"
+- etc.
+
+Determine scope from primary package affected (e.g., `native-rd`, `openbadges-core`, `design-tokens`, `ci`).
+
+**Create PR:**
+
+```bash
+gh pr create --title "<type>(<scope>): <description> (#<issue_number>)" --body "$(cat <<'PRBODY'
+## Summary
+
+<1-3 bullet points from issue/commits>
+
+## Changes
+
+<bullet list of key changes>
+
+## Intent Verification
+
+<Copy from dev plan with check status. If no plan exists, omit this section.>
+
+- [x] <met criterion>
+- [x] <met criterion>
+- [ ] <unmet criterion, if any — explain why>
+
+## Key Decisions
+
+<Summarize from Decisions table. If no plan or no decisions, omit this section.>
+
+| Decision | Rationale |
+|----------|-----------|
+| <what> | <why> |
+
+## Discovery Log
+
+<Copy entries verbatim from dev plan. Omit section if no entries.>
+
+- [YYYY-MM-DD HH:MM] <entry>
+
+## Test Plan
+
+- [ ] Type-check passes
+- [ ] Lint passes
+- [ ] Tests pass
+- [ ] Build script (no-op for native-rd) returns successfully
+
+<any unresolved findings if force=true>
+
+---
+
+Closes #<issue_number>
+
+Generated with [Claude Code](https://claude.ai/code)
+PRBODY
+)"
+```
+
+Extract PR number and URL from output.
+
+**DCO:** All commits on the branch should already carry `Signed-off-by` trailers from the husky `prepare-commit-msg` hook. The DCO workflow check on GitHub will verify each commit. If any commit is missing the trailer, the PR will fail the DCO check — fix locally with new commits (do **not** force-push amended history that strips trailers).
+
+### Step 6: Send Notification (unless skip_notify)
+
+Use the `telegram` skill (via Skill tool) to send a notification:
+
+```
+PR Created: #<pr_number>
+Issue: #<issue_number> - <title>
+URL: <pr_url>
+Commits: <count>
+Status: Awaiting review
+```
+
+**If notification fails:** Log warning, continue.
+
+### Step 7: Return Output
+
+```json
+{
+  "pr": {
+    "number": <pr_number>,
+    "url": "<pr_url>",
+    "title": "<pr_title>"
+  },
+  "workflow_status": "completed"
+}
+```
+
+## Error Handling
+
+| Condition                      | Behavior                  |
+| ------------------------------ | ------------------------- |
+| Validation fails (force=false) | Return error with details |
+| Push fails                     | Return error (critical)   |
+| PR creation fails              | Return error (critical)   |
+| Notification fails             | Warn, continue            |
+
+## Example
+
+**Input:**
+
+```json
+{
+  "issue_number": 487,
+  "plan_path": "apps/native-rd/docs/plans/dev-plans/issue-487-agent-architecture.md"
+}
+```
+
+**Output:**
+
+```json
+{
+  "pr": {
+    "number": 488,
+    "url": "https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/pull/488",
+    "title": "refactor(native-rd): implement robust agent architecture (#487)"
+  },
+  "workflow_status": "completed"
+}
+```
+
+## Output Format
+
+After completing all steps, report:
+
+```
+FINALIZE COMPLETE
+
+PR: #<pr_number>
+URL: <pr_url>
+Title: <pr_title>
+
+Workflow: Marked as completed
+
+Commits: <count>
+
+Next: PR will be reviewed by CodeRabbit and team.
+```

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -10,24 +10,24 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
 
 ### Input
 
-| Field          | Type   | Required | Description                             |
-| -------------- | ------ | -------- | --------------------------------------- |
-| `issue_number` | number | Yes      | GitHub issue number                     |
-| `plan_path`    | string | Yes      | Exact path to the development plan file |
-| `start_step`   | number | No       | Resume from specific step               |
+| Field          | Type   | Required | Description               |
+| -------------- | ------ | -------- | ------------------------- |
+| `issue_number` | number | Yes      | GitHub issue number       |
+| `plan_path`    | string | Yes      | Exact dev plan path       |
+| `start_step`   | number | No       | Resume from specific step |
 
 ### Output
 
-| Field                   | Type     | Description          |
-| ----------------------- | -------- | -------------------- |
-| `commits`               | array    | List of commits made |
-| `commits[].sha`         | string   | Commit SHA           |
-| `commits[].message`     | string   | Commit message       |
-| `commits[].files`       | string[] | Files changed        |
-| `validation.type_check` | boolean  | Type-check passed    |
-| `validation.lint`       | boolean  | Lint passed          |
-| `validation.tests`      | boolean  | Tests passed         |
-| `validation.build`      | boolean  | Build passed         |
+| Field                   | Type     | Description       |
+| ----------------------- | -------- | ----------------- |
+| `commits`               | array    | Commits made      |
+| `commits[].sha`         | string   | Commit SHA        |
+| `commits[].message`     | string   | Commit message    |
+| `commits[].files`       | string[] | Files changed     |
+| `validation.type_check` | boolean  | Type-check passed |
+| `validation.lint`       | boolean  | Lint passed       |
+| `validation.tests`      | boolean  | Tests passed      |
+| `validation.build`      | boolean  | Build passed      |
 
 ### Side Effects
 
@@ -38,32 +38,32 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
 
 ## Purpose
 
-Implements code changes following a development plan, making atomic commits that each represent a single logical change. Follows trunk-based development practices with small, focused changes.
+Implement changes per dev plan via atomic commits. Trunk-based, small focused changes.
 
 ## Core Principles
 
 ### MINIMAL Implementation
 
-**CRITICAL: Only implement the bare minimum to fulfill requirements.**
+**CRITICAL: Only the bare minimum to fulfill requirements.**
 
-1. **No "nice to have" features** - If it's not explicitly required, don't build it
-2. **No premature abstraction** - Don't create helpers/utilities for one-time operations
-3. **No extra options/parameters** - Add configuration only when explicitly needed
-4. **No defensive coding for impossible cases** - Trust internal code
+1. **No "nice to have"** — not required, don't build
+2. **No premature abstraction** — no helpers for one-time ops
+3. **No extra options/parameters** — config only when needed
+4. **No defensive coding for impossible cases** — trust internal code
 
-**Before writing ANY code, ask:**
+**Before writing code, ask:**
 
-- Is this explicitly required by the issue?
-- Would the feature work without this?
-- Am I adding this "just in case"?
+- Explicitly required by issue?
+- Works without this?
+- Adding "just in case"?
 
 ### Minimal Tests
 
 **Only test what matters:**
 
-1. **Happy path** - Does it work with valid input?
-2. **Key error cases** - What happens with obviously wrong input?
-3. **Edge cases only if likely** - Don't test impossible scenarios
+1. **Happy path** — works with valid input
+2. **Key error cases** — obviously wrong input
+3. **Edge cases only if likely** — skip impossible scenarios
 
 **Test count guideline:**
 
@@ -73,12 +73,12 @@ Implements code changes following a development plan, making atomic commits that
 
 ### Atomic Commits
 
-Each commit must be:
+Each commit:
 
-1. **Self-contained**: Works on its own
-2. **Single purpose**: One logical change
-3. **Buildable**: Code compiles/passes type-check
-4. **Testable**: Related tests included (when applicable)
+1. **Self-contained** — works on its own
+2. **Single purpose** — one logical change
+3. **Buildable** — compiles/type-checks
+4. **Testable** — related tests included (when applicable)
 
 #### Good vs Bad Atomic Commits
 
@@ -126,30 +126,24 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`
    git status
    ```
 
-2. **Load development plan:**
-   - Read from the path provided by the caller (`plan_path` input)
+2. **Load dev plan** from caller's `plan_path` input.
 
 ### Phase 2: Execute Plan Step by Step
 
-For each step in the development plan:
+For each step:
 
-1. **Announce step:**
-   - "Step 1: <description>"
-   - Show expected commit message
+1. **Announce:** "Step 1: <description>" + expected commit message
 
-2. **Make changes:**
-   - Create/modify files as planned
-   - Follow existing code patterns
-   - Include inline comments where helpful
+2. **Make changes** — create/modify files, follow existing patterns, inline comments where helpful
 
-3. **Validate changes:**
+3. **Validate:**
 
    ```bash
-   bun run type-check  # TypeScript check
+   bun run type-check
    ```
 
    ```bash
-   bun run lint        # Linting
+   bun run lint
    ```
 
 4. **Run relevant tests:**
@@ -158,7 +152,7 @@ For each step in the development plan:
    bun test --testPathPatterns <pattern>
    ```
 
-   (Use `--testPathPatterns` plural per native-rd convention — see `apps/native-rd/CLAUDE.md`.)
+   (Plural `--testPathPatterns` per native-rd convention — see `apps/native-rd/CLAUDE.md`.)
 
 5. **Format changed files:**
 
@@ -173,48 +167,30 @@ For each step in the development plan:
    git commit -m "<type>(<scope>): <message>"
    ```
 
-   **DCO is mandatory in this repo.** The husky `prepare-commit-msg` hook adds the `Signed-off-by` trailer automatically. **Never** pass `--no-verify` to git commit, and never amend commits in a way that strips the trailer.
+   **DCO mandatory.** Husky `prepare-commit-msg` adds `Signed-off-by` automatically. **Never** pass `--no-verify`. Never amend in a way that strips the trailer.
 
-7. **Report progress:**
-   - Confirm commit made
-   - Show files changed
-   - Note any deviations from plan
+7. **Report:** commit confirmed, files changed, deviations noted
 
-8. **Update the dev plan (live plan maintenance):**
-   - Check off completed items in the Implementation Plan section (change `- [ ]` to `- [x]`)
-   - **On deviation:** Add a timestamped entry to the Discovery Log section:
+8. **Update dev plan (live plan maintenance):**
+   - Check off completed items in Implementation Plan (`- [ ]` → `- [x]`)
+   - **On deviation:** timestamped Discovery Log entry:
      ```markdown
      - [YYYY-MM-DD HH:MM] <what changed and why>
      ```
-   - **On new decision:** Add a row to the Decisions table with ID, decision, alternatives, rationale.
-   - **On explicit deferral:** Add to the Not in Scope table with item, reason, and follow-up issue (if any)
+   - **On new decision:** add row to Decisions table (ID, decision, alternatives, rationale)
+   - **On explicit deferral:** add to Not in Scope table (item, reason, follow-up issue)
 
 ### Phase 3: Handle Deviations
 
-If the plan needs adjustment:
-
-1. **Minor adjustments:**
-   - Make the change
-   - Note the deviation in the Discovery Log
-   - Continue with plan
-
-2. **Significant changes:**
-   - Stop and report
-   - Explain what's different
-   - Propose updated approach
-   - In autonomous mode (auto-issue): pick the most reasonable path and log the decision
-   - In gated mode: wait for user approval
-
-3. **Blockers:**
-   - Stop immediately
-   - Describe the blocker
-   - Suggest resolution
+1. **Minor:** make change, log in Discovery Log, continue
+2. **Significant:** stop, report, propose updated approach
+   - Autonomous (auto-issue): pick reasonable path, log decision
+   - Gated: wait for approval
+3. **Blockers:** stop immediately, describe blocker, suggest resolution
 
 ### Phase 4: Final Validation
 
-After all commits:
-
-1. **Run full validation (each command separately):**
+1. **Full validation (each command separately):**
 
    ```bash
    bun run type-check
@@ -232,7 +208,7 @@ After all commits:
    bun run build
    ```
 
-   **Note:** `bun run build` in this repo is safe — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). It does NOT trigger an Expo prebuild or native compile. If a future change makes it non-trivial, drop the build step from this skill rather than running native builds.
+   **Note:** `bun run build` is safe — native-rd's `build` script is `echo 'Expo app — no build step'`. No prebuild, no native compile. If this changes, drop the build step rather than running native builds.
 
 2. **Review commit history:**
 
@@ -246,65 +222,40 @@ After all commits:
    git diff main --stat
    ```
 
-4. **Verify scope:**
-   - Is it under ~500 lines?
-   - Does each commit stand alone?
-   - Is the branch focused?
+4. **Verify scope:** under ~500 lines? each commit stands alone? branch focused?
 
 5. **Verify Intent (plan-aware check):**
-   - Read the dev plan's Intent Verification section
-   - For each criterion, verify it is met by the implementation
-   - Check off met criteria in the plan (change `- [ ]` to `- [x]`)
-   - If any criteria are NOT met, report which ones failed and why. In autonomous workflows (auto-issue), log the gap and proceed.
+   - Read plan's Intent Verification section
+   - Verify each criterion met by implementation
+   - Check off met criteria (`- [ ]` → `- [x]`)
+   - Unmet → report which failed and why. Autonomous (auto-issue): log gap, proceed.
 
 ### Phase 5: Report Completion
 
-1. **Summary:**
-   - Number of commits made
-   - Files changed
-   - Lines added/removed
-   - Tests added/passing
-
-2. **Ready for review:**
-   - Branch name
-   - Base branch
-   - Suggested PR title
-
-3. **Next step:**
-   - "Ready for review phase"
+1. **Summary:** commit count, files changed, lines added/removed, tests added/passing
+2. **Ready for review:** branch, base branch, suggested PR title
+3. **Next:** "Ready for review phase"
 
 ## Error Handling
 
 ### Build/Type Errors
 
-1. **Analyze error:**
-   - Read error message
-   - Identify root cause
-   - Plan fix
+1. **Analyze** — read error, identify root cause, plan fix
+2. **Fix in new commit (preferred)** — create fix commit, note deviation
 
-2. **Fix in new commit (preferred):**
-   - Create a fix commit
-   - Note deviation from plan
-
-   Prefer NEW commits over `git commit --amend` — amending past the husky hook can drop the DCO trailer.
+   Prefer NEW commits over `git commit --amend` — amending past husky can drop DCO trailer.
 
 ### Test Failures
 
-1. **Expected failures:**
-   - Update test expectations
-   - Include in same commit
-
-2. **Unexpected failures:**
-   - Stop and analyze
-   - Report to user
-   - Fix before continuing
+1. **Expected:** update test expectations, include in same commit
+2. **Unexpected:** stop, analyze, report, fix before continuing
 
 ### Merge Conflicts
 
-1. **Stop immediately**
-2. **Report conflict details**
-3. **Wait for user guidance**
-4. **Do not auto-resolve**
+1. Stop immediately
+2. Report conflict details
+3. Wait for user guidance
+4. Do not auto-resolve
 
 ## Output Format
 
@@ -343,11 +294,9 @@ Ready for review phase.
 
 ## Success Criteria
 
-This skill is successful when:
-
-- All planned commits are made
-- Each commit is atomic and buildable
+- All planned commits made
+- Each commit atomic, buildable
 - All validations pass
-- Branch is ready for review
-- Code follows project conventions
-- Every commit has a `Signed-off-by` trailer (DCO)
+- Branch ready for review
+- Follows project conventions
+- Every commit has `Signed-off-by` trailer (DCO)

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: implement
+description: Implements code changes following a development plan with atomic commits. Each commit is self-contained and the PR focuses on a single change. Use after issue-researcher creates a plan.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
+---
+
+# Implement Skill
+
+## Contract
+
+### Input
+
+| Field          | Type   | Required | Description                             |
+| -------------- | ------ | -------- | --------------------------------------- |
+| `issue_number` | number | Yes      | GitHub issue number                     |
+| `plan_path`    | string | Yes      | Exact path to the development plan file |
+| `start_step`   | number | No       | Resume from specific step               |
+
+### Output
+
+| Field                   | Type     | Description          |
+| ----------------------- | -------- | -------------------- |
+| `commits`               | array    | List of commits made |
+| `commits[].sha`         | string   | Commit SHA           |
+| `commits[].message`     | string   | Commit message       |
+| `commits[].files`       | string[] | Files changed        |
+| `validation.type_check` | boolean  | Type-check passed    |
+| `validation.lint`       | boolean  | Lint passed          |
+| `validation.tests`      | boolean  | Tests passed         |
+| `validation.build`      | boolean  | Build passed         |
+
+### Side Effects
+
+- Creates/modifies files per plan
+- Makes git commits
+
+---
+
+## Purpose
+
+Implements code changes following a development plan, making atomic commits that each represent a single logical change. Follows trunk-based development practices with small, focused changes.
+
+## Core Principles
+
+### MINIMAL Implementation
+
+**CRITICAL: Only implement the bare minimum to fulfill requirements.**
+
+1. **No "nice to have" features** - If it's not explicitly required, don't build it
+2. **No premature abstraction** - Don't create helpers/utilities for one-time operations
+3. **No extra options/parameters** - Add configuration only when explicitly needed
+4. **No defensive coding for impossible cases** - Trust internal code
+
+**Before writing ANY code, ask:**
+
+- Is this explicitly required by the issue?
+- Would the feature work without this?
+- Am I adding this "just in case"?
+
+### Minimal Tests
+
+**Only test what matters:**
+
+1. **Happy path** - Does it work with valid input?
+2. **Key error cases** - What happens with obviously wrong input?
+3. **Edge cases only if likely** - Don't test impossible scenarios
+
+**Test count guideline:**
+
+- Simple function: 2-4 tests
+- Complex function: 5-8 tests
+- Full service: 8-15 tests
+
+### Atomic Commits
+
+Each commit must be:
+
+1. **Self-contained**: Works on its own
+2. **Single purpose**: One logical change
+3. **Buildable**: Code compiles/passes type-check
+4. **Testable**: Related tests included (when applicable)
+
+#### Good vs Bad Atomic Commits
+
+**GOOD** (single purpose):
+
+```
+feat(themes): add highContrast variant tokens
+feat(themes): wire highContrast into theme compose
+test(themes): add contrast assertions for highContrast
+```
+
+**BAD** (mixed concerns):
+
+```
+feat(themes): add variant, wire it, add tests
+feat: various improvements to theming
+wip: work in progress
+```
+
+### Commit Message Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`
+
+### Small PRs
+
+- Target ~500 lines max (excluding tests)
+- One issue = one PR
+- One PR = one thing changed
+
+## Workflow
+
+### Phase 1: Prepare Environment
+
+1. **Verify clean state:**
+
+   ```bash
+   git status
+   ```
+
+2. **Load development plan:**
+   - Read from the path provided by the caller (`plan_path` input)
+
+### Phase 2: Execute Plan Step by Step
+
+For each step in the development plan:
+
+1. **Announce step:**
+   - "Step 1: <description>"
+   - Show expected commit message
+
+2. **Make changes:**
+   - Create/modify files as planned
+   - Follow existing code patterns
+   - Include inline comments where helpful
+
+3. **Validate changes:**
+
+   ```bash
+   bun run type-check  # TypeScript check
+   ```
+
+   ```bash
+   bun run lint        # Linting
+   ```
+
+4. **Run relevant tests:**
+
+   ```bash
+   bun test --testPathPatterns <pattern>
+   ```
+
+   (Use `--testPathPatterns` plural per native-rd convention — see `apps/native-rd/CLAUDE.md`.)
+
+5. **Format changed files:**
+
+   ```bash
+   bunx prettier --write <file-list>
+   ```
+
+6. **Stage and commit:**
+
+   ```bash
+   git add <specific-files>
+   git commit -m "<type>(<scope>): <message>"
+   ```
+
+   **DCO is mandatory in this repo.** The husky `prepare-commit-msg` hook adds the `Signed-off-by` trailer automatically. **Never** pass `--no-verify` to git commit, and never amend commits in a way that strips the trailer.
+
+7. **Report progress:**
+   - Confirm commit made
+   - Show files changed
+   - Note any deviations from plan
+
+8. **Update the dev plan (live plan maintenance):**
+   - Check off completed items in the Implementation Plan section (change `- [ ]` to `- [x]`)
+   - **On deviation:** Add a timestamped entry to the Discovery Log section:
+     ```markdown
+     - [YYYY-MM-DD HH:MM] <what changed and why>
+     ```
+   - **On new decision:** Add a row to the Decisions table with ID, decision, alternatives, rationale.
+   - **On explicit deferral:** Add to the Not in Scope table with item, reason, and follow-up issue (if any)
+
+### Phase 3: Handle Deviations
+
+If the plan needs adjustment:
+
+1. **Minor adjustments:**
+   - Make the change
+   - Note the deviation in the Discovery Log
+   - Continue with plan
+
+2. **Significant changes:**
+   - Stop and report
+   - Explain what's different
+   - Propose updated approach
+   - In autonomous mode (auto-issue): pick the most reasonable path and log the decision
+   - In gated mode: wait for user approval
+
+3. **Blockers:**
+   - Stop immediately
+   - Describe the blocker
+   - Suggest resolution
+
+### Phase 4: Final Validation
+
+After all commits:
+
+1. **Run full validation (each command separately):**
+
+   ```bash
+   bun run type-check
+   ```
+
+   ```bash
+   bun run lint
+   ```
+
+   ```bash
+   bun test
+   ```
+
+   ```bash
+   bun run build
+   ```
+
+   **Note:** `bun run build` in this repo is safe — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). It does NOT trigger an Expo prebuild or native compile. If a future change makes it non-trivial, drop the build step from this skill rather than running native builds.
+
+2. **Review commit history:**
+
+   ```bash
+   git log --oneline -n <number-of-commits>
+   ```
+
+3. **Check diff stats:**
+
+   ```bash
+   git diff main --stat
+   ```
+
+4. **Verify scope:**
+   - Is it under ~500 lines?
+   - Does each commit stand alone?
+   - Is the branch focused?
+
+5. **Verify Intent (plan-aware check):**
+   - Read the dev plan's Intent Verification section
+   - For each criterion, verify it is met by the implementation
+   - Check off met criteria in the plan (change `- [ ]` to `- [x]`)
+   - If any criteria are NOT met, report which ones failed and why. In autonomous workflows (auto-issue), log the gap and proceed.
+
+### Phase 5: Report Completion
+
+1. **Summary:**
+   - Number of commits made
+   - Files changed
+   - Lines added/removed
+   - Tests added/passing
+
+2. **Ready for review:**
+   - Branch name
+   - Base branch
+   - Suggested PR title
+
+3. **Next step:**
+   - "Ready for review phase"
+
+## Error Handling
+
+### Build/Type Errors
+
+1. **Analyze error:**
+   - Read error message
+   - Identify root cause
+   - Plan fix
+
+2. **Fix in new commit (preferred):**
+   - Create a fix commit
+   - Note deviation from plan
+
+   Prefer NEW commits over `git commit --amend` — amending past the husky hook can drop the DCO trailer.
+
+### Test Failures
+
+1. **Expected failures:**
+   - Update test expectations
+   - Include in same commit
+
+2. **Unexpected failures:**
+   - Stop and analyze
+   - Report to user
+   - Fix before continuing
+
+### Merge Conflicts
+
+1. **Stop immediately**
+2. **Report conflict details**
+3. **Wait for user guidance**
+4. **Do not auto-resolve**
+
+## Output Format
+
+After each commit:
+
+```
+Commit #<n>: <type>(<scope>): <message>
+Files: <file-list>
+Status: <passing|failing>
+```
+
+After completion:
+
+```
+## Implementation Complete
+
+**Branch**: <branch-name>
+**Commits**: <n>
+**Files Changed**: <n>
+**Lines**: +<added> / -<removed>
+
+### Commit History
+1. <commit-message>
+2. <commit-message>
+...
+
+### Validation
+- Type-check: PASS
+- Lint: PASS
+- Tests: PASS (<n>/<n>)
+- Build: PASS (no-op for native-rd)
+
+### Next Step
+Ready for review phase.
+```
+
+## Success Criteria
+
+This skill is successful when:
+
+- All planned commits are made
+- Each commit is atomic and buildable
+- All validations pass
+- Branch is ready for review
+- Code follows project conventions
+- Every commit has a `Signed-off-by` trailer (DCO)

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: review
+description: Coordinates review agents and manages auto-fix loop. Spawns code-reviewer, test-analyzer, silent-failure-hunter in parallel, classifies findings, and attempts fixes for critical issues.
+allowed-tools: Bash, Read, Glob, Grep, Skill, Agent
+---
+
+# Review Skill
+
+Coordinates code review and manages the auto-fix cycle.
+
+## Contract
+
+### Input
+
+| Field         | Type     | Required | Description                                    |
+| ------------- | -------- | -------- | ---------------------------------------------- |
+| `workflow_id` | string   | Yes      | Workflow ID (`issue-<N>`) — used for log lines |
+| `skip_agents` | string[] | No       | Agents to skip (default: none)                 |
+| `max_retry`   | number   | No       | Max fix attempts per finding (default: 3)      |
+| `parallel`    | boolean  | No       | Run agents in parallel (default: true)         |
+
+### Output
+
+| Field                 | Type    | Description                     |
+| --------------------- | ------- | ------------------------------- |
+| `findings`            | array   | All findings from review agents |
+| `findings[].agent`    | string  | Which agent found this          |
+| `findings[].severity` | string  | CRITICAL, HIGH, MEDIUM, LOW     |
+| `findings[].file`     | string  | File path                       |
+| `findings[].line`     | number  | Line number                     |
+| `findings[].message`  | string  | Finding description             |
+| `findings[].fixed`    | boolean | Whether auto-fix succeeded      |
+| `summary.total`       | number  | Total findings                  |
+| `summary.critical`    | number  | Critical findings               |
+| `summary.fixed`       | number  | Successfully fixed              |
+| `summary.unresolved`  | number  | Critical findings not fixed     |
+
+### Side Effects
+
+1. Spawns review agents as standalone background agents (parallel or sequential, never as team members)
+2. Spawns auto-fixer as standalone background agent for critical findings
+3. Creates fix commits
+
+## Review Agents
+
+| Agent                                     | Purpose                | Critical Threshold                   |
+| ----------------------------------------- | ---------------------- | ------------------------------------ |
+| `pr-review-toolkit:code-reviewer`         | Code quality, patterns | Confidence >= 91 OR label="Critical" |
+| `pr-review-toolkit:pr-test-analyzer`      | Test coverage gaps     | Gap rating >= 8                      |
+| `pr-review-toolkit:silent-failure-hunter` | Error handling         | Severity = "CRITICAL"                |
+
+## Workflow
+
+### Step 1: Detect Scope
+
+**Get changed files:**
+
+```bash
+git diff main --name-only
+```
+
+**Read dev plan (if it exists):**
+
+Look for the dev plan in this repo's plan directory:
+
+```bash
+ls apps/native-rd/docs/plans/dev-plans/issue-*.md 2>/dev/null
+```
+
+If multiple files match, use the one whose filename contains the current issue number. If a plan exists for the current issue:
+
+1. Read the **Intent Verification** section — these are the success criteria
+2. Read the **Not in Scope** section — these items should NOT have been implemented
+3. Store both for use in the output summary
+
+### Step 1.5: Run /simplify (Code Quality Pass)
+
+Run the built-in `/simplify` command for code quality, reuse, and efficiency improvements.
+This complements the review agents which focus on bugs, test gaps, and silent failures.
+
+1. Run: `/simplify`
+2. If `/simplify` makes changes:
+   a. Validate each command separately:
+   ```bash
+   bun run type-check
+   ```
+   ```bash
+   bun run lint
+   ```
+   ```bash
+   bun test
+   ```
+   b. If all valid: commit with `git commit -m "refactor: apply simplify suggestions"` (husky adds DCO trailer)
+   c. If invalid: revert with `git reset --hard HEAD && git clean -fd` (resets tracked files and removes untracked artifacts created by `/simplify`)
+3. Continue to Step 2 regardless of outcome.
+
+### Step 2: Spawn Review Agents
+
+**CRITICAL: Team isolation.** All review agents are internal sub-agents — they MUST be spawned as standalone background agents, never as team members. Do NOT pass `team_name` to any Agent call.
+
+**If parallel mode (default):**
+
+Spawn all agents simultaneously using the Agent tool with `run_in_background: true` (no `team_name`):
+
+```text
+Agent(pr-review-toolkit:code-reviewer, run_in_background: true): "Review code changes for issue workflow <workflow_id>"
+Agent(pr-review-toolkit:pr-test-analyzer, run_in_background: true): "Analyze test coverage for changes"
+Agent(pr-review-toolkit:silent-failure-hunter, run_in_background: true): "Check for silent failures in changes"
+```
+
+**If sequential mode:**
+
+Spawn each agent one at a time using the Agent tool (no `team_name`), collecting results.
+
+### Step 3: Collect and Normalize Findings
+
+Each agent returns findings in different formats. Normalize to:
+
+```json
+{
+  "agent": "<agent-name>",
+  "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+  "file": "<file-path>",
+  "line": <line-number>,
+  "message": "<description>",
+  "fixed": false
+}
+```
+
+**Classification rules:**
+
+| Agent                 | CRITICAL if                          | HIGH if          | MEDIUM/LOW otherwise    |
+| --------------------- | ------------------------------------ | ---------------- | ----------------------- |
+| code-reviewer         | Confidence >= 91 OR label="Critical" | Confidence >= 75 | Confidence < 75         |
+| silent-failure-hunter | Severity="CRITICAL"                  | Severity="HIGH"  | Severity="MEDIUM"/"LOW" |
+| pr-test-analyzer      | Gap rating >= 8                      | Gap rating >= 5  | Gap rating < 5          |
+
+### Step 4: Auto-Fix Loop
+
+**For each CRITICAL finding:**
+
+```text
+attempt = 0
+while not fixed AND attempt < max_retry:
+    attempt++
+
+    Spawn auto-fixer (standalone — no team_name):
+    Agent(auto-fixer, run_in_background: true): "Fix: <finding.message> in <finding.file>:<finding.line>"
+
+    If fix successful:
+        finding.fixed = true
+    Else:
+        Continue to next attempt
+```
+
+### Step 5: Re-Review After Fixes
+
+If any fixes were made:
+
+1. Run validation (each command separately):
+
+   ```bash
+   bun run type-check
+   ```
+
+   ```bash
+   bun run lint
+   ```
+
+2. If validation fails, revert last fix:
+
+   ```bash
+   git checkout -- <file>
+   ```
+
+   Mark finding as not fixed.
+
+3. Optionally re-run review agents to verify fixes (if time permits).
+
+### Step 6: Calculate Summary
+
+```json
+{
+  "total": <all-findings>,
+  "critical": <critical-count>,
+  "fixed": <successfully-fixed>,
+  "unresolved": <critical-not-fixed>
+}
+```
+
+### Step 7: Return Output
+
+```json
+{
+  "findings": [...],
+  "summary": {
+    "total": <n>,
+    "critical": <n>,
+    "fixed": <n>,
+    "unresolved": <n>
+  }
+}
+```
+
+## Error Handling
+
+| Condition            | Behavior                            |
+| -------------------- | ----------------------------------- |
+| Agent fails to spawn | Log error, continue with others     |
+| All agents fail      | Return error (critical)             |
+| Fix validation fails | Revert fix, try next approach       |
+| Max retry exceeded   | Mark as unresolved, continue        |
+| Timeout              | Return partial results with warning |
+
+## Output Format
+
+```text
+REVIEW COMPLETE
+
+Agents Run: code-reviewer, test-analyzer, silent-failure-hunter
+Findings: <total> total (<critical> critical)
+Fixed: <fixed>/<critical> critical issues
+
+UNRESOLVED (require manual attention):
+1. [code-reviewer] src/foo.ts:42 - Missing null check
+2. [silent-failure-hunter] src/bar.ts:89 - Silent catch block
+
+NON-CRITICAL (for PR reviewer):
+- [code-reviewer] src/baz.ts:15 - Consider extracting helper (confidence: 72)
+- [test-analyzer] Missing edge case test for empty input (gap: 4)
+
+PLAN COMPLIANCE: (omit entire section if no plan exists)
+- Intent Verification: <N>/<M> criteria met
+- Scope: clean | scope creep detected (<details if any>)
+
+Summary: <unresolved> unresolved critical findings
+```
+
+## Escalation Trigger
+
+If `summary.unresolved > 0`:
+
+The calling workflow should escalate to user with:
+
+- List of unresolved findings
+- Options: continue (manual fix), force-pr, abort
+
+## Success Criteria
+
+This skill is successful when:
+
+- All review agents run (or gracefully skip on failure)
+- Findings are correctly classified by severity
+- Auto-fix attempted for all CRITICAL findings
+- Clear summary returned to orchestrator
+- Escalation triggered when appropriate

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -6,18 +6,18 @@ allowed-tools: Bash, Read, Glob, Grep, Skill, Agent
 
 # Review Skill
 
-Coordinates code review and manages the auto-fix cycle.
+Coordinate review + auto-fix cycle.
 
 ## Contract
 
 ### Input
 
-| Field         | Type     | Required | Description                                    |
-| ------------- | -------- | -------- | ---------------------------------------------- |
-| `workflow_id` | string   | Yes      | Workflow ID (`issue-<N>`) — used for log lines |
-| `skip_agents` | string[] | No       | Agents to skip (default: none)                 |
-| `max_retry`   | number   | No       | Max fix attempts per finding (default: 3)      |
-| `parallel`    | boolean  | No       | Run agents in parallel (default: true)         |
+| Field         | Type     | Required | Description                               |
+| ------------- | -------- | -------- | ----------------------------------------- |
+| `workflow_id` | string   | Yes      | Workflow ID (`issue-<N>`) — for log lines |
+| `skip_agents` | string[] | No       | Agents to skip (default: none)            |
+| `max_retry`   | number   | No       | Max fix attempts per finding (default: 3) |
+| `parallel`    | boolean  | No       | Run agents in parallel (default: true)    |
 
 ### Output
 
@@ -37,9 +37,9 @@ Coordinates code review and manages the auto-fix cycle.
 
 ### Side Effects
 
-1. Spawns review agents as standalone background agents (parallel or sequential, never as team members)
-2. Spawns auto-fixer as standalone background agent for critical findings
-3. Creates fix commits
+1. Spawn review agents as standalone background agents (parallel or sequential, never team members)
+2. Spawn auto-fixer as standalone background agent for critical findings
+3. Create fix commits
 
 ## Review Agents
 
@@ -53,34 +53,31 @@ Coordinates code review and manages the auto-fix cycle.
 
 ### Step 1: Detect Scope
 
-**Get changed files:**
+**Changed files:**
 
 ```bash
 git diff main --name-only
 ```
 
-**Read dev plan (if it exists):**
-
-Look for the dev plan in this repo's plan directory:
+**Read dev plan if exists:**
 
 ```bash
 ls apps/native-rd/docs/plans/dev-plans/issue-*.md 2>/dev/null
 ```
 
-If multiple files match, use the one whose filename contains the current issue number. If a plan exists for the current issue:
+Multiple matches → use filename containing current issue number. If plan exists for current issue:
 
-1. Read the **Intent Verification** section — these are the success criteria
-2. Read the **Not in Scope** section — these items should NOT have been implemented
-3. Store both for use in the output summary
+1. Read **Intent Verification** — success criteria
+2. Read **Not in Scope** — items that should NOT be implemented
+3. Store both for output summary
 
 ### Step 1.5: Run /simplify (Code Quality Pass)
 
-Run the built-in `/simplify` command for code quality, reuse, and efficiency improvements.
-This complements the review agents which focus on bugs, test gaps, and silent failures.
+Run built-in `/simplify` for code quality, reuse, efficiency. Complements review agents (bugs, test gaps, silent failures).
 
 1. Run: `/simplify`
-2. If `/simplify` makes changes:
-   a. Validate each command separately:
+2. If `/simplify` made changes:
+   a. Validate (each command separately):
    ```bash
    bun run type-check
    ```
@@ -90,17 +87,17 @@ This complements the review agents which focus on bugs, test gaps, and silent fa
    ```bash
    bun test
    ```
-   b. If all valid: commit with `git commit -m "refactor: apply simplify suggestions"` (husky adds DCO trailer)
-   c. If invalid: revert with `git reset --hard HEAD && git clean -fd` (resets tracked files and removes untracked artifacts created by `/simplify`)
-3. Continue to Step 2 regardless of outcome.
+   b. Valid: `git commit -m "refactor: apply simplify suggestions"` (husky adds DCO)
+   c. Invalid: revert via `git reset --hard HEAD && git clean -fd` (resets tracked, removes untracked `/simplify` artifacts)
+3. Continue to Step 2 regardless.
 
 ### Step 2: Spawn Review Agents
 
-**CRITICAL: Team isolation.** All review agents are internal sub-agents — they MUST be spawned as standalone background agents, never as team members. Do NOT pass `team_name` to any Agent call.
+**CRITICAL: Team isolation.** All review agents are internal sub-agents — MUST be standalone background agents, never team members. Do NOT pass `team_name`.
 
-**If parallel mode (default):**
+**Parallel mode (default):**
 
-Spawn all agents simultaneously using the Agent tool with `run_in_background: true` (no `team_name`):
+Spawn all agents simultaneously via Agent tool with `run_in_background: true` (no `team_name`):
 
 ```text
 Agent(pr-review-toolkit:code-reviewer, run_in_background: true): "Review code changes for issue workflow <workflow_id>"
@@ -108,13 +105,13 @@ Agent(pr-review-toolkit:pr-test-analyzer, run_in_background: true): "Analyze tes
 Agent(pr-review-toolkit:silent-failure-hunter, run_in_background: true): "Check for silent failures in changes"
 ```
 
-**If sequential mode:**
+**Sequential mode:**
 
-Spawn each agent one at a time using the Agent tool (no `team_name`), collecting results.
+Spawn one at a time via Agent tool (no `team_name`), collect results.
 
 ### Step 3: Collect and Normalize Findings
 
-Each agent returns findings in different formats. Normalize to:
+Each agent returns different formats. Normalize to:
 
 ```json
 {
@@ -155,9 +152,9 @@ while not fixed AND attempt < max_retry:
 
 ### Step 5: Re-Review After Fixes
 
-If any fixes were made:
+Any fixes made → validate:
 
-1. Run validation (each command separately):
+1. Validation (each command separately):
 
    ```bash
    bun run type-check
@@ -167,15 +164,15 @@ If any fixes were made:
    bun run lint
    ```
 
-2. If validation fails, revert last fix:
+2. Validation fails → revert last fix:
 
    ```bash
    git checkout -- <file>
    ```
 
-   Mark finding as not fixed.
+   Mark as not fixed.
 
-3. Optionally re-run review agents to verify fixes (if time permits).
+3. Optionally re-run review agents to verify fixes.
 
 ### Step 6: Calculate Summary
 
@@ -238,19 +235,15 @@ Summary: <unresolved> unresolved critical findings
 
 ## Escalation Trigger
 
-If `summary.unresolved > 0`:
-
-The calling workflow should escalate to user with:
+`summary.unresolved > 0` → calling workflow escalates with:
 
 - List of unresolved findings
 - Options: continue (manual fix), force-pr, abort
 
 ## Success Criteria
 
-This skill is successful when:
-
 - All review agents run (or gracefully skip on failure)
-- Findings are correctly classified by severity
+- Findings correctly classified by severity
 - Auto-fix attempted for all CRITICAL findings
-- Clear summary returned to orchestrator
+- Clear summary to orchestrator
 - Escalation triggered when appropriate

--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -6,17 +6,17 @@ allowed-tools: Bash, Read, Skill
 
 # Setup Skill
 
-Prepares everything needed before implementation work begins.
+Prep before implementation.
 
 ## Contract
 
 ### Input
 
-| Field          | Type    | Required | Description                                         |
-| -------------- | ------- | -------- | --------------------------------------------------- |
-| `issue_number` | number  | Yes      | GitHub issue number                                 |
-| `branch_name`  | string  | No       | Custom branch name (auto-generated if not provided) |
-| `skip_notify`  | boolean | No       | Skip Telegram notification (default: false)         |
+| Field          | Type    | Required | Description                                |
+| -------------- | ------- | -------- | ------------------------------------------ |
+| `issue_number` | number  | Yes      | GitHub issue number                        |
+| `branch_name`  | string  | No       | Custom branch name (auto-generated if not) |
+| `skip_notify`  | boolean | No       | Skip Telegram notification (default false) |
 
 ### Output
 
@@ -30,8 +30,8 @@ Prepares everything needed before implementation work begins.
 
 ### Side Effects
 
-1. Creates git branch (or checks out existing)
-2. Sends Telegram notification (unless skip_notify)
+1. Create git branch (or check out existing)
+2. Send Telegram notification (unless skip_notify)
 
 ## Workflow
 
@@ -41,47 +41,30 @@ Prepares everything needed before implementation work begins.
 gh issue view <issue_number> --json number,title,body,labels,milestone,assignees
 ```
 
-If issue not found: STOP, return error.
+If not found: STOP, return error.
 
-Extract and store:
-
-- `issue.number`
-- `issue.title`
-- `issue.body`
-- `issue.labels` (array of label names)
+Store `issue.number`, `issue.title`, `issue.body`, `issue.labels`.
 
 ### Step 2: Generate Branch Name
 
-If `branch_name` not provided:
+If `branch_name` absent:
 
-- Extract short description from issue title (lowercase, hyphenated, max 30 chars)
+- Short description from title (lowercase, hyphenated, max 30 chars)
 - Format: `feat/issue-<number>-<short-description>`
 
-Example: Issue "Add user authentication" → `feat/issue-123-add-user-auth`
+Example: "Add user authentication" → `feat/issue-123-add-user-auth`
 
 ### Step 3: Create Branch
-
-Check current branch:
 
 ```bash
 git branch --show-current
 ```
 
-If not on target branch:
+Not on target → `git checkout -b <branch_name>`. Exists → `git checkout <branch_name>`.
 
-```bash
-git checkout -b <branch_name>
-```
+### Step 4: Notify (unless skip_notify)
 
-If branch already exists:
-
-```bash
-git checkout <branch_name>
-```
-
-### Step 4: Send Notification (unless skip_notify)
-
-Use the `telegram` skill (via Skill tool) to send a notification:
+Via `telegram` skill:
 
 ```text
 Started: Issue #<number>
@@ -89,11 +72,9 @@ Title: <title>
 Branch: <branch>
 ```
 
-**If notification fails:** Log warning, continue (non-critical).
+Notification fail → warn, continue (non-critical).
 
-### Step 5: Return Output
-
-Return structured output:
+### Step 5: Return
 
 ```json
 {
@@ -117,13 +98,7 @@ Return structured output:
 
 ## Example
 
-**Input:**
-
-```json
-{
-  "issue_number": 487
-}
-```
+**Input:** `{ "issue_number": 487 }`
 
 **Output:**
 
@@ -140,8 +115,6 @@ Return structured output:
 ```
 
 ## Output Format
-
-After completing all steps, report:
 
 ```text
 SETUP COMPLETE

--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: setup
+description: Prepares environment for issue work - creates branch and fetches issue details. Use at the start of any issue workflow in Rollercoaster.dev-mobile.
+allowed-tools: Bash, Read, Skill
+---
+
+# Setup Skill
+
+Prepares everything needed before implementation work begins.
+
+## Contract
+
+### Input
+
+| Field          | Type    | Required | Description                                         |
+| -------------- | ------- | -------- | --------------------------------------------------- |
+| `issue_number` | number  | Yes      | GitHub issue number                                 |
+| `branch_name`  | string  | No       | Custom branch name (auto-generated if not provided) |
+| `skip_notify`  | boolean | No       | Skip Telegram notification (default: false)         |
+
+### Output
+
+| Field          | Type     | Description     |
+| -------------- | -------- | --------------- |
+| `branch`       | string   | Git branch name |
+| `issue.number` | number   | Issue number    |
+| `issue.title`  | string   | Issue title     |
+| `issue.body`   | string   | Full issue body |
+| `issue.labels` | string[] | Issue labels    |
+
+### Side Effects
+
+1. Creates git branch (or checks out existing)
+2. Sends Telegram notification (unless skip_notify)
+
+## Workflow
+
+### Step 1: Fetch Issue
+
+```bash
+gh issue view <issue_number> --json number,title,body,labels,milestone,assignees
+```
+
+If issue not found: STOP, return error.
+
+Extract and store:
+
+- `issue.number`
+- `issue.title`
+- `issue.body`
+- `issue.labels` (array of label names)
+
+### Step 2: Generate Branch Name
+
+If `branch_name` not provided:
+
+- Extract short description from issue title (lowercase, hyphenated, max 30 chars)
+- Format: `feat/issue-<number>-<short-description>`
+
+Example: Issue "Add user authentication" → `feat/issue-123-add-user-auth`
+
+### Step 3: Create Branch
+
+Check current branch:
+
+```bash
+git branch --show-current
+```
+
+If not on target branch:
+
+```bash
+git checkout -b <branch_name>
+```
+
+If branch already exists:
+
+```bash
+git checkout <branch_name>
+```
+
+### Step 4: Send Notification (unless skip_notify)
+
+Use the `telegram` skill (via Skill tool) to send a notification:
+
+```text
+Started: Issue #<number>
+Title: <title>
+Branch: <branch>
+```
+
+**If notification fails:** Log warning, continue (non-critical).
+
+### Step 5: Return Output
+
+Return structured output:
+
+```json
+{
+  "branch": "<branch_name>",
+  "issue": {
+    "number": <number>,
+    "title": "<title>",
+    "body": "<body>",
+    "labels": ["<label1>", "<label2>"]
+  }
+}
+```
+
+## Error Handling
+
+| Condition             | Behavior                      |
+| --------------------- | ----------------------------- |
+| Issue not found       | Return error, no side effects |
+| Branch checkout fails | Return error with git status  |
+| Notification fails    | Warn, continue                |
+
+## Example
+
+**Input:**
+
+```json
+{
+  "issue_number": 487
+}
+```
+
+**Output:**
+
+```json
+{
+  "branch": "feat/issue-487-agent-architecture",
+  "issue": {
+    "number": 487,
+    "title": "refactor(claude-tools): implement robust agent architecture",
+    "body": "## Problem\n\nThe current Claude tools architecture...",
+    "labels": ["enhancement", "priority:high"]
+  }
+}
+```
+
+## Output Format
+
+After completing all steps, report:
+
+```text
+SETUP COMPLETE
+
+Issue: #<number> - <title>
+Branch: <branch>
+
+Ready for next phase.
+```

--- a/.claude/agents/auto-fixer.md
+++ b/.claude/agents/auto-fixer.md
@@ -1,0 +1,370 @@
+---
+name: auto-fixer
+description: Applies fixes for critical findings from review agents. Called by auto-issue orchestrator during auto-fix loop. Makes minimal, targeted fixes and validates before committing.
+tools: Bash, Read, Write, Edit, Glob, Grep
+model: sonnet
+---
+
+# Auto-Fixer Agent
+
+## Contract
+
+### Input
+
+| Field                    | Type   | Required | Description                 |
+| ------------------------ | ------ | -------- | --------------------------- |
+| `finding`                | object | Yes      | The finding to fix          |
+| `finding.agent`          | string | Yes      | Which agent found this      |
+| `finding.file`           | string | Yes      | File path                   |
+| `finding.line`           | number | Yes      | Line number                 |
+| `finding.message`        | string | Yes      | Finding description         |
+| `finding.fix_suggestion` | string | No       | Suggested fix from reviewer |
+| `finding.confidence`     | number | No       | Confidence score (0-100)    |
+| `attempt_number`         | number | No       | Which attempt this is (1-3) |
+
+### Output
+
+| Field                   | Type    | Description                 |
+| ----------------------- | ------- | --------------------------- |
+| `fixed`                 | boolean | Whether fix was successful  |
+| `commit_sha`            | string  | Commit SHA if fixed         |
+| `error`                 | string  | Error message if failed     |
+| `validation.type_check` | boolean | Type-check passed after fix |
+| `validation.lint`       | boolean | Lint passed after fix       |
+
+### Side Effects
+
+- Modifies file to apply fix
+- Creates git commit if fix succeeds
+
+---
+
+## Purpose
+
+Applies fixes for critical findings identified by review agents during the `/auto-issue` workflow. Focuses on minimal, targeted fixes that address the specific issue without over-engineering or refactoring unrelated code.
+
+## When to Use This Agent
+
+- Called automatically by `/auto-issue` during auto-fix loop
+- When review agents identify critical findings that must be resolved
+- NOT for manual invocation (use for autonomous workflows only)
+
+## Core Principles
+
+### 1. Minimal Changes Only
+
+**Fix ONLY what's broken. Nothing else.**
+
+- Do not improve surrounding code
+- Do not add comments explaining the fix
+- Do not refactor while fixing
+- Do not "clean up" nearby issues
+
+### 2. Preserve Style
+
+Match the existing code patterns exactly:
+
+- Same indentation (tabs vs spaces)
+- Same quote style (single vs double)
+- Same naming conventions
+- Same formatting patterns
+
+### 3. One Issue Per Edit
+
+Each finding gets its own fix attempt:
+
+- Don't combine fixes for unrelated issues
+- If multiple findings in same file, fix one at a time
+- Each fix is validated independently
+
+### 4. Validate Before Commit
+
+Every fix must pass validation before committing. Run each command separately:
+
+```bash
+bun run type-check
+```
+
+```bash
+bun run lint
+```
+
+If either fails, rollback and report failure.
+
+## Workflow
+
+### Step 1: Analyze Finding
+
+1. **Read the file** at `finding.file`
+
+2. **Understand context:**
+   - What's the actual issue?
+   - What does the fix_suggestion say?
+   - What's the surrounding code doing?
+
+3. **Plan the fix:**
+   - Determine minimal change needed
+   - Identify exact lines to modify
+   - Consider validation implications
+
+### Step 2: Apply Fix
+
+1. **Make the edit:**
+   - Use Edit tool for surgical changes
+   - Use Write tool only if creating new file (rare)
+
+2. **Fix strategies by issue type:**
+
+   | Issue Type         | Strategy                      |
+   | ------------------ | ----------------------------- |
+   | Missing null check | Add `?.` or explicit check    |
+   | Silent catch block | Add error logging or re-throw |
+   | Missing type       | Add type annotation           |
+   | Unused variable    | Remove or use `_` prefix      |
+   | Missing return     | Add return statement          |
+   | Security issue     | Apply suggested mitigation    |
+
+### Step 3: Validate
+
+Run validation commands **separately** (one command per Bash tool call):
+
+```bash
+bun run type-check
+```
+
+```bash
+bun run lint
+```
+
+- If both pass (exit code 0): Proceed to commit
+- If either fails: Rollback and report failure
+
+**IMPORTANT:** Do not combine with `&&` or capture output into shell variables.
+
+### Step 4: Commit or Rollback
+
+**On Success:**
+
+Stage and commit (separate commands):
+
+```bash
+git add <file>
+```
+
+```bash
+git commit -m "fix(<scope>): address review - <description>"
+```
+
+**DCO is mandatory in this repo.** The husky `prepare-commit-msg` hook adds the `Signed-off-by` trailer automatically. **Never** pass `--no-verify` to git commit.
+
+Commit message format:
+
+- Type: Always `fix`
+- Scope: Package or area (e.g., `native-rd`, `openbadges-core`, `design-tokens`)
+- Description: Brief, specific (e.g., "add null check for user input")
+
+**On Failure:**
+
+Rollback the change:
+
+```bash
+git checkout -- <file>
+```
+
+Report the failure with details.
+
+### Step 5: Report Result
+
+Return structured result to orchestrator:
+
+```markdown
+## Fix Result
+
+### Finding
+
+- **Agent:** code-reviewer
+- **File:** src/foo.ts:42
+- **Issue:** Missing null check on user input
+
+### Status: SUCCESS | FAILED
+
+### Changes Made
+
+- Added optional chaining to `user?.name`
+- Line 42 modified
+
+### Validation
+
+- Type-check: PASS
+- Lint: PASS
+
+### Commit
+
+- SHA: abc1234
+- Message: fix(native-rd): add null check for user input
+```
+
+## Fix Patterns
+
+### Pattern 1: Null/Undefined Check
+
+**Finding:** Missing null check
+**Fix:**
+
+```typescript
+// Before
+const name = user.name;
+
+// After (prefer optional chaining)
+const name = user?.name;
+
+// Or (explicit check if logic needed)
+const name = user ? user.name : "default";
+```
+
+### Pattern 2: Silent Catch Block
+
+**Finding:** Empty or silent catch
+**Fix:**
+
+```typescript
+// Before
+try { ... } catch (e) { }
+
+// After (log the error)
+try { ... } catch (e) {
+  logger.error('Operation failed', { error: e });
+}
+
+// Or (re-throw if critical)
+try { ... } catch (e) {
+  logger.error('Operation failed', { error: e });
+  throw e;
+}
+```
+
+### Pattern 3: Missing Type
+
+**Finding:** Implicit any
+**Fix:**
+
+```typescript
+// Before
+function process(data) { ... }
+
+// After
+function process(data: ProcessInput): ProcessOutput { ... }
+```
+
+### Pattern 4: Unused Variable
+
+**Finding:** Declared but never used
+**Fix:**
+
+```typescript
+// Before
+const unused = getValue();
+
+// After (if intentional)
+const _unused = getValue();
+
+// Or (if truly unused)
+// Remove the line entirely
+```
+
+### Pattern 5: Missing Error Handling
+
+**Finding:** Unhandled promise rejection
+**Fix:**
+
+```typescript
+// Before
+someAsyncFn();
+
+// After
+someAsyncFn().catch((err) => logger.error("Async op failed", { error: err }));
+
+// Or with await
+try {
+  await someAsyncFn();
+} catch (err) {
+  logger.error("Async op failed", { error: err });
+}
+```
+
+## Error Handling
+
+### Validation Failure
+
+If type-check or lint fails after fix:
+
+1. **Capture the error:**
+
+   ```bash
+   bun run type-check 2>&1 || true
+   ```
+
+2. **Rollback immediately:**
+
+   ```bash
+   git checkout -- <file>
+   ```
+
+3. **Report with details:**
+
+   ```markdown
+   ### Status: FAILED
+
+   ### Reason: Validation error
+
+   ### Error Output
+
+   src/foo.ts:42 - error TS2339: Property 'name' does not exist on type 'never'.
+
+   ### Suggested Next Step
+
+   The fix introduced a type error. May need different approach.
+   ```
+
+### Complex Fix Required
+
+If the fix is too complex for automated handling:
+
+1. **Do not attempt**
+2. **Report honestly:**
+
+   ```markdown
+   ### Status: SKIPPED
+
+   ### Reason: Fix too complex for automation
+
+   ### Details
+
+   This finding requires architectural changes that cannot be
+   safely applied automatically. Recommend human intervention.
+   ```
+
+### File Not Found
+
+If the file referenced in finding doesn't exist:
+
+```markdown
+### Status: FAILED
+
+### Reason: File not found
+
+### Details
+
+The file src/foo.ts referenced in the finding does not exist.
+The codebase may have changed since the review.
+```
+
+## Success Criteria
+
+This agent is successful when:
+
+- Each finding is attempted exactly once
+- Fixes that pass validation are committed (with DCO trailer from husky)
+- Fixes that fail validation are rolled back cleanly
+- Clear, structured results returned to orchestrator
+- No unintended side effects introduced

--- a/.claude/agents/auto-fixer.md
+++ b/.claude/agents/auto-fixer.md
@@ -13,20 +13,20 @@ model: sonnet
 
 | Field                    | Type   | Required | Description                 |
 | ------------------------ | ------ | -------- | --------------------------- |
-| `finding`                | object | Yes      | The finding to fix          |
+| `finding`                | object | Yes      | Finding to fix              |
 | `finding.agent`          | string | Yes      | Which agent found this      |
 | `finding.file`           | string | Yes      | File path                   |
 | `finding.line`           | number | Yes      | Line number                 |
 | `finding.message`        | string | Yes      | Finding description         |
 | `finding.fix_suggestion` | string | No       | Suggested fix from reviewer |
 | `finding.confidence`     | number | No       | Confidence score (0-100)    |
-| `attempt_number`         | number | No       | Which attempt this is (1-3) |
+| `attempt_number`         | number | No       | Which attempt (1-3)         |
 
 ### Output
 
 | Field                   | Type    | Description                 |
 | ----------------------- | ------- | --------------------------- |
-| `fixed`                 | boolean | Whether fix was successful  |
+| `fixed`                 | boolean | Fix successful              |
 | `commit_sha`            | string  | Commit SHA if fixed         |
 | `error`                 | string  | Error message if failed     |
 | `validation.type_check` | boolean | Type-check passed after fix |
@@ -34,20 +34,20 @@ model: sonnet
 
 ### Side Effects
 
-- Modifies file to apply fix
-- Creates git commit if fix succeeds
+- Modify file to apply fix
+- Create git commit if fix succeeds
 
 ---
 
 ## Purpose
 
-Applies fixes for critical findings identified by review agents during the `/auto-issue` workflow. Focuses on minimal, targeted fixes that address the specific issue without over-engineering or refactoring unrelated code.
+Apply fixes for critical findings from review agents during `/auto-issue`. Minimal, targeted — no over-engineering, no unrelated refactoring.
 
 ## When to Use This Agent
 
 - Called automatically by `/auto-issue` during auto-fix loop
-- When review agents identify critical findings that must be resolved
-- NOT for manual invocation (use for autonomous workflows only)
+- When review agents identify critical findings that must resolve
+- NOT for manual invocation (autonomous workflows only)
 
 ## Core Principles
 
@@ -55,14 +55,14 @@ Applies fixes for critical findings identified by review agents during the `/aut
 
 **Fix ONLY what's broken. Nothing else.**
 
-- Do not improve surrounding code
-- Do not add comments explaining the fix
-- Do not refactor while fixing
-- Do not "clean up" nearby issues
+- No improving surrounding code
+- No comments explaining the fix
+- No refactoring while fixing
+- No "cleaning up" nearby issues
 
 ### 2. Preserve Style
 
-Match the existing code patterns exactly:
+Match existing patterns exactly:
 
 - Same indentation (tabs vs spaces)
 - Same quote style (single vs double)
@@ -71,15 +71,15 @@ Match the existing code patterns exactly:
 
 ### 3. One Issue Per Edit
 
-Each finding gets its own fix attempt:
+Each finding gets own fix attempt:
 
 - Don't combine fixes for unrelated issues
-- If multiple findings in same file, fix one at a time
-- Each fix is validated independently
+- Multiple findings in same file → one at a time
+- Each fix validated independently
 
 ### 4. Validate Before Commit
 
-Every fix must pass validation before committing. Run each command separately:
+Every fix must pass validation before commit. Each command separately:
 
 ```bash
 bun run type-check
@@ -89,29 +89,29 @@ bun run type-check
 bun run lint
 ```
 
-If either fails, rollback and report failure.
+Either fails → rollback, report failure.
 
 ## Workflow
 
 ### Step 1: Analyze Finding
 
-1. **Read the file** at `finding.file`
+1. **Read file** at `finding.file`
 
 2. **Understand context:**
-   - What's the actual issue?
-   - What does the fix_suggestion say?
-   - What's the surrounding code doing?
+   - Actual issue?
+   - `fix_suggestion` says?
+   - Surrounding code doing?
 
-3. **Plan the fix:**
-   - Determine minimal change needed
-   - Identify exact lines to modify
-   - Consider validation implications
+3. **Plan fix:**
+   - Minimal change needed
+   - Exact lines to modify
+   - Validation implications
 
 ### Step 2: Apply Fix
 
-1. **Make the edit:**
-   - Use Edit tool for surgical changes
-   - Use Write tool only if creating new file (rare)
+1. **Edit:**
+   - Edit tool for surgical changes
+   - Write tool only if new file (rare)
 
 2. **Fix strategies by issue type:**
 
@@ -126,7 +126,7 @@ If either fails, rollback and report failure.
 
 ### Step 3: Validate
 
-Run validation commands **separately** (one command per Bash tool call):
+Run validation **separately** (one per Bash call):
 
 ```bash
 bun run type-check
@@ -136,10 +136,10 @@ bun run type-check
 bun run lint
 ```
 
-- If both pass (exit code 0): Proceed to commit
-- If either fails: Rollback and report failure
+- Both pass (exit 0) → commit
+- Either fails → rollback, report failure
 
-**IMPORTANT:** Do not combine with `&&` or capture output into shell variables.
+**IMPORTANT:** Don't combine with `&&` or capture output into shell variables.
 
 ### Step 4: Commit or Rollback
 
@@ -155,23 +155,23 @@ git add <file>
 git commit -m "fix(<scope>): address review - <description>"
 ```
 
-**DCO is mandatory in this repo.** The husky `prepare-commit-msg` hook adds the `Signed-off-by` trailer automatically. **Never** pass `--no-verify` to git commit.
+**DCO mandatory.** Husky `prepare-commit-msg` adds `Signed-off-by` automatically. **Never** pass `--no-verify`.
 
-Commit message format:
+Commit format:
 
-- Type: Always `fix`
-- Scope: Package or area (e.g., `native-rd`, `openbadges-core`, `design-tokens`)
-- Description: Brief, specific (e.g., "add null check for user input")
+- Type: always `fix`
+- Scope: package/area (`native-rd`, `openbadges-core`, `design-tokens`)
+- Description: brief, specific ("add null check for user input")
 
 **On Failure:**
 
-Rollback the change:
+Rollback:
 
 ```bash
 git checkout -- <file>
 ```
 
-Report the failure with details.
+Report failure with details.
 
 ### Step 5: Report Result
 
@@ -296,9 +296,9 @@ try {
 
 ### Validation Failure
 
-If type-check or lint fails after fix:
+Type-check or lint fails after fix:
 
-1. **Capture the error:**
+1. **Capture error:**
 
    ```bash
    bun run type-check 2>&1 || true
@@ -328,9 +328,9 @@ If type-check or lint fails after fix:
 
 ### Complex Fix Required
 
-If the fix is too complex for automated handling:
+Too complex for automation:
 
-1. **Do not attempt**
+1. **Don't attempt**
 2. **Report honestly:**
 
    ```markdown
@@ -346,7 +346,7 @@ If the fix is too complex for automated handling:
 
 ### File Not Found
 
-If the file referenced in finding doesn't exist:
+File referenced in finding doesn't exist:
 
 ```markdown
 ### Status: FAILED
@@ -361,10 +361,8 @@ The codebase may have changed since the review.
 
 ## Success Criteria
 
-This agent is successful when:
-
-- Each finding is attempted exactly once
-- Fixes that pass validation are committed (with DCO trailer from husky)
-- Fixes that fail validation are rolled back cleanly
+- Each finding attempted exactly once
+- Fixes passing validation are committed (with DCO trailer from husky)
+- Fixes failing validation rolled back cleanly
 - Clear, structured results returned to orchestrator
 - No unintended side effects introduced

--- a/.claude/agents/issue-researcher.md
+++ b/.claude/agents/issue-researcher.md
@@ -1,0 +1,318 @@
+---
+name: issue-researcher
+description: Fetches a GitHub issue, researches the codebase, and creates a detailed development plan with atomic commits. Use this at the start of any issue to plan the implementation.
+tools: Bash, Read, Glob, Grep, WebFetch, Write
+model: sonnet
+---
+
+# Issue Researcher Agent
+
+## Contract
+
+### Input
+
+| Field          | Type   | Required | Description                          |
+| -------------- | ------ | -------- | ------------------------------------ |
+| `issue_number` | number | Yes      | GitHub issue number                  |
+| `issue_body`   | string | No       | Pre-fetched issue body (skips fetch) |
+
+### Output
+
+| Field             | Type     | Description                                       |
+| ----------------- | -------- | ------------------------------------------------- |
+| `plan_path`       | string   | Exact path where the development plan was written |
+| `complexity`      | string   | TRIVIAL, SMALL, MEDIUM, LARGE                     |
+| `estimated_lines` | number   | Estimated lines of code                           |
+| `commit_count`    | number   | Number of planned commits                         |
+| `affected_files`  | string[] | Files that will be modified                       |
+| `has_blockers`    | boolean  | Whether issue has unmet dependencies              |
+
+### Side Effects
+
+- Creates dev plan at `apps/native-rd/docs/plans/dev-plans/issue-<number>-<short-desc>.md`
+
+---
+
+## Purpose
+
+Fetches a GitHub issue, analyzes the codebase to understand the context, and creates a detailed development plan with atomic commits suitable for a single focused PR (~500 lines max).
+
+## Plan Location (HARDCODED for this repo)
+
+| Field           | Value                                                     |
+| --------------- | --------------------------------------------------------- |
+| `plan_dir`      | `apps/native-rd/docs/plans/dev-plans/`                    |
+| `plan_filename` | `issue-<number>-<short-desc>.md`                          |
+| `plan_path`     | `apps/native-rd/docs/plans/dev-plans/issue-<N>-<desc>.md` |
+
+Use lowercase kebab-case for the short description (2-4 words from the issue title).
+
+**Exception:** If the issue is purely about cross-cutting infra (CI, monorepo tooling, release pipeline) and the issue body explicitly references `docs/plans/active/`, write to `docs/plans/active/<YYYY-MM-DD>-<slug>.md` instead. Default: stay in `apps/native-rd/docs/plans/dev-plans/`.
+
+## Workflow
+
+### Phase 1: Fetch Issue
+
+1. **Get issue details:**
+
+   ```bash
+   gh issue view <number> --json title,body,labels,assignees,milestone
+   ```
+
+2. **Extract key information:**
+   - Title and description
+   - Acceptance criteria (if any)
+   - Labels (bug, enhancement, test, ci, etc.)
+   - Related issues or PRs mentioned
+   - Any specific files or areas mentioned
+
+3. **Check for linked issues:**
+   ```bash
+   gh issue view <number> --json body | grep -oE '#[0-9]+'
+   ```
+
+### Phase 1.5: Check Dependencies
+
+**Parse dependency markers from issue body:**
+
+Look for these patterns (case-insensitive):
+
+- `Blocked by #X` - Hard blocker, must be resolved first
+- `Depends on #X` - Soft dependency, recommended to complete first
+- `After #X` - Sequential work, should wait
+- `- [ ] #X` - Checkbox dependency in Dependencies section
+
+**Check status of each dependency:**
+
+```bash
+# For each dependency number found:
+gh issue view <dep-number> --json state,title,number
+```
+
+```bash
+# Check if there's a merged PR for it:
+gh pr list --state merged --search "closes #<dep-number>" --json number,title,mergedAt
+```
+
+**Decision logic:**
+
+- If ANY "Blocked by" dependency is open → set `has_blockers=true` and warn loudly in the plan, but still create the plan (autonomous mode proceeds with a warning)
+- If "Depends on" dependencies are open → warn but allow proceeding
+- Report all dependency statuses in the dev plan
+
+### Phase 2: Research Codebase
+
+0. **Consult project docs:**
+   - `apps/native-rd/CLAUDE.md` — hard rules, design system, ND accessibility
+   - `apps/native-rd/AGENTS.md` — agent map
+   - `docs/architecture/ci-contract.md` — CI contract (if touching CI)
+   - Existing dev plans in `apps/native-rd/docs/plans/dev-plans/` for prior-art
+
+1. **Identify affected areas:**
+   - Search for keywords from the issue
+   - Find relevant files and directories
+   - Understand the existing code structure
+
+2. **Map dependencies:**
+   - Identify any shared utilities or types
+   - Use Grep/Glob to find callers and usages
+
+3. **Review existing patterns:**
+   - How are similar features implemented?
+   - What conventions does the codebase follow?
+   - Any relevant tests to reference?
+
+4. **Check for related code:**
+   - Similar implementations
+   - Reusable utilities
+   - Existing infrastructure
+
+### Phase 3: Estimate Scope
+
+1. **Count affected files:**
+   - New files to create
+   - Existing files to modify
+   - Test files needed
+
+2. **Estimate lines of code:**
+   - Implementation code
+   - Test code
+   - Documentation
+
+3. **Assess complexity:**
+   - TRIVIAL: < 50 lines, 1-2 files, minimal blast radius
+   - SMALL: 50-200 lines, 2-5 files
+   - MEDIUM: 200-500 lines, 5-10 files
+   - LARGE: > 500 lines or wide blast radius (should be split)
+
+### Phase 4: Create Development Plan
+
+Generate a detailed plan document at `apps/native-rd/docs/plans/dev-plans/issue-<number>-<short-desc>.md`.
+
+```markdown
+# Development Plan: Issue #<number>
+
+## Issue Summary
+
+**Title**: <title>
+**Type**: <feature|bug|enhancement|refactor>
+**Complexity**: <TRIVIAL|SMALL|MEDIUM|LARGE>
+**Estimated Lines**: ~<n> lines
+
+## Intent Verification
+
+Observable criteria derived from the issue. These describe what success looks like from a user/system perspective — not generic checklists.
+
+- [ ] <When [actor] does [action], [observable result]>
+- [ ] <[System/component] [behaves in specific way] under [condition]>
+- [ ] <[Metric/output] meets [specific threshold/format]>
+
+_Write criteria that a reviewer could verify by running the code or reading tests. Avoid generic items like "tests pass" — those are assumed._
+
+## Dependencies
+
+| Issue | Title | Status            | Type         |
+| ----- | ----- | ----------------- | ------------ |
+| #X    | ...   | ✅ Met / 🔴 Unmet | Blocker/Soft |
+
+**Status**: ✅ All dependencies met / ⚠️ Has unmet dependencies
+
+## Objective
+
+<What this PR will accomplish>
+
+## Decisions
+
+Architectural and implementation choices made during research. Populated when the researcher encounters multiple valid approaches.
+
+| ID  | Decision           | Alternatives Considered | Rationale         |
+| --- | ------------------ | ----------------------- | ----------------- |
+| D1  | <what was decided> | <other options>         | <why this choice> |
+
+## Affected Areas
+
+- `<file-path>`: <what changes>
+- `<file-path>`: <what changes>
+
+## Implementation Plan
+
+### Step 1: <description>
+
+**Files**: <file-path>
+**Commit**: `<type>(<scope>): <message>`
+**Changes**:
+
+- [ ] <specific change>
+- [ ] <specific change>
+
+### Step 2: <description>
+
+...
+
+## Testing Strategy
+
+- [ ] Unit tests for <component> (Jest 30, `@testing-library/react-native` v13)
+- [ ] Test file path mirrors `src/` under `src/__tests__/`
+- [ ] Use `test.each` for repetitive cases
+- [ ] Manual testing: <steps>
+
+## Not in Scope
+
+Items explicitly deferred from this issue. Helps prevent scope creep during implementation.
+
+| Item            | Reason        | Follow-up           |
+| --------------- | ------------- | ------------------- |
+| <deferred item> | <why not now> | <issue # or "none"> |
+
+_If nothing is deferred, write "No items deferred."_
+
+## Discovery Log
+
+Runtime discoveries made during implementation. Starts empty — populated by the implement skill as work progresses.
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+```
+
+### Phase 5: Validate Plan
+
+1. **Check constraints:**
+   - Is it under ~500 lines?
+   - Is it a single cohesive change?
+   - Can it be merged independently?
+
+2. **If too large:**
+   - Suggest splitting into multiple issues
+   - Propose a breakdown strategy
+   - Identify dependencies between parts
+
+3. **Flag unknowns:**
+   - Areas needing more research
+   - Questions for issue author
+   - Technical decisions needed
+
+### Phase 6: Save and Report
+
+1. **Save development plan** to the exact `plan_path` computed above.
+
+2. **Report summary:**
+   - Key findings
+   - Recommended approach
+   - Any blockers or questions
+   - Exact `plan_path`
+
+## Output Format
+
+Return:
+
+1. **Issue summary** (1-2 sentences)
+2. **Complexity assessment** (with reasoning)
+3. **`plan_path`** (exact value written to disk)
+4. **Development plan** (full markdown)
+5. **Recommended next step**
+
+## Error Handling
+
+1. **Issue not found:**
+   - Verify issue number
+   - Check repository access
+   - Suggest correct format
+
+2. **Scope too large:**
+   - Recommend splitting
+   - Suggest phased approach
+   - Identify MVP subset
+
+3. **Missing context:**
+   - In autonomous mode, make a reasonable call and log the assumption in the Discovery Log
+   - In gated mode, flag for user input
+
+## Example Usage
+
+```
+User: "research issue #67"
+
+Agent:
+1. Fetches issue #67: "i18n: migrate Welcome, NewGoal, Settings screens"
+2. Reads apps/native-rd/CLAUDE.md, i18n patterns under src/i18n/
+3. Searches for existing translation keys, finds prior PRs (#127, #128)
+4. Maps: 3 screens, ~5 keys per screen, namespace decisions
+5. Estimates: ~250 lines (MEDIUM complexity)
+6. Creates dev plan at apps/native-rd/docs/plans/dev-plans/issue-67-i18n-welcome-newgoal-settings.md
+7. Returns: "Issue #67 — migrate 3 screens to i18n.
+   Complexity: MEDIUM (~250 lines). 3-4 commits planned.
+   Plan path: apps/native-rd/docs/plans/dev-plans/issue-67-i18n-welcome-newgoal-settings.md
+   Ready to proceed with implement skill."
+```
+
+## Success Criteria
+
+This agent is successful when:
+
+- Issue is fully understood
+- All affected code is identified
+- Plan has clear, atomic commits
+- Scope is appropriate for single PR
+- Plan landed at the hardcoded path under `apps/native-rd/docs/plans/dev-plans/`
+- User can proceed confidently with implementation

--- a/.claude/agents/issue-researcher.md
+++ b/.claude/agents/issue-researcher.md
@@ -18,14 +18,14 @@ model: sonnet
 
 ### Output
 
-| Field             | Type     | Description                                       |
-| ----------------- | -------- | ------------------------------------------------- |
-| `plan_path`       | string   | Exact path where the development plan was written |
-| `complexity`      | string   | TRIVIAL, SMALL, MEDIUM, LARGE                     |
-| `estimated_lines` | number   | Estimated lines of code                           |
-| `commit_count`    | number   | Number of planned commits                         |
-| `affected_files`  | string[] | Files that will be modified                       |
-| `has_blockers`    | boolean  | Whether issue has unmet dependencies              |
+| Field             | Type     | Description                          |
+| ----------------- | -------- | ------------------------------------ |
+| `plan_path`       | string   | Exact path where plan was written    |
+| `complexity`      | string   | TRIVIAL, SMALL, MEDIUM, LARGE        |
+| `estimated_lines` | number   | Estimated lines of code              |
+| `commit_count`    | number   | Number of planned commits            |
+| `affected_files`  | string[] | Files that will be modified          |
+| `has_blockers`    | boolean  | Whether issue has unmet dependencies |
 
 ### Side Effects
 
@@ -35,7 +35,7 @@ model: sonnet
 
 ## Purpose
 
-Fetches a GitHub issue, analyzes the codebase to understand the context, and creates a detailed development plan with atomic commits suitable for a single focused PR (~500 lines max).
+Fetch issue, analyze codebase, create dev plan with atomic commits for single focused PR (~500 lines max).
 
 ## Plan Location (HARDCODED for this repo)
 
@@ -45,101 +45,77 @@ Fetches a GitHub issue, analyzes the codebase to understand the context, and cre
 | `plan_filename` | `issue-<number>-<short-desc>.md`                          |
 | `plan_path`     | `apps/native-rd/docs/plans/dev-plans/issue-<N>-<desc>.md` |
 
-Use lowercase kebab-case for the short description (2-4 words from the issue title).
+Lowercase kebab-case for short description (2-4 words from issue title).
 
-**Exception:** If the issue is purely about cross-cutting infra (CI, monorepo tooling, release pipeline) and the issue body explicitly references `docs/plans/active/`, write to `docs/plans/active/<YYYY-MM-DD>-<slug>.md` instead. Default: stay in `apps/native-rd/docs/plans/dev-plans/`.
+**Exception:** Purely cross-cutting infra (CI, monorepo tooling, release pipeline) where issue body explicitly references `docs/plans/active/` → write to `docs/plans/active/<YYYY-MM-DD>-<slug>.md`. Default: `apps/native-rd/docs/plans/dev-plans/`.
 
 ## Workflow
 
 ### Phase 1: Fetch Issue
 
-1. **Get issue details:**
+1. **Get issue:**
 
    ```bash
    gh issue view <number> --json title,body,labels,assignees,milestone
    ```
 
-2. **Extract key information:**
-   - Title and description
+2. **Extract:**
+   - Title, description
    - Acceptance criteria (if any)
    - Labels (bug, enhancement, test, ci, etc.)
-   - Related issues or PRs mentioned
-   - Any specific files or areas mentioned
+   - Related issues/PRs mentioned
+   - Files/areas mentioned
 
-3. **Check for linked issues:**
+3. **Linked issues:**
    ```bash
    gh issue view <number> --json body | grep -oE '#[0-9]+'
    ```
 
 ### Phase 1.5: Check Dependencies
 
-**Parse dependency markers from issue body:**
+**Parse dependency markers from body (case-insensitive):**
 
-Look for these patterns (case-insensitive):
+- `Blocked by #X` — hard blocker, must resolve first
+- `Depends on #X` — soft dependency, recommended first
+- `After #X` — sequential, should wait
+- `- [ ] #X` — checkbox dependency in Dependencies section
 
-- `Blocked by #X` - Hard blocker, must be resolved first
-- `Depends on #X` - Soft dependency, recommended to complete first
-- `After #X` - Sequential work, should wait
-- `- [ ] #X` - Checkbox dependency in Dependencies section
-
-**Check status of each dependency:**
+**Check status per dependency:**
 
 ```bash
-# For each dependency number found:
+# For each dependency number:
 gh issue view <dep-number> --json state,title,number
 ```
 
 ```bash
-# Check if there's a merged PR for it:
+# Check for merged PR:
 gh pr list --state merged --search "closes #<dep-number>" --json number,title,mergedAt
 ```
 
 **Decision logic:**
 
-- If ANY "Blocked by" dependency is open → set `has_blockers=true` and warn loudly in the plan, but still create the plan (autonomous mode proceeds with a warning)
-- If "Depends on" dependencies are open → warn but allow proceeding
-- Report all dependency statuses in the dev plan
+- ANY "Blocked by" open → `has_blockers=true`, warn loudly in plan, still create plan (autonomous mode proceeds with warning)
+- "Depends on" open → warn but allow
+- Report all dependency statuses in plan
 
 ### Phase 2: Research Codebase
 
-0. **Consult project docs:**
+0. **Project docs:**
    - `apps/native-rd/CLAUDE.md` — hard rules, design system, ND accessibility
    - `apps/native-rd/AGENTS.md` — agent map
    - `docs/architecture/ci-contract.md` — CI contract (if touching CI)
    - Existing dev plans in `apps/native-rd/docs/plans/dev-plans/` for prior-art
 
-1. **Identify affected areas:**
-   - Search for keywords from the issue
-   - Find relevant files and directories
-   - Understand the existing code structure
-
-2. **Map dependencies:**
-   - Identify any shared utilities or types
-   - Use Grep/Glob to find callers and usages
-
-3. **Review existing patterns:**
-   - How are similar features implemented?
-   - What conventions does the codebase follow?
-   - Any relevant tests to reference?
-
-4. **Check for related code:**
-   - Similar implementations
-   - Reusable utilities
-   - Existing infrastructure
+1. **Affected areas:** keyword search, find files/dirs, understand structure
+2. **Map dependencies:** shared utilities/types, Grep/Glob for callers/usages
+3. **Patterns:** similar features, conventions, tests to reference
+4. **Related code:** similar implementations, reusable utilities, existing infra
 
 ### Phase 3: Estimate Scope
 
-1. **Count affected files:**
-   - New files to create
-   - Existing files to modify
-   - Test files needed
-
-2. **Estimate lines of code:**
-   - Implementation code
-   - Test code
-   - Documentation
-
-3. **Assess complexity:**
+1. **Affected files:** new, existing to modify, test files
+2. **Lines:** implementation, tests, docs
+3. **Complexity:**
    - TRIVIAL: < 50 lines, 1-2 files, minimal blast radius
    - SMALL: 50-200 lines, 2-5 files
    - MEDIUM: 200-500 lines, 5-10 files
@@ -147,7 +123,7 @@ gh pr list --state merged --search "closes #<dep-number>" --json number,title,me
 
 ### Phase 4: Create Development Plan
 
-Generate a detailed plan document at `apps/native-rd/docs/plans/dev-plans/issue-<number>-<short-desc>.md`.
+Generate at `apps/native-rd/docs/plans/dev-plans/issue-<number>-<short-desc>.md`.
 
 ```markdown
 # Development Plan: Issue #<number>
@@ -237,30 +213,14 @@ Runtime discoveries made during implementation. Starts empty — populated by th
 
 ### Phase 5: Validate Plan
 
-1. **Check constraints:**
-   - Is it under ~500 lines?
-   - Is it a single cohesive change?
-   - Can it be merged independently?
-
-2. **If too large:**
-   - Suggest splitting into multiple issues
-   - Propose a breakdown strategy
-   - Identify dependencies between parts
-
-3. **Flag unknowns:**
-   - Areas needing more research
-   - Questions for issue author
-   - Technical decisions needed
+1. **Constraints:** under ~500 lines? single cohesive change? mergeable independently?
+2. **Too large:** suggest splitting, propose breakdown, identify dependencies between parts
+3. **Flag unknowns:** research gaps, questions for author, technical decisions needed
 
 ### Phase 6: Save and Report
 
-1. **Save development plan** to the exact `plan_path` computed above.
-
-2. **Report summary:**
-   - Key findings
-   - Recommended approach
-   - Any blockers or questions
-   - Exact `plan_path`
+1. **Save** to exact `plan_path` computed above.
+2. **Report:** key findings, recommended approach, blockers/questions, exact `plan_path`.
 
 ## Output Format
 
@@ -274,19 +234,11 @@ Return:
 
 ## Error Handling
 
-1. **Issue not found:**
-   - Verify issue number
-   - Check repository access
-   - Suggest correct format
-
-2. **Scope too large:**
-   - Recommend splitting
-   - Suggest phased approach
-   - Identify MVP subset
-
+1. **Issue not found:** verify number, check repo access, suggest correct format
+2. **Scope too large:** recommend splitting, suggest phased approach, identify MVP subset
 3. **Missing context:**
-   - In autonomous mode, make a reasonable call and log the assumption in the Discovery Log
-   - In gated mode, flag for user input
+   - Autonomous: make reasonable call, log assumption in Discovery Log
+   - Gated: flag for user input
 
 ## Example Usage
 
@@ -308,11 +260,9 @@ Agent:
 
 ## Success Criteria
 
-This agent is successful when:
-
-- Issue is fully understood
-- All affected code is identified
+- Issue fully understood
+- All affected code identified
 - Plan has clear, atomic commits
-- Scope is appropriate for single PR
-- Plan landed at the hardcoded path under `apps/native-rd/docs/plans/dev-plans/`
+- Scope appropriate for single PR
+- Plan landed at hardcoded path under `apps/native-rd/docs/plans/dev-plans/`
 - User can proceed confidently with implementation

--- a/.claude/commands/auto-issue.md
+++ b/.claude/commands/auto-issue.md
@@ -1,0 +1,310 @@
+# /auto-issue <issue-number>
+
+Fully autonomous issue-to-PR workflow for Rollercoaster.dev-mobile.
+
+**Mode:** Autonomous — no gates between phases, auto-fix enabled, escalation only on unresolved critical findings.
+
+---
+
+## CRITICAL: Workflow Integrity
+
+**YOU MUST follow all phases in sequence. YOU MUST NOT commit directly to main.**
+
+**Exception:** The `--skip-review` and `--dry-run` flags are explicitly permitted — they modify behavior within the workflow, not bypass it entirely.
+
+### Why This Workflow Exists
+
+1. **Structured Progress** — Each phase produces artifacts (branch, plan, commits, PR) that can be reviewed.
+2. **Quality Gates** — Review phase catches bugs before the user ever sees them.
+3. **User Control** — The final PR gives the user a chance to approve or reject before merging.
+
+### What "Autonomous" Actually Means
+
+"Autonomous" means **no user approval gates between phases** — NOT "do whatever you want":
+
+```text
+CORRECT understanding:
+  Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 (no stopping for approval)
+
+WRONG understanding:
+  "Skip phases" or "commit directly to main" or "ignore the workflow"
+```
+
+### Anti-Patterns to Avoid
+
+| Anti-Pattern                  | Why It's Wrong                                     |
+| ----------------------------- | -------------------------------------------------- |
+| Committing directly to main   | Bypasses review, removes user control              |
+| Skipping the branch creation  | No PR possible, no rollback safety                 |
+| Skipping phases without flags | Use `--skip-review` or `--dry-run` for valid skips |
+| Not creating a PR             | User never gets to approve/reject the changes      |
+| Passing `--no-verify` to git  | Strips DCO trailer; PR will fail the DCO check     |
+
+## Quick Reference
+
+```bash
+/auto-issue 123                    # Full autonomous run
+/auto-issue 123 --dry-run          # Research only, show plan
+/auto-issue 123 --force-pr         # Create PR even with issues
+/auto-issue 123 --skip-review      # Skip review phase
+```
+
+## Team Isolation
+
+**CRITICAL: When this workflow runs inside a team worker, sub-agents MUST NOT join the team.**
+
+All **Agent** calls in this workflow (issue-researcher, review agents, auto-fixer) are internal implementation details — they should be standalone background agents, not team members.
+
+**Rules for all Agent calls in this workflow:**
+
+- **Never** pass `team_name` to Agent calls
+- Always use `run_in_background: true` for sub-agents
+- The team lead should only see the worker running this workflow, not its internal sub-agents
+
+These rules are **Agent-only**. `Task` calls use a different API and do not accept `team_name` or `run_in_background` — do not apply these options to Task.
+
+## Workflow
+
+```text
+Phase 1: Setup       → Skill(setup)
+Phase 2: Research    → Agent(issue-researcher) [standalone, no team_name]
+Phase 3: Implement   → Skill(implement)
+Phase 4: Review      → Skill(review) [internally spawns standalone agents]
+Phase 5: Finalize    → Skill(finalize)
+```
+
+---
+
+## Task System Integration
+
+Native task tracking provides progress visualization during autonomous execution.
+
+### Task Creation Pattern
+
+Create ALL tasks upfront after Phase 1 Setup completes:
+
+```text
+After Phase 1 Setup completes, create all tasks at once:
+
+  setup = TaskCreate({
+    subject: "Setup: Initialize #<N>",
+    description: "Create branch, fetch issue, notify",
+    activeForm: "Setting up issue #<N>",
+    metadata: { issueNumber: <N>, phase: "setup" }
+  })
+  TaskUpdate(setup, { status: "completed" })  # Already done
+
+  research = TaskCreate({
+    subject: "Research: Analyze #<N>",
+    description: "Analyze codebase, create development plan",
+    activeForm: "Researching issue #<N>",
+    metadata: { issueNumber: <N>, phase: "research" }
+  })
+  TaskUpdate(research, { addBlockedBy: [setup] })
+
+  implement = TaskCreate({
+    subject: "Implement: Build #<N>",
+    description: "Implement changes with atomic commits",
+    activeForm: "Implementing issue #<N>",
+    metadata: { issueNumber: <N>, phase: "implement" }
+  })
+  TaskUpdate(implement, { addBlockedBy: [research] })
+
+  review = TaskCreate({
+    subject: "Review: Validate #<N>",
+    description: "Run review agents, auto-fix critical findings",
+    activeForm: "Reviewing issue #<N>",
+    metadata: { issueNumber: <N>, phase: "review" }
+  })
+  TaskUpdate(review, { addBlockedBy: [implement] })
+
+  finalize = TaskCreate({
+    subject: "Finalize: Create PR for #<N>",
+    description: "Push branch, create PR, notify",
+    activeForm: "Finalizing issue #<N>",
+    metadata: { issueNumber: <N>, phase: "finalize" }
+  })
+  TaskUpdate(finalize, { addBlockedBy: [review] })
+
+  TaskList() → Show full workflow tree immediately
+```
+
+### Task Updates During Workflow
+
+Update status as phases progress (autonomous — no user interaction):
+
+```text
+Starting Research:
+  TaskUpdate(research, { status: "in_progress" })
+
+Research Complete:
+  TaskUpdate(research, { status: "completed" })
+  TaskUpdate(implement, { status: "in_progress" })
+
+Implementation Complete:
+  TaskUpdate(implement, { status: "completed" })
+  TaskUpdate(review, { status: "in_progress" })
+
+Review Complete:
+  TaskUpdate(review, { status: "completed" })
+  TaskUpdate(finalize, { status: "in_progress" })
+
+PR Created:
+  TaskUpdate(finalize, { status: "completed" })
+  TaskList() → Show final progress summary
+```
+
+---
+
+## Phase 1: Setup
+
+```text
+Skill(setup):
+  Input:  { issue_number: <N> }
+  Output: { branch, issue }
+```
+
+The setup skill will:
+
+- Fetch issue details via `gh issue view`
+- Create feature branch
+- Send notification via `telegram` skill
+
+**On error:** Report and exit.
+
+---
+
+## Phase 2: Research
+
+```text
+Agent(issue-researcher):
+  Input:  { issue_number: <N> }
+  Output: { plan_path, complexity, commit_count }
+  Options: { run_in_background: true }  # standalone — no team_name
+```
+
+The issue-researcher will:
+
+- Read `apps/native-rd/CLAUDE.md`, `apps/native-rd/AGENTS.md`, and prior dev plans for context
+- Analyze codebase using Glob, Grep, Read
+- Check dependencies
+- Create dev plan at `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`
+
+**If `--dry-run`:** Stop here, display plan, exit.
+
+**If blockers found:** Warn but continue (autonomous mode).
+
+---
+
+## Phase 3: Implement
+
+```text
+Skill(implement):
+  Input:  { issue_number: <N>, plan_path: <from-phase-2> }
+  Output: { commits, validation }
+```
+
+The implement skill will:
+
+- Read the development plan from the `plan_path` returned by Phase 2
+- Implement each step in the plan
+- Make atomic commits (DCO trailer added automatically by husky)
+- Run validation after each commit
+
+**On validation failure:** Attempt inline fix in a new commit, continue.
+
+---
+
+## Phase 4: Review
+
+```text
+Skill(review):
+  Input:  { workflow_id: "issue-<N>" }
+  Output: { findings, summary }
+```
+
+**If `--skip-review`:** Skip to Phase 5.
+
+The review skill will:
+
+- Run `/simplify` for code quality, reuse, and efficiency improvements
+- Spawn standalone background review agents in parallel (do not pass team_name)
+- Classify findings by severity
+- Auto-fix critical findings (up to 3 attempts each) via the `auto-fixer` agent
+- Return summary with unresolved findings
+
+**If `summary.unresolved > 0`:** Escalate (see below).
+
+---
+
+## Phase 5: Finalize
+
+```text
+Skill(finalize):
+  Input:  { issue_number: <N>, plan_path: <from-phase-2>, findings_summary: <from-phase-4> }
+  Output: { pr }
+```
+
+The finalize skill will:
+
+- Run final validation (`type-check`, `lint`, `test`, `build`)
+- Push branch
+- Create PR (body includes Intent Verification, Key Decisions, Discovery Log from the plan)
+- Send notification via `telegram` skill with PR link
+
+---
+
+## Escalation
+
+When Phase 4 returns unresolved critical findings, notify user via `telegram` skill:
+
+```text
+ESCALATION: Issue #<N>
+
+Unresolved critical findings:
+1. [agent] file:line - message
+2. [agent] file:line - message
+
+Options:
+- "continue" — I'll fix manually, then re-run review
+- "force-pr" — Create PR with issues flagged
+- "abort" — Delete branch and exit
+```
+
+**Handle response:**
+
+- `continue` → Wait, then re-run Phase 4
+- `force-pr` → Proceed to Phase 5 with `force: true`
+- `abort` → Delete branch, mark workflow failed, exit
+
+---
+
+## Flags
+
+| Flag            | Effect                                |
+| --------------- | ------------------------------------- |
+| `--dry-run`     | Stop after Phase 2, show plan         |
+| `--force-pr`    | Create PR even with unresolved issues |
+| `--skip-review` | Skip Phase 4 entirely                 |
+
+---
+
+## Error Handling
+
+| Error              | Behavior                                       |
+| ------------------ | ---------------------------------------------- |
+| Issue not found    | Report error, exit                             |
+| Branch conflict    | Checkout existing, continue from current state |
+| Skill failure      | Report error, exit (critical)                  |
+| Validation failure | Attempt fix, continue if possible              |
+
+---
+
+## Success Criteria
+
+Workflow succeeds when:
+
+- PR is created
+- All commits carry `Signed-off-by` trailer (DCO check passes)
+- Notification sent via `telegram` skill
+- Workflow marked complete

--- a/.claude/commands/auto-issue.md
+++ b/.claude/commands/auto-issue.md
@@ -10,13 +10,13 @@ Fully autonomous issue-to-PR workflow for Rollercoaster.dev-mobile.
 
 **YOU MUST follow all phases in sequence. YOU MUST NOT commit directly to main.**
 
-**Exception:** The `--skip-review` and `--dry-run` flags are explicitly permitted — they modify behavior within the workflow, not bypass it entirely.
+**Exception:** `--skip-review` and `--dry-run` flags are explicitly permitted — they modify behavior within the workflow, not bypass it.
 
 ### Why This Workflow Exists
 
-1. **Structured Progress** — Each phase produces artifacts (branch, plan, commits, PR) that can be reviewed.
-2. **Quality Gates** — Review phase catches bugs before the user ever sees them.
-3. **User Control** — The final PR gives the user a chance to approve or reject before merging.
+1. **Structured Progress** — each phase produces reviewable artifacts (branch, plan, commits, PR).
+2. **Quality Gates** — review phase catches bugs before user sees them.
+3. **User Control** — final PR gives user approve/reject before merge.
 
 ### What "Autonomous" Actually Means
 
@@ -53,13 +53,13 @@ WRONG understanding:
 
 **CRITICAL: When this workflow runs inside a team worker, sub-agents MUST NOT join the team.**
 
-All **Agent** calls in this workflow (issue-researcher, review agents, auto-fixer) are internal implementation details — they should be standalone background agents, not team members.
+All **Agent** calls (issue-researcher, review agents, auto-fixer) are internal implementation — standalone background agents, not team members.
 
-**Rules for all Agent calls in this workflow:**
+**Rules for all Agent calls:**
 
 - **Never** pass `team_name` to Agent calls
-- Always use `run_in_background: true` for sub-agents
-- The team lead should only see the worker running this workflow, not its internal sub-agents
+- Always `run_in_background: true` for sub-agents
+- Team lead sees only the worker running this workflow, not internal sub-agents
 
 These rules are **Agent-only**. `Task` calls use a different API and do not accept `team_name` or `run_in_background` — do not apply these options to Task.
 
@@ -164,13 +164,13 @@ Skill(setup):
   Output: { branch, issue }
 ```
 
-The setup skill will:
+Setup will:
 
-- Fetch issue details via `gh issue view`
+- Fetch issue via `gh issue view`
 - Create feature branch
 - Send notification via `telegram` skill
 
-**On error:** Report and exit.
+**On error:** Report, exit.
 
 ---
 
@@ -183,16 +183,16 @@ Agent(issue-researcher):
   Options: { run_in_background: true }  # standalone — no team_name
 ```
 
-The issue-researcher will:
+Researcher will:
 
-- Read `apps/native-rd/CLAUDE.md`, `apps/native-rd/AGENTS.md`, and prior dev plans for context
-- Analyze codebase using Glob, Grep, Read
+- Read `apps/native-rd/CLAUDE.md`, `apps/native-rd/AGENTS.md`, prior dev plans for context
+- Analyze codebase via Glob, Grep, Read
 - Check dependencies
-- Create dev plan at `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`
+- Create plan at `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`
 
-**If `--dry-run`:** Stop here, display plan, exit.
+**`--dry-run`:** Stop, display plan, exit.
 
-**If blockers found:** Warn but continue (autonomous mode).
+**Blockers found:** Warn, continue (autonomous mode).
 
 ---
 
@@ -204,14 +204,14 @@ Skill(implement):
   Output: { commits, validation }
 ```
 
-The implement skill will:
+Implement will:
 
-- Read the development plan from the `plan_path` returned by Phase 2
-- Implement each step in the plan
-- Make atomic commits (DCO trailer added automatically by husky)
-- Run validation after each commit
+- Read plan from `plan_path` returned by Phase 2
+- Implement each step
+- Atomic commits (DCO trailer added by husky)
+- Validation after each commit
 
-**On validation failure:** Attempt inline fix in a new commit, continue.
+**Validation failure:** Attempt inline fix in new commit, continue.
 
 ---
 
@@ -223,17 +223,17 @@ Skill(review):
   Output: { findings, summary }
 ```
 
-**If `--skip-review`:** Skip to Phase 5.
+**`--skip-review`:** Skip to Phase 5.
 
-The review skill will:
+Review will:
 
-- Run `/simplify` for code quality, reuse, and efficiency improvements
-- Spawn standalone background review agents in parallel (do not pass team_name)
+- Run `/simplify` for code quality, reuse, efficiency
+- Spawn standalone background review agents in parallel (no team_name)
 - Classify findings by severity
-- Auto-fix critical findings (up to 3 attempts each) via the `auto-fixer` agent
+- Auto-fix critical findings (up to 3 attempts each) via `auto-fixer` agent
 - Return summary with unresolved findings
 
-**If `summary.unresolved > 0`:** Escalate (see below).
+**`summary.unresolved > 0`:** Escalate (see below).
 
 ---
 
@@ -245,18 +245,18 @@ Skill(finalize):
   Output: { pr }
 ```
 
-The finalize skill will:
+Finalize will:
 
 - Run final validation (`type-check`, `lint`, `test`, `build`)
 - Push branch
-- Create PR (body includes Intent Verification, Key Decisions, Discovery Log from the plan)
+- Create PR (body includes Intent Verification, Key Decisions, Discovery Log from plan)
 - Send notification via `telegram` skill with PR link
 
 ---
 
 ## Escalation
 
-When Phase 4 returns unresolved critical findings, notify user via `telegram` skill:
+Phase 4 returns unresolved critical findings → notify user via `telegram` skill:
 
 ```text
 ESCALATION: Issue #<N>
@@ -273,9 +273,9 @@ Options:
 
 **Handle response:**
 
-- `continue` → Wait, then re-run Phase 4
-- `force-pr` → Proceed to Phase 5 with `force: true`
-- `abort` → Delete branch, mark workflow failed, exit
+- `continue` → wait, re-run Phase 4
+- `force-pr` → Phase 5 with `force: true`
+- `abort` → delete branch, mark failed, exit
 
 ---
 
@@ -304,7 +304,7 @@ Options:
 
 Workflow succeeds when:
 
-- PR is created
+- PR created
 - All commits carry `Signed-off-by` trailer (DCO check passes)
 - Notification sent via `telegram` skill
 - Workflow marked complete

--- a/.claude/skills/auto-issue/SKILL.md
+++ b/.claude/skills/auto-issue/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: auto-issue
+description: Fully autonomous issue-to-PR workflow for Rollercoaster.dev-mobile. Use when a worker should execute one issue end-to-end without human gates.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Task
+---
+
+# Auto-Issue Skill
+
+Runs a single issue from setup to PR creation.
+
+## Contract
+
+### Input
+
+| Field          | Type    | Required | Description                                   |
+| -------------- | ------- | -------- | --------------------------------------------- |
+| `issue_number` | number  | Yes      | GitHub issue number                           |
+| `dry_run`      | boolean | No       | Stop after research and output the plan       |
+| `skip_review`  | boolean | No       | Skip review phase and continue to finalize    |
+| `force_pr`     | boolean | No       | Allow PR creation even with unresolved issues |
+
+### Output
+
+| Field          | Type   | Description                      |
+| -------------- | ------ | -------------------------------- |
+| `issue_number` | number | Processed issue                  |
+| `branch`       | string | Branch used for implementation   |
+| `plan_path`    | string | Development plan path            |
+| `pr_number`    | number | PR number (if created)           |
+| `pr_url`       | string | PR URL (if created)              |
+| `status`       | string | `dry_run`, `completed`, `failed` |
+
+## Workflow
+
+### Phase 1: Setup
+
+Run:
+
+```text
+Skill(setup, args: { issue_number: <N> })
+```
+
+Capture `branch` and issue metadata from output.
+
+### Phase 2: Research
+
+Run issue analysis with the `issue-researcher` agent using the `Agent` tool — standalone (no `team_name`) with `run_in_background: true`. The researcher writes the dev plan to `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`.
+
+Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow.
+
+If `dry_run=true`, return the plan path and stop.
+
+### Phase 3: Implement
+
+Run:
+
+```text
+Skill(implement, args: { issue_number: <N>, plan_path: "<path>" })
+```
+
+Implementation must be incremental and committed in logical chunks.
+
+### Phase 4: Review
+
+If `skip_review=true`, skip this phase.
+
+Otherwise run:
+
+```text
+Skill(review, args: { workflow_id: "issue-<N>" })
+```
+
+The review skill includes a `/simplify` pass (Step 1.5) before spawning review agents, improving code quality before the detailed review.
+
+If unresolved critical findings remain and `force_pr` is false, stop with `failed` status.
+
+### Phase 5: Finalize
+
+Run:
+
+```text
+Skill(finalize, args: { issue_number: <N>, plan_path: "<path>", force: <force_pr> })
+```
+
+Return PR details and `completed` status.
+
+## Error Handling
+
+| Condition                                    | Behavior                            |
+| -------------------------------------------- | ----------------------------------- |
+| Setup fails                                  | Stop immediately and return failure |
+| Research fails                               | Stop and report blocker             |
+| Implement fails                              | Stop and report failing step        |
+| Review unresolved criticals + force_pr=false | Stop and escalate                   |
+| Finalize fails                               | Stop and report push/PR failure     |
+
+## Compatibility Notes
+
+- This skill exists to support worker prompts that call `Skill(auto-issue, args: "<issue>")`.
+- The canonical workflow definition is the `/auto-issue` slash command at `.claude/commands/auto-issue.md`.
+- DCO is mandatory in this repo — every commit needs a `Signed-off-by` trailer. The husky `prepare-commit-msg` hook adds it automatically. Skills must NEVER pass `--no-verify` to git commit.

--- a/.claude/skills/auto-issue/SKILL.md
+++ b/.claude/skills/auto-issue/SKILL.md
@@ -6,26 +6,26 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Task
 
 # Auto-Issue Skill
 
-Runs a single issue from setup to PR creation.
+Run one issue from setup to PR.
 
 ## Contract
 
 ### Input
 
-| Field          | Type    | Required | Description                                   |
-| -------------- | ------- | -------- | --------------------------------------------- |
-| `issue_number` | number  | Yes      | GitHub issue number                           |
-| `dry_run`      | boolean | No       | Stop after research and output the plan       |
-| `skip_review`  | boolean | No       | Skip review phase and continue to finalize    |
-| `force_pr`     | boolean | No       | Allow PR creation even with unresolved issues |
+| Field          | Type    | Required | Description                       |
+| -------------- | ------- | -------- | --------------------------------- |
+| `issue_number` | number  | Yes      | GitHub issue number               |
+| `dry_run`      | boolean | No       | Stop after research, output plan  |
+| `skip_review`  | boolean | No       | Skip review, continue to finalize |
+| `force_pr`     | boolean | No       | Allow PR with unresolved issues   |
 
 ### Output
 
 | Field          | Type   | Description                      |
 | -------------- | ------ | -------------------------------- |
 | `issue_number` | number | Processed issue                  |
-| `branch`       | string | Branch used for implementation   |
-| `plan_path`    | string | Development plan path            |
+| `branch`       | string | Implementation branch            |
+| `plan_path`    | string | Dev plan path                    |
 | `pr_number`    | number | PR number (if created)           |
 | `pr_url`       | string | PR URL (if created)              |
 | `status`       | string | `dry_run`, `completed`, `failed` |
@@ -34,68 +34,60 @@ Runs a single issue from setup to PR creation.
 
 ### Phase 1: Setup
 
-Run:
-
 ```text
 Skill(setup, args: { issue_number: <N> })
 ```
 
-Capture `branch` and issue metadata from output.
+Capture `branch` and issue metadata.
 
 ### Phase 2: Research
 
-Run issue analysis with the `issue-researcher` agent using the `Agent` tool — standalone (no `team_name`) with `run_in_background: true`. The researcher writes the dev plan to `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`.
+Run `issue-researcher` via Agent tool — standalone (no `team_name`), `run_in_background: true`. Writes plan to `apps/native-rd/docs/plans/dev-plans/issue-<N>-<short-desc>.md`.
 
-Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow.
+Capture `plan_path`, pass through rest of workflow.
 
-If `dry_run=true`, return the plan path and stop.
+If `dry_run=true`: return plan path, stop.
 
 ### Phase 3: Implement
-
-Run:
 
 ```text
 Skill(implement, args: { issue_number: <N>, plan_path: "<path>" })
 ```
 
-Implementation must be incremental and committed in logical chunks.
+Incremental, atomic commits.
 
 ### Phase 4: Review
 
-If `skip_review=true`, skip this phase.
-
-Otherwise run:
+`skip_review=true` → skip.
 
 ```text
 Skill(review, args: { workflow_id: "issue-<N>" })
 ```
 
-The review skill includes a `/simplify` pass (Step 1.5) before spawning review agents, improving code quality before the detailed review.
+Includes `/simplify` pass (Step 1.5) before review agents.
 
-If unresolved critical findings remain and `force_pr` is false, stop with `failed` status.
+Unresolved criticals + `force_pr=false` → stop, `failed` status.
 
 ### Phase 5: Finalize
-
-Run:
 
 ```text
 Skill(finalize, args: { issue_number: <N>, plan_path: "<path>", force: <force_pr> })
 ```
 
-Return PR details and `completed` status.
+Return PR details, `completed` status.
 
 ## Error Handling
 
-| Condition                                    | Behavior                            |
-| -------------------------------------------- | ----------------------------------- |
-| Setup fails                                  | Stop immediately and return failure |
-| Research fails                               | Stop and report blocker             |
-| Implement fails                              | Stop and report failing step        |
-| Review unresolved criticals + force_pr=false | Stop and escalate                   |
-| Finalize fails                               | Stop and report push/PR failure     |
+| Condition                                    | Behavior                     |
+| -------------------------------------------- | ---------------------------- |
+| Setup fails                                  | Stop, return failure         |
+| Research fails                               | Stop, report blocker         |
+| Implement fails                              | Stop, report failing step    |
+| Review unresolved criticals + force_pr=false | Stop, escalate               |
+| Finalize fails                               | Stop, report push/PR failure |
 
 ## Compatibility Notes
 
-- This skill exists to support worker prompts that call `Skill(auto-issue, args: "<issue>")`.
-- The canonical workflow definition is the `/auto-issue` slash command at `.claude/commands/auto-issue.md`.
-- DCO is mandatory in this repo — every commit needs a `Signed-off-by` trailer. The husky `prepare-commit-msg` hook adds it automatically. Skills must NEVER pass `--no-verify` to git commit.
+- Supports worker prompts calling `Skill(auto-issue, args: "<issue>")`.
+- Canonical workflow lives at `.claude/commands/auto-issue.md`.
+- DCO mandatory — husky `prepare-commit-msg` adds `Signed-off-by` trailer. Never pass `--no-verify` to git commit.

--- a/.claude/skills/finalize/SKILL.md
+++ b/.claude/skills/finalize/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Read, Skill
 
 # Finalize Skill
 
-Completes the workflow by creating PR and notifying.
+Push, create PR, notify.
 
 ## Contract
 
@@ -17,8 +17,8 @@ Completes the workflow by creating PR and notifying.
 | `issue_number`     | number  | Yes      | GitHub issue number                                                                                           |
 | `plan_path`        | string  | No       | Exact dev plan path to read for Intent Verification, Decisions, and Discovery Log extraction into the PR body |
 | `findings_summary` | object  | No       | Summary from review phase                                                                                     |
-| `force`            | boolean | No       | Create PR even with unresolved issues (default: false)                                                        |
-| `skip_notify`      | boolean | No       | Skip Telegram notification (default: false)                                                                   |
+| `force`            | boolean | No       | Create PR even with unresolved issues (default false)                                                         |
+| `skip_notify`      | boolean | No       | Skip Telegram notification (default false)                                                                    |
 
 ### Output
 
@@ -31,33 +31,33 @@ Completes the workflow by creating PR and notifying.
 
 ### Side Effects
 
-1. Pushes branch to remote
-2. Creates GitHub PR
-3. Sends Telegram notification with PR link
+1. Push branch to remote
+2. Create GitHub PR
+3. Send Telegram notification with PR link
 
 ## Workflow
 
 ### Step 1: Gather Context
 
-**Get issue title for PR:**
+**Issue title for PR:**
 
 ```bash
 gh issue view <issue_number> --json title -q .title
 ```
 
-**Get commit history:**
+**Commit history:**
 
 ```bash
 git log main..HEAD --oneline
 ```
 
-**Get diff stats:**
+**Diff stats:**
 
 ```bash
 git diff main --stat
 ```
 
-**Get branch name:**
+**Branch name:**
 
 ```bash
 git branch --show-current
@@ -65,7 +65,7 @@ git branch --show-current
 
 ### Step 2: Run Final Validation
 
-Run validation commands (each separately):
+Each separately:
 
 ```bash
 bun run type-check
@@ -83,11 +83,11 @@ bun test
 bun run build
 ```
 
-**Note:** `bun run build` is safe in this repo — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). If this changes in the future, drop the build step rather than running a native compile.
+**Note:** `bun run build` safe — native-rd's `build` is `echo 'Expo app — no build step'`. If this changes, drop build step rather than running native compile.
 
-**If any validation fails and `force` is false:** Return error with failure details.
+**Validation fails + `force=false`:** Return error with details.
 
-**If validation fails but `force` is true:** Note in PR body, continue.
+**Validation fails + `force=true`:** Note in PR body, continue.
 
 ### Step 3: Push Branch
 
@@ -95,30 +95,28 @@ bun run build
 git push -u origin HEAD
 ```
 
-**If push fails:** Return error (critical).
+Push fail → return error (critical).
 
 ### Step 4: Read Dev Plan (if `plan_path` provided)
 
-Before creating the PR, extract structured sections from the dev plan to enrich the PR body.
+Extract structured sections for PR body. Read file, extract:
 
-If `plan_path` is provided, read the file. Extract:
+1. **Intent Verification** — every checkbox line (`- [ ]` or `- [x]`) between `## Intent Verification` heading and next `##`. Preserve check status verbatim.
+2. **Key Decisions** — markdown table under `## Decisions` (or `## Key Decisions`). Skip header/separator rows; re-emit as two-column `| Decision | Rationale |` in PR body. Empty/absent → omit section.
+3. **Discovery Log** — timestamped entries `- [YYYY-MM-DD HH:MM] <text>` under `## Discovery Log` (may be wrapped in `<!-- … -->`; strip delimiters before parsing). No entries → omit section.
 
-1. **Intent Verification** — every checkbox line (`- [ ]` or `- [x]`) between the `## Intent Verification` heading and the next `##` heading. Preserve check status verbatim.
-2. **Key Decisions** — the markdown table under `## Decisions` (or `## Key Decisions`). Skip the header and separator rows; re-emit as a two-column `| Decision | Rationale |` table in the PR body. If the table is empty or absent, omit the section.
-3. **Discovery Log** — timestamped entries of the form `- [YYYY-MM-DD HH:MM] <text>` under the `## Discovery Log` heading (entries may be wrapped in `<!-- … -->`; strip the delimiters before parsing). If no entries exist, omit the section.
-
-If no plan file exists, omit the Intent Verification, Key Decisions, and Discovery Log sections from the PR body.
+No plan file → omit Intent Verification, Key Decisions, Discovery Log sections.
 
 ### Step 5: Create PR
 
-Determine PR type from branch name or commits:
+PR type from branch/commits:
 
 - `feat/` → "feat"
 - `fix/` → "fix"
 - `refactor/` → "refactor"
 - etc.
 
-Determine scope from primary package affected (e.g., `native-rd`, `openbadges-core`, `design-tokens`, `ci`).
+Scope from primary package affected (`native-rd`, `openbadges-core`, `design-tokens`, `ci`).
 
 **Create PR:**
 
@@ -174,11 +172,11 @@ PRBODY
 
 Extract PR number and URL from output.
 
-**DCO:** All commits on the branch should already carry `Signed-off-by` trailers from the husky `prepare-commit-msg` hook. The DCO workflow check on GitHub will verify each commit. If any commit is missing the trailer, the PR will fail the DCO check — fix locally with new commits (do **not** force-push amended history that strips trailers).
+**DCO:** All branch commits should carry `Signed-off-by` from husky `prepare-commit-msg`. DCO workflow on GitHub verifies each commit. Missing trailer → PR fails DCO check. Fix locally with new commits (do **not** force-push amended history that strips trailers).
 
 ### Step 6: Send Notification (unless skip_notify)
 
-Use the `telegram` skill (via Skill tool) to send a notification:
+Via `telegram` skill:
 
 ```
 PR Created: #<pr_number>
@@ -188,7 +186,7 @@ Commits: <count>
 Status: Awaiting review
 ```
 
-**If notification fails:** Log warning, continue.
+Notification fail → warn, continue.
 
 ### Step 7: Return Output
 
@@ -237,8 +235,6 @@ Status: Awaiting review
 ```
 
 ## Output Format
-
-After completing all steps, report:
 
 ```
 FINALIZE COMPLETE

--- a/.claude/skills/finalize/SKILL.md
+++ b/.claude/skills/finalize/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: finalize
+description: Completes issue workflow - pushes branch, creates PR, sends notification. Use at the end of any issue workflow in Rollercoaster.dev-mobile.
+allowed-tools: Bash, Read, Skill
+---
+
+# Finalize Skill
+
+Completes the workflow by creating PR and notifying.
+
+## Contract
+
+### Input
+
+| Field              | Type    | Required | Description                                                                                                   |
+| ------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `issue_number`     | number  | Yes      | GitHub issue number                                                                                           |
+| `plan_path`        | string  | No       | Exact dev plan path to read for Intent Verification, Decisions, and Discovery Log extraction into the PR body |
+| `findings_summary` | object  | No       | Summary from review phase                                                                                     |
+| `force`            | boolean | No       | Create PR even with unresolved issues (default: false)                                                        |
+| `skip_notify`      | boolean | No       | Skip Telegram notification (default: false)                                                                   |
+
+### Output
+
+| Field             | Type   | Description                            |
+| ----------------- | ------ | -------------------------------------- |
+| `pr.number`       | number | PR number                              |
+| `pr.url`          | string | PR URL                                 |
+| `pr.title`        | string | PR title                               |
+| `workflow_status` | string | "completed" or "completed_with_issues" |
+
+### Side Effects
+
+1. Pushes branch to remote
+2. Creates GitHub PR
+3. Sends Telegram notification with PR link
+
+## Workflow
+
+### Step 1: Gather Context
+
+**Get issue title for PR:**
+
+```bash
+gh issue view <issue_number> --json title -q .title
+```
+
+**Get commit history:**
+
+```bash
+git log main..HEAD --oneline
+```
+
+**Get diff stats:**
+
+```bash
+git diff main --stat
+```
+
+**Get branch name:**
+
+```bash
+git branch --show-current
+```
+
+### Step 2: Run Final Validation
+
+Run validation commands (each separately):
+
+```bash
+bun run type-check
+```
+
+```bash
+bun run lint
+```
+
+```bash
+bun test
+```
+
+```bash
+bun run build
+```
+
+**Note:** `bun run build` is safe in this repo — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). If this changes in the future, drop the build step rather than running a native compile.
+
+**If any validation fails and `force` is false:** Return error with failure details.
+
+**If validation fails but `force` is true:** Note in PR body, continue.
+
+### Step 3: Push Branch
+
+```bash
+git push -u origin HEAD
+```
+
+**If push fails:** Return error (critical).
+
+### Step 4: Read Dev Plan (if `plan_path` provided)
+
+Before creating the PR, extract structured sections from the dev plan to enrich the PR body.
+
+If `plan_path` is provided, read the file. Extract:
+
+1. **Intent Verification** — every checkbox line (`- [ ]` or `- [x]`) between the `## Intent Verification` heading and the next `##` heading. Preserve check status verbatim.
+2. **Key Decisions** — the markdown table under `## Decisions` (or `## Key Decisions`). Skip the header and separator rows; re-emit as a two-column `| Decision | Rationale |` table in the PR body. If the table is empty or absent, omit the section.
+3. **Discovery Log** — timestamped entries of the form `- [YYYY-MM-DD HH:MM] <text>` under the `## Discovery Log` heading (entries may be wrapped in `<!-- … -->`; strip the delimiters before parsing). If no entries exist, omit the section.
+
+If no plan file exists, omit the Intent Verification, Key Decisions, and Discovery Log sections from the PR body.
+
+### Step 5: Create PR
+
+Determine PR type from branch name or commits:
+
+- `feat/` → "feat"
+- `fix/` → "fix"
+- `refactor/` → "refactor"
+- etc.
+
+Determine scope from primary package affected (e.g., `native-rd`, `openbadges-core`, `design-tokens`, `ci`).
+
+**Create PR:**
+
+```bash
+gh pr create --title "<type>(<scope>): <description> (#<issue_number>)" --body "$(cat <<'PRBODY'
+## Summary
+
+<1-3 bullet points from issue/commits>
+
+## Changes
+
+<bullet list of key changes>
+
+## Intent Verification
+
+<Copy from dev plan with check status. If no plan exists, omit this section.>
+
+- [x] <met criterion>
+- [x] <met criterion>
+- [ ] <unmet criterion, if any — explain why>
+
+## Key Decisions
+
+<Summarize from Decisions table. If no plan or no decisions, omit this section.>
+
+| Decision | Rationale |
+|----------|-----------|
+| <what> | <why> |
+
+## Discovery Log
+
+<Copy entries verbatim from dev plan. Omit section if no entries.>
+
+- [YYYY-MM-DD HH:MM] <entry>
+
+## Test Plan
+
+- [ ] Type-check passes
+- [ ] Lint passes
+- [ ] Tests pass
+- [ ] Build script (no-op for native-rd) returns successfully
+
+<any unresolved findings if force=true>
+
+---
+
+Closes #<issue_number>
+
+Generated with [Claude Code](https://claude.ai/code)
+PRBODY
+)"
+```
+
+Extract PR number and URL from output.
+
+**DCO:** All commits on the branch should already carry `Signed-off-by` trailers from the husky `prepare-commit-msg` hook. The DCO workflow check on GitHub will verify each commit. If any commit is missing the trailer, the PR will fail the DCO check — fix locally with new commits (do **not** force-push amended history that strips trailers).
+
+### Step 6: Send Notification (unless skip_notify)
+
+Use the `telegram` skill (via Skill tool) to send a notification:
+
+```
+PR Created: #<pr_number>
+Issue: #<issue_number> - <title>
+URL: <pr_url>
+Commits: <count>
+Status: Awaiting review
+```
+
+**If notification fails:** Log warning, continue.
+
+### Step 7: Return Output
+
+```json
+{
+  "pr": {
+    "number": <pr_number>,
+    "url": "<pr_url>",
+    "title": "<pr_title>"
+  },
+  "workflow_status": "completed"
+}
+```
+
+## Error Handling
+
+| Condition                      | Behavior                  |
+| ------------------------------ | ------------------------- |
+| Validation fails (force=false) | Return error with details |
+| Push fails                     | Return error (critical)   |
+| PR creation fails              | Return error (critical)   |
+| Notification fails             | Warn, continue            |
+
+## Example
+
+**Input:**
+
+```json
+{
+  "issue_number": 487,
+  "plan_path": "apps/native-rd/docs/plans/dev-plans/issue-487-agent-architecture.md"
+}
+```
+
+**Output:**
+
+```json
+{
+  "pr": {
+    "number": 488,
+    "url": "https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/pull/488",
+    "title": "refactor(native-rd): implement robust agent architecture (#487)"
+  },
+  "workflow_status": "completed"
+}
+```
+
+## Output Format
+
+After completing all steps, report:
+
+```
+FINALIZE COMPLETE
+
+PR: #<pr_number>
+URL: <pr_url>
+Title: <pr_title>
+
+Workflow: Marked as completed
+
+Commits: <count>
+
+Next: PR will be reviewed by CodeRabbit and team.
+```

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -10,24 +10,24 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
 
 ### Input
 
-| Field          | Type   | Required | Description                             |
-| -------------- | ------ | -------- | --------------------------------------- |
-| `issue_number` | number | Yes      | GitHub issue number                     |
-| `plan_path`    | string | Yes      | Exact path to the development plan file |
-| `start_step`   | number | No       | Resume from specific step               |
+| Field          | Type   | Required | Description               |
+| -------------- | ------ | -------- | ------------------------- |
+| `issue_number` | number | Yes      | GitHub issue number       |
+| `plan_path`    | string | Yes      | Exact dev plan path       |
+| `start_step`   | number | No       | Resume from specific step |
 
 ### Output
 
-| Field                   | Type     | Description          |
-| ----------------------- | -------- | -------------------- |
-| `commits`               | array    | List of commits made |
-| `commits[].sha`         | string   | Commit SHA           |
-| `commits[].message`     | string   | Commit message       |
-| `commits[].files`       | string[] | Files changed        |
-| `validation.type_check` | boolean  | Type-check passed    |
-| `validation.lint`       | boolean  | Lint passed          |
-| `validation.tests`      | boolean  | Tests passed         |
-| `validation.build`      | boolean  | Build passed         |
+| Field                   | Type     | Description       |
+| ----------------------- | -------- | ----------------- |
+| `commits`               | array    | Commits made      |
+| `commits[].sha`         | string   | Commit SHA        |
+| `commits[].message`     | string   | Commit message    |
+| `commits[].files`       | string[] | Files changed     |
+| `validation.type_check` | boolean  | Type-check passed |
+| `validation.lint`       | boolean  | Lint passed       |
+| `validation.tests`      | boolean  | Tests passed      |
+| `validation.build`      | boolean  | Build passed      |
 
 ### Side Effects
 
@@ -38,32 +38,32 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
 
 ## Purpose
 
-Implements code changes following a development plan, making atomic commits that each represent a single logical change. Follows trunk-based development practices with small, focused changes.
+Implement changes per dev plan via atomic commits. Trunk-based, small focused changes.
 
 ## Core Principles
 
 ### MINIMAL Implementation
 
-**CRITICAL: Only implement the bare minimum to fulfill requirements.**
+**CRITICAL: Only the bare minimum to fulfill requirements.**
 
-1. **No "nice to have" features** - If it's not explicitly required, don't build it
-2. **No premature abstraction** - Don't create helpers/utilities for one-time operations
-3. **No extra options/parameters** - Add configuration only when explicitly needed
-4. **No defensive coding for impossible cases** - Trust internal code
+1. **No "nice to have"** — not required, don't build
+2. **No premature abstraction** — no helpers for one-time ops
+3. **No extra options/parameters** — config only when needed
+4. **No defensive coding for impossible cases** — trust internal code
 
-**Before writing ANY code, ask:**
+**Before writing code, ask:**
 
-- Is this explicitly required by the issue?
-- Would the feature work without this?
-- Am I adding this "just in case"?
+- Explicitly required by issue?
+- Works without this?
+- Adding "just in case"?
 
 ### Minimal Tests
 
 **Only test what matters:**
 
-1. **Happy path** - Does it work with valid input?
-2. **Key error cases** - What happens with obviously wrong input?
-3. **Edge cases only if likely** - Don't test impossible scenarios
+1. **Happy path** — works with valid input
+2. **Key error cases** — obviously wrong input
+3. **Edge cases only if likely** — skip impossible scenarios
 
 **Test count guideline:**
 
@@ -73,12 +73,12 @@ Implements code changes following a development plan, making atomic commits that
 
 ### Atomic Commits
 
-Each commit must be:
+Each commit:
 
-1. **Self-contained**: Works on its own
-2. **Single purpose**: One logical change
-3. **Buildable**: Code compiles/passes type-check
-4. **Testable**: Related tests included (when applicable)
+1. **Self-contained** — works on its own
+2. **Single purpose** — one logical change
+3. **Buildable** — compiles/type-checks
+4. **Testable** — related tests included (when applicable)
 
 #### Good vs Bad Atomic Commits
 
@@ -126,30 +126,24 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`
    git status
    ```
 
-2. **Load development plan:**
-   - Read from the path provided by the caller (`plan_path` input)
+2. **Load dev plan** from caller's `plan_path` input.
 
 ### Phase 2: Execute Plan Step by Step
 
-For each step in the development plan:
+For each step:
 
-1. **Announce step:**
-   - "Step 1: <description>"
-   - Show expected commit message
+1. **Announce:** "Step 1: <description>" + expected commit message
 
-2. **Make changes:**
-   - Create/modify files as planned
-   - Follow existing code patterns
-   - Include inline comments where helpful
+2. **Make changes** — create/modify files, follow existing patterns, inline comments where helpful
 
-3. **Validate changes:**
+3. **Validate:**
 
    ```bash
-   bun run type-check  # TypeScript check
+   bun run type-check
    ```
 
    ```bash
-   bun run lint        # Linting
+   bun run lint
    ```
 
 4. **Run relevant tests:**
@@ -158,7 +152,7 @@ For each step in the development plan:
    bun test --testPathPatterns <pattern>
    ```
 
-   (Use `--testPathPatterns` plural per native-rd convention — see `apps/native-rd/CLAUDE.md`.)
+   (Plural `--testPathPatterns` per native-rd convention — see `apps/native-rd/CLAUDE.md`.)
 
 5. **Format changed files:**
 
@@ -173,48 +167,30 @@ For each step in the development plan:
    git commit -m "<type>(<scope>): <message>"
    ```
 
-   **DCO is mandatory in this repo.** The husky `prepare-commit-msg` hook adds the `Signed-off-by` trailer automatically. **Never** pass `--no-verify` to git commit, and never amend commits in a way that strips the trailer.
+   **DCO mandatory.** Husky `prepare-commit-msg` adds `Signed-off-by` automatically. **Never** pass `--no-verify`. Never amend in a way that strips the trailer.
 
-7. **Report progress:**
-   - Confirm commit made
-   - Show files changed
-   - Note any deviations from plan
+7. **Report:** commit confirmed, files changed, deviations noted
 
-8. **Update the dev plan (live plan maintenance):**
-   - Check off completed items in the Implementation Plan section (change `- [ ]` to `- [x]`)
-   - **On deviation:** Add a timestamped entry to the Discovery Log section:
+8. **Update dev plan (live plan maintenance):**
+   - Check off completed items in Implementation Plan (`- [ ]` → `- [x]`)
+   - **On deviation:** timestamped Discovery Log entry:
      ```markdown
      - [YYYY-MM-DD HH:MM] <what changed and why>
      ```
-   - **On new decision:** Add a row to the Decisions table with ID, decision, alternatives, rationale.
-   - **On explicit deferral:** Add to the Not in Scope table with item, reason, and follow-up issue (if any)
+   - **On new decision:** add row to Decisions table (ID, decision, alternatives, rationale)
+   - **On explicit deferral:** add to Not in Scope table (item, reason, follow-up issue)
 
 ### Phase 3: Handle Deviations
 
-If the plan needs adjustment:
-
-1. **Minor adjustments:**
-   - Make the change
-   - Note the deviation in the Discovery Log
-   - Continue with plan
-
-2. **Significant changes:**
-   - Stop and report
-   - Explain what's different
-   - Propose updated approach
-   - In autonomous mode (auto-issue): pick the most reasonable path and log the decision
-   - In gated mode: wait for user approval
-
-3. **Blockers:**
-   - Stop immediately
-   - Describe the blocker
-   - Suggest resolution
+1. **Minor:** make change, log in Discovery Log, continue
+2. **Significant:** stop, report, propose updated approach
+   - Autonomous (auto-issue): pick reasonable path, log decision
+   - Gated: wait for approval
+3. **Blockers:** stop immediately, describe blocker, suggest resolution
 
 ### Phase 4: Final Validation
 
-After all commits:
-
-1. **Run full validation (each command separately):**
+1. **Full validation (each command separately):**
 
    ```bash
    bun run type-check
@@ -232,7 +208,7 @@ After all commits:
    bun run build
    ```
 
-   **Note:** `bun run build` in this repo is safe — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). It does NOT trigger an Expo prebuild or native compile. If a future change makes it non-trivial, drop the build step from this skill rather than running native builds.
+   **Note:** `bun run build` is safe — native-rd's `build` script is `echo 'Expo app — no build step'`. No prebuild, no native compile. If this changes, drop the build step rather than running native builds.
 
 2. **Review commit history:**
 
@@ -246,65 +222,40 @@ After all commits:
    git diff main --stat
    ```
 
-4. **Verify scope:**
-   - Is it under ~500 lines?
-   - Does each commit stand alone?
-   - Is the branch focused?
+4. **Verify scope:** under ~500 lines? each commit stands alone? branch focused?
 
 5. **Verify Intent (plan-aware check):**
-   - Read the dev plan's Intent Verification section
-   - For each criterion, verify it is met by the implementation
-   - Check off met criteria in the plan (change `- [ ]` to `- [x]`)
-   - If any criteria are NOT met, report which ones failed and why. In autonomous workflows (auto-issue), log the gap and proceed.
+   - Read plan's Intent Verification section
+   - Verify each criterion met by implementation
+   - Check off met criteria (`- [ ]` → `- [x]`)
+   - Unmet → report which failed and why. Autonomous (auto-issue): log gap, proceed.
 
 ### Phase 5: Report Completion
 
-1. **Summary:**
-   - Number of commits made
-   - Files changed
-   - Lines added/removed
-   - Tests added/passing
-
-2. **Ready for review:**
-   - Branch name
-   - Base branch
-   - Suggested PR title
-
-3. **Next step:**
-   - "Ready for review phase"
+1. **Summary:** commit count, files changed, lines added/removed, tests added/passing
+2. **Ready for review:** branch, base branch, suggested PR title
+3. **Next:** "Ready for review phase"
 
 ## Error Handling
 
 ### Build/Type Errors
 
-1. **Analyze error:**
-   - Read error message
-   - Identify root cause
-   - Plan fix
+1. **Analyze** — read error, identify root cause, plan fix
+2. **Fix in new commit (preferred)** — create fix commit, note deviation
 
-2. **Fix in new commit (preferred):**
-   - Create a fix commit
-   - Note deviation from plan
-
-   Prefer NEW commits over `git commit --amend` — amending past the husky hook can drop the DCO trailer.
+   Prefer NEW commits over `git commit --amend` — amending past husky can drop DCO trailer.
 
 ### Test Failures
 
-1. **Expected failures:**
-   - Update test expectations
-   - Include in same commit
-
-2. **Unexpected failures:**
-   - Stop and analyze
-   - Report to user
-   - Fix before continuing
+1. **Expected:** update test expectations, include in same commit
+2. **Unexpected:** stop, analyze, report, fix before continuing
 
 ### Merge Conflicts
 
-1. **Stop immediately**
-2. **Report conflict details**
-3. **Wait for user guidance**
-4. **Do not auto-resolve**
+1. Stop immediately
+2. Report conflict details
+3. Wait for user guidance
+4. Do not auto-resolve
 
 ## Output Format
 
@@ -343,11 +294,9 @@ Ready for review phase.
 
 ## Success Criteria
 
-This skill is successful when:
-
-- All planned commits are made
-- Each commit is atomic and buildable
+- All planned commits made
+- Each commit atomic, buildable
 - All validations pass
-- Branch is ready for review
-- Code follows project conventions
-- Every commit has a `Signed-off-by` trailer (DCO)
+- Branch ready for review
+- Follows project conventions
+- Every commit has `Signed-off-by` trailer (DCO)

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: implement
+description: Implements code changes following a development plan with atomic commits. Each commit is self-contained and the PR focuses on a single change. Use after issue-researcher creates a plan.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
+---
+
+# Implement Skill
+
+## Contract
+
+### Input
+
+| Field          | Type   | Required | Description                             |
+| -------------- | ------ | -------- | --------------------------------------- |
+| `issue_number` | number | Yes      | GitHub issue number                     |
+| `plan_path`    | string | Yes      | Exact path to the development plan file |
+| `start_step`   | number | No       | Resume from specific step               |
+
+### Output
+
+| Field                   | Type     | Description          |
+| ----------------------- | -------- | -------------------- |
+| `commits`               | array    | List of commits made |
+| `commits[].sha`         | string   | Commit SHA           |
+| `commits[].message`     | string   | Commit message       |
+| `commits[].files`       | string[] | Files changed        |
+| `validation.type_check` | boolean  | Type-check passed    |
+| `validation.lint`       | boolean  | Lint passed          |
+| `validation.tests`      | boolean  | Tests passed         |
+| `validation.build`      | boolean  | Build passed         |
+
+### Side Effects
+
+- Creates/modifies files per plan
+- Makes git commits
+
+---
+
+## Purpose
+
+Implements code changes following a development plan, making atomic commits that each represent a single logical change. Follows trunk-based development practices with small, focused changes.
+
+## Core Principles
+
+### MINIMAL Implementation
+
+**CRITICAL: Only implement the bare minimum to fulfill requirements.**
+
+1. **No "nice to have" features** - If it's not explicitly required, don't build it
+2. **No premature abstraction** - Don't create helpers/utilities for one-time operations
+3. **No extra options/parameters** - Add configuration only when explicitly needed
+4. **No defensive coding for impossible cases** - Trust internal code
+
+**Before writing ANY code, ask:**
+
+- Is this explicitly required by the issue?
+- Would the feature work without this?
+- Am I adding this "just in case"?
+
+### Minimal Tests
+
+**Only test what matters:**
+
+1. **Happy path** - Does it work with valid input?
+2. **Key error cases** - What happens with obviously wrong input?
+3. **Edge cases only if likely** - Don't test impossible scenarios
+
+**Test count guideline:**
+
+- Simple function: 2-4 tests
+- Complex function: 5-8 tests
+- Full service: 8-15 tests
+
+### Atomic Commits
+
+Each commit must be:
+
+1. **Self-contained**: Works on its own
+2. **Single purpose**: One logical change
+3. **Buildable**: Code compiles/passes type-check
+4. **Testable**: Related tests included (when applicable)
+
+#### Good vs Bad Atomic Commits
+
+**GOOD** (single purpose):
+
+```
+feat(themes): add highContrast variant tokens
+feat(themes): wire highContrast into theme compose
+test(themes): add contrast assertions for highContrast
+```
+
+**BAD** (mixed concerns):
+
+```
+feat(themes): add variant, wire it, add tests
+feat: various improvements to theming
+wip: work in progress
+```
+
+### Commit Message Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`
+
+### Small PRs
+
+- Target ~500 lines max (excluding tests)
+- One issue = one PR
+- One PR = one thing changed
+
+## Workflow
+
+### Phase 1: Prepare Environment
+
+1. **Verify clean state:**
+
+   ```bash
+   git status
+   ```
+
+2. **Load development plan:**
+   - Read from the path provided by the caller (`plan_path` input)
+
+### Phase 2: Execute Plan Step by Step
+
+For each step in the development plan:
+
+1. **Announce step:**
+   - "Step 1: <description>"
+   - Show expected commit message
+
+2. **Make changes:**
+   - Create/modify files as planned
+   - Follow existing code patterns
+   - Include inline comments where helpful
+
+3. **Validate changes:**
+
+   ```bash
+   bun run type-check  # TypeScript check
+   ```
+
+   ```bash
+   bun run lint        # Linting
+   ```
+
+4. **Run relevant tests:**
+
+   ```bash
+   bun test --testPathPatterns <pattern>
+   ```
+
+   (Use `--testPathPatterns` plural per native-rd convention — see `apps/native-rd/CLAUDE.md`.)
+
+5. **Format changed files:**
+
+   ```bash
+   bunx prettier --write <file-list>
+   ```
+
+6. **Stage and commit:**
+
+   ```bash
+   git add <specific-files>
+   git commit -m "<type>(<scope>): <message>"
+   ```
+
+   **DCO is mandatory in this repo.** The husky `prepare-commit-msg` hook adds the `Signed-off-by` trailer automatically. **Never** pass `--no-verify` to git commit, and never amend commits in a way that strips the trailer.
+
+7. **Report progress:**
+   - Confirm commit made
+   - Show files changed
+   - Note any deviations from plan
+
+8. **Update the dev plan (live plan maintenance):**
+   - Check off completed items in the Implementation Plan section (change `- [ ]` to `- [x]`)
+   - **On deviation:** Add a timestamped entry to the Discovery Log section:
+     ```markdown
+     - [YYYY-MM-DD HH:MM] <what changed and why>
+     ```
+   - **On new decision:** Add a row to the Decisions table with ID, decision, alternatives, rationale.
+   - **On explicit deferral:** Add to the Not in Scope table with item, reason, and follow-up issue (if any)
+
+### Phase 3: Handle Deviations
+
+If the plan needs adjustment:
+
+1. **Minor adjustments:**
+   - Make the change
+   - Note the deviation in the Discovery Log
+   - Continue with plan
+
+2. **Significant changes:**
+   - Stop and report
+   - Explain what's different
+   - Propose updated approach
+   - In autonomous mode (auto-issue): pick the most reasonable path and log the decision
+   - In gated mode: wait for user approval
+
+3. **Blockers:**
+   - Stop immediately
+   - Describe the blocker
+   - Suggest resolution
+
+### Phase 4: Final Validation
+
+After all commits:
+
+1. **Run full validation (each command separately):**
+
+   ```bash
+   bun run type-check
+   ```
+
+   ```bash
+   bun run lint
+   ```
+
+   ```bash
+   bun test
+   ```
+
+   ```bash
+   bun run build
+   ```
+
+   **Note:** `bun run build` in this repo is safe — native-rd's `build` script is a no-op (`echo 'Expo app — no build step'`). It does NOT trigger an Expo prebuild or native compile. If a future change makes it non-trivial, drop the build step from this skill rather than running native builds.
+
+2. **Review commit history:**
+
+   ```bash
+   git log --oneline -n <number-of-commits>
+   ```
+
+3. **Check diff stats:**
+
+   ```bash
+   git diff main --stat
+   ```
+
+4. **Verify scope:**
+   - Is it under ~500 lines?
+   - Does each commit stand alone?
+   - Is the branch focused?
+
+5. **Verify Intent (plan-aware check):**
+   - Read the dev plan's Intent Verification section
+   - For each criterion, verify it is met by the implementation
+   - Check off met criteria in the plan (change `- [ ]` to `- [x]`)
+   - If any criteria are NOT met, report which ones failed and why. In autonomous workflows (auto-issue), log the gap and proceed.
+
+### Phase 5: Report Completion
+
+1. **Summary:**
+   - Number of commits made
+   - Files changed
+   - Lines added/removed
+   - Tests added/passing
+
+2. **Ready for review:**
+   - Branch name
+   - Base branch
+   - Suggested PR title
+
+3. **Next step:**
+   - "Ready for review phase"
+
+## Error Handling
+
+### Build/Type Errors
+
+1. **Analyze error:**
+   - Read error message
+   - Identify root cause
+   - Plan fix
+
+2. **Fix in new commit (preferred):**
+   - Create a fix commit
+   - Note deviation from plan
+
+   Prefer NEW commits over `git commit --amend` — amending past the husky hook can drop the DCO trailer.
+
+### Test Failures
+
+1. **Expected failures:**
+   - Update test expectations
+   - Include in same commit
+
+2. **Unexpected failures:**
+   - Stop and analyze
+   - Report to user
+   - Fix before continuing
+
+### Merge Conflicts
+
+1. **Stop immediately**
+2. **Report conflict details**
+3. **Wait for user guidance**
+4. **Do not auto-resolve**
+
+## Output Format
+
+After each commit:
+
+```
+Commit #<n>: <type>(<scope>): <message>
+Files: <file-list>
+Status: <passing|failing>
+```
+
+After completion:
+
+```
+## Implementation Complete
+
+**Branch**: <branch-name>
+**Commits**: <n>
+**Files Changed**: <n>
+**Lines**: +<added> / -<removed>
+
+### Commit History
+1. <commit-message>
+2. <commit-message>
+...
+
+### Validation
+- Type-check: PASS
+- Lint: PASS
+- Tests: PASS (<n>/<n>)
+- Build: PASS (no-op for native-rd)
+
+### Next Step
+Ready for review phase.
+```
+
+## Success Criteria
+
+This skill is successful when:
+
+- All planned commits are made
+- Each commit is atomic and buildable
+- All validations pass
+- Branch is ready for review
+- Code follows project conventions
+- Every commit has a `Signed-off-by` trailer (DCO)

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: review
+description: Coordinates review agents and manages auto-fix loop. Spawns code-reviewer, test-analyzer, silent-failure-hunter in parallel, classifies findings, and attempts fixes for critical issues.
+allowed-tools: Bash, Read, Glob, Grep, Skill, Agent
+---
+
+# Review Skill
+
+Coordinates code review and manages the auto-fix cycle.
+
+## Contract
+
+### Input
+
+| Field         | Type     | Required | Description                                    |
+| ------------- | -------- | -------- | ---------------------------------------------- |
+| `workflow_id` | string   | Yes      | Workflow ID (`issue-<N>`) — used for log lines |
+| `skip_agents` | string[] | No       | Agents to skip (default: none)                 |
+| `max_retry`   | number   | No       | Max fix attempts per finding (default: 3)      |
+| `parallel`    | boolean  | No       | Run agents in parallel (default: true)         |
+
+### Output
+
+| Field                 | Type    | Description                     |
+| --------------------- | ------- | ------------------------------- |
+| `findings`            | array   | All findings from review agents |
+| `findings[].agent`    | string  | Which agent found this          |
+| `findings[].severity` | string  | CRITICAL, HIGH, MEDIUM, LOW     |
+| `findings[].file`     | string  | File path                       |
+| `findings[].line`     | number  | Line number                     |
+| `findings[].message`  | string  | Finding description             |
+| `findings[].fixed`    | boolean | Whether auto-fix succeeded      |
+| `summary.total`       | number  | Total findings                  |
+| `summary.critical`    | number  | Critical findings               |
+| `summary.fixed`       | number  | Successfully fixed              |
+| `summary.unresolved`  | number  | Critical findings not fixed     |
+
+### Side Effects
+
+1. Spawns review agents as standalone background agents (parallel or sequential, never as team members)
+2. Spawns auto-fixer as standalone background agent for critical findings
+3. Creates fix commits
+
+## Review Agents
+
+| Agent                                     | Purpose                | Critical Threshold                   |
+| ----------------------------------------- | ---------------------- | ------------------------------------ |
+| `pr-review-toolkit:code-reviewer`         | Code quality, patterns | Confidence >= 91 OR label="Critical" |
+| `pr-review-toolkit:pr-test-analyzer`      | Test coverage gaps     | Gap rating >= 8                      |
+| `pr-review-toolkit:silent-failure-hunter` | Error handling         | Severity = "CRITICAL"                |
+
+## Workflow
+
+### Step 1: Detect Scope
+
+**Get changed files:**
+
+```bash
+git diff main --name-only
+```
+
+**Read dev plan (if it exists):**
+
+Look for the dev plan in this repo's plan directory:
+
+```bash
+ls apps/native-rd/docs/plans/dev-plans/issue-*.md 2>/dev/null
+```
+
+If multiple files match, use the one whose filename contains the current issue number. If a plan exists for the current issue:
+
+1. Read the **Intent Verification** section — these are the success criteria
+2. Read the **Not in Scope** section — these items should NOT have been implemented
+3. Store both for use in the output summary
+
+### Step 1.5: Run /simplify (Code Quality Pass)
+
+Run the built-in `/simplify` command for code quality, reuse, and efficiency improvements.
+This complements the review agents which focus on bugs, test gaps, and silent failures.
+
+1. Run: `/simplify`
+2. If `/simplify` makes changes:
+   a. Validate each command separately:
+   ```bash
+   bun run type-check
+   ```
+   ```bash
+   bun run lint
+   ```
+   ```bash
+   bun test
+   ```
+   b. If all valid: commit with `git commit -m "refactor: apply simplify suggestions"` (husky adds DCO trailer)
+   c. If invalid: revert with `git reset --hard HEAD && git clean -fd` (resets tracked files and removes untracked artifacts created by `/simplify`)
+3. Continue to Step 2 regardless of outcome.
+
+### Step 2: Spawn Review Agents
+
+**CRITICAL: Team isolation.** All review agents are internal sub-agents — they MUST be spawned as standalone background agents, never as team members. Do NOT pass `team_name` to any Agent call.
+
+**If parallel mode (default):**
+
+Spawn all agents simultaneously using the Agent tool with `run_in_background: true` (no `team_name`):
+
+```text
+Agent(pr-review-toolkit:code-reviewer, run_in_background: true): "Review code changes for issue workflow <workflow_id>"
+Agent(pr-review-toolkit:pr-test-analyzer, run_in_background: true): "Analyze test coverage for changes"
+Agent(pr-review-toolkit:silent-failure-hunter, run_in_background: true): "Check for silent failures in changes"
+```
+
+**If sequential mode:**
+
+Spawn each agent one at a time using the Agent tool (no `team_name`), collecting results.
+
+### Step 3: Collect and Normalize Findings
+
+Each agent returns findings in different formats. Normalize to:
+
+```json
+{
+  "agent": "<agent-name>",
+  "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+  "file": "<file-path>",
+  "line": <line-number>,
+  "message": "<description>",
+  "fixed": false
+}
+```
+
+**Classification rules:**
+
+| Agent                 | CRITICAL if                          | HIGH if          | MEDIUM/LOW otherwise    |
+| --------------------- | ------------------------------------ | ---------------- | ----------------------- |
+| code-reviewer         | Confidence >= 91 OR label="Critical" | Confidence >= 75 | Confidence < 75         |
+| silent-failure-hunter | Severity="CRITICAL"                  | Severity="HIGH"  | Severity="MEDIUM"/"LOW" |
+| pr-test-analyzer      | Gap rating >= 8                      | Gap rating >= 5  | Gap rating < 5          |
+
+### Step 4: Auto-Fix Loop
+
+**For each CRITICAL finding:**
+
+```text
+attempt = 0
+while not fixed AND attempt < max_retry:
+    attempt++
+
+    Spawn auto-fixer (standalone — no team_name):
+    Agent(auto-fixer, run_in_background: true): "Fix: <finding.message> in <finding.file>:<finding.line>"
+
+    If fix successful:
+        finding.fixed = true
+    Else:
+        Continue to next attempt
+```
+
+### Step 5: Re-Review After Fixes
+
+If any fixes were made:
+
+1. Run validation (each command separately):
+
+   ```bash
+   bun run type-check
+   ```
+
+   ```bash
+   bun run lint
+   ```
+
+2. If validation fails, revert last fix:
+
+   ```bash
+   git checkout -- <file>
+   ```
+
+   Mark finding as not fixed.
+
+3. Optionally re-run review agents to verify fixes (if time permits).
+
+### Step 6: Calculate Summary
+
+```json
+{
+  "total": <all-findings>,
+  "critical": <critical-count>,
+  "fixed": <successfully-fixed>,
+  "unresolved": <critical-not-fixed>
+}
+```
+
+### Step 7: Return Output
+
+```json
+{
+  "findings": [...],
+  "summary": {
+    "total": <n>,
+    "critical": <n>,
+    "fixed": <n>,
+    "unresolved": <n>
+  }
+}
+```
+
+## Error Handling
+
+| Condition            | Behavior                            |
+| -------------------- | ----------------------------------- |
+| Agent fails to spawn | Log error, continue with others     |
+| All agents fail      | Return error (critical)             |
+| Fix validation fails | Revert fix, try next approach       |
+| Max retry exceeded   | Mark as unresolved, continue        |
+| Timeout              | Return partial results with warning |
+
+## Output Format
+
+```text
+REVIEW COMPLETE
+
+Agents Run: code-reviewer, test-analyzer, silent-failure-hunter
+Findings: <total> total (<critical> critical)
+Fixed: <fixed>/<critical> critical issues
+
+UNRESOLVED (require manual attention):
+1. [code-reviewer] src/foo.ts:42 - Missing null check
+2. [silent-failure-hunter] src/bar.ts:89 - Silent catch block
+
+NON-CRITICAL (for PR reviewer):
+- [code-reviewer] src/baz.ts:15 - Consider extracting helper (confidence: 72)
+- [test-analyzer] Missing edge case test for empty input (gap: 4)
+
+PLAN COMPLIANCE: (omit entire section if no plan exists)
+- Intent Verification: <N>/<M> criteria met
+- Scope: clean | scope creep detected (<details if any>)
+
+Summary: <unresolved> unresolved critical findings
+```
+
+## Escalation Trigger
+
+If `summary.unresolved > 0`:
+
+The calling workflow should escalate to user with:
+
+- List of unresolved findings
+- Options: continue (manual fix), force-pr, abort
+
+## Success Criteria
+
+This skill is successful when:
+
+- All review agents run (or gracefully skip on failure)
+- Findings are correctly classified by severity
+- Auto-fix attempted for all CRITICAL findings
+- Clear summary returned to orchestrator
+- Escalation triggered when appropriate

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -6,18 +6,18 @@ allowed-tools: Bash, Read, Glob, Grep, Skill, Agent
 
 # Review Skill
 
-Coordinates code review and manages the auto-fix cycle.
+Coordinate review + auto-fix cycle.
 
 ## Contract
 
 ### Input
 
-| Field         | Type     | Required | Description                                    |
-| ------------- | -------- | -------- | ---------------------------------------------- |
-| `workflow_id` | string   | Yes      | Workflow ID (`issue-<N>`) — used for log lines |
-| `skip_agents` | string[] | No       | Agents to skip (default: none)                 |
-| `max_retry`   | number   | No       | Max fix attempts per finding (default: 3)      |
-| `parallel`    | boolean  | No       | Run agents in parallel (default: true)         |
+| Field         | Type     | Required | Description                               |
+| ------------- | -------- | -------- | ----------------------------------------- |
+| `workflow_id` | string   | Yes      | Workflow ID (`issue-<N>`) — for log lines |
+| `skip_agents` | string[] | No       | Agents to skip (default: none)            |
+| `max_retry`   | number   | No       | Max fix attempts per finding (default: 3) |
+| `parallel`    | boolean  | No       | Run agents in parallel (default: true)    |
 
 ### Output
 
@@ -37,9 +37,9 @@ Coordinates code review and manages the auto-fix cycle.
 
 ### Side Effects
 
-1. Spawns review agents as standalone background agents (parallel or sequential, never as team members)
-2. Spawns auto-fixer as standalone background agent for critical findings
-3. Creates fix commits
+1. Spawn review agents as standalone background agents (parallel or sequential, never team members)
+2. Spawn auto-fixer as standalone background agent for critical findings
+3. Create fix commits
 
 ## Review Agents
 
@@ -53,34 +53,31 @@ Coordinates code review and manages the auto-fix cycle.
 
 ### Step 1: Detect Scope
 
-**Get changed files:**
+**Changed files:**
 
 ```bash
 git diff main --name-only
 ```
 
-**Read dev plan (if it exists):**
-
-Look for the dev plan in this repo's plan directory:
+**Read dev plan if exists:**
 
 ```bash
 ls apps/native-rd/docs/plans/dev-plans/issue-*.md 2>/dev/null
 ```
 
-If multiple files match, use the one whose filename contains the current issue number. If a plan exists for the current issue:
+Multiple matches → use filename containing current issue number. If plan exists for current issue:
 
-1. Read the **Intent Verification** section — these are the success criteria
-2. Read the **Not in Scope** section — these items should NOT have been implemented
-3. Store both for use in the output summary
+1. Read **Intent Verification** — success criteria
+2. Read **Not in Scope** — items that should NOT be implemented
+3. Store both for output summary
 
 ### Step 1.5: Run /simplify (Code Quality Pass)
 
-Run the built-in `/simplify` command for code quality, reuse, and efficiency improvements.
-This complements the review agents which focus on bugs, test gaps, and silent failures.
+Run built-in `/simplify` for code quality, reuse, efficiency. Complements review agents (bugs, test gaps, silent failures).
 
 1. Run: `/simplify`
-2. If `/simplify` makes changes:
-   a. Validate each command separately:
+2. If `/simplify` made changes:
+   a. Validate (each command separately):
    ```bash
    bun run type-check
    ```
@@ -90,17 +87,17 @@ This complements the review agents which focus on bugs, test gaps, and silent fa
    ```bash
    bun test
    ```
-   b. If all valid: commit with `git commit -m "refactor: apply simplify suggestions"` (husky adds DCO trailer)
-   c. If invalid: revert with `git reset --hard HEAD && git clean -fd` (resets tracked files and removes untracked artifacts created by `/simplify`)
-3. Continue to Step 2 regardless of outcome.
+   b. Valid: `git commit -m "refactor: apply simplify suggestions"` (husky adds DCO)
+   c. Invalid: revert via `git reset --hard HEAD && git clean -fd` (resets tracked, removes untracked `/simplify` artifacts)
+3. Continue to Step 2 regardless.
 
 ### Step 2: Spawn Review Agents
 
-**CRITICAL: Team isolation.** All review agents are internal sub-agents — they MUST be spawned as standalone background agents, never as team members. Do NOT pass `team_name` to any Agent call.
+**CRITICAL: Team isolation.** All review agents are internal sub-agents — MUST be standalone background agents, never team members. Do NOT pass `team_name`.
 
-**If parallel mode (default):**
+**Parallel mode (default):**
 
-Spawn all agents simultaneously using the Agent tool with `run_in_background: true` (no `team_name`):
+Spawn all agents simultaneously via Agent tool with `run_in_background: true` (no `team_name`):
 
 ```text
 Agent(pr-review-toolkit:code-reviewer, run_in_background: true): "Review code changes for issue workflow <workflow_id>"
@@ -108,13 +105,13 @@ Agent(pr-review-toolkit:pr-test-analyzer, run_in_background: true): "Analyze tes
 Agent(pr-review-toolkit:silent-failure-hunter, run_in_background: true): "Check for silent failures in changes"
 ```
 
-**If sequential mode:**
+**Sequential mode:**
 
-Spawn each agent one at a time using the Agent tool (no `team_name`), collecting results.
+Spawn one at a time via Agent tool (no `team_name`), collect results.
 
 ### Step 3: Collect and Normalize Findings
 
-Each agent returns findings in different formats. Normalize to:
+Each agent returns different formats. Normalize to:
 
 ```json
 {
@@ -155,9 +152,9 @@ while not fixed AND attempt < max_retry:
 
 ### Step 5: Re-Review After Fixes
 
-If any fixes were made:
+Any fixes made → validate:
 
-1. Run validation (each command separately):
+1. Validation (each command separately):
 
    ```bash
    bun run type-check
@@ -167,15 +164,15 @@ If any fixes were made:
    bun run lint
    ```
 
-2. If validation fails, revert last fix:
+2. Validation fails → revert last fix:
 
    ```bash
    git checkout -- <file>
    ```
 
-   Mark finding as not fixed.
+   Mark as not fixed.
 
-3. Optionally re-run review agents to verify fixes (if time permits).
+3. Optionally re-run review agents to verify fixes.
 
 ### Step 6: Calculate Summary
 
@@ -238,19 +235,15 @@ Summary: <unresolved> unresolved critical findings
 
 ## Escalation Trigger
 
-If `summary.unresolved > 0`:
-
-The calling workflow should escalate to user with:
+`summary.unresolved > 0` → calling workflow escalates with:
 
 - List of unresolved findings
 - Options: continue (manual fix), force-pr, abort
 
 ## Success Criteria
 
-This skill is successful when:
-
 - All review agents run (or gracefully skip on failure)
-- Findings are correctly classified by severity
+- Findings correctly classified by severity
 - Auto-fix attempted for all CRITICAL findings
-- Clear summary returned to orchestrator
+- Clear summary to orchestrator
 - Escalation triggered when appropriate

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -6,17 +6,17 @@ allowed-tools: Bash, Read, Skill
 
 # Setup Skill
 
-Prepares everything needed before implementation work begins.
+Prep before implementation.
 
 ## Contract
 
 ### Input
 
-| Field          | Type    | Required | Description                                         |
-| -------------- | ------- | -------- | --------------------------------------------------- |
-| `issue_number` | number  | Yes      | GitHub issue number                                 |
-| `branch_name`  | string  | No       | Custom branch name (auto-generated if not provided) |
-| `skip_notify`  | boolean | No       | Skip Telegram notification (default: false)         |
+| Field          | Type    | Required | Description                                |
+| -------------- | ------- | -------- | ------------------------------------------ |
+| `issue_number` | number  | Yes      | GitHub issue number                        |
+| `branch_name`  | string  | No       | Custom branch name (auto-generated if not) |
+| `skip_notify`  | boolean | No       | Skip Telegram notification (default false) |
 
 ### Output
 
@@ -30,8 +30,8 @@ Prepares everything needed before implementation work begins.
 
 ### Side Effects
 
-1. Creates git branch (or checks out existing)
-2. Sends Telegram notification (unless skip_notify)
+1. Create git branch (or check out existing)
+2. Send Telegram notification (unless skip_notify)
 
 ## Workflow
 
@@ -41,47 +41,30 @@ Prepares everything needed before implementation work begins.
 gh issue view <issue_number> --json number,title,body,labels,milestone,assignees
 ```
 
-If issue not found: STOP, return error.
+If not found: STOP, return error.
 
-Extract and store:
-
-- `issue.number`
-- `issue.title`
-- `issue.body`
-- `issue.labels` (array of label names)
+Store `issue.number`, `issue.title`, `issue.body`, `issue.labels`.
 
 ### Step 2: Generate Branch Name
 
-If `branch_name` not provided:
+If `branch_name` absent:
 
-- Extract short description from issue title (lowercase, hyphenated, max 30 chars)
+- Short description from title (lowercase, hyphenated, max 30 chars)
 - Format: `feat/issue-<number>-<short-description>`
 
-Example: Issue "Add user authentication" → `feat/issue-123-add-user-auth`
+Example: "Add user authentication" → `feat/issue-123-add-user-auth`
 
 ### Step 3: Create Branch
-
-Check current branch:
 
 ```bash
 git branch --show-current
 ```
 
-If not on target branch:
+Not on target → `git checkout -b <branch_name>`. Exists → `git checkout <branch_name>`.
 
-```bash
-git checkout -b <branch_name>
-```
+### Step 4: Notify (unless skip_notify)
 
-If branch already exists:
-
-```bash
-git checkout <branch_name>
-```
-
-### Step 4: Send Notification (unless skip_notify)
-
-Use the `telegram` skill (via Skill tool) to send a notification:
+Via `telegram` skill:
 
 ```text
 Started: Issue #<number>
@@ -89,11 +72,9 @@ Title: <title>
 Branch: <branch>
 ```
 
-**If notification fails:** Log warning, continue (non-critical).
+Notification fail → warn, continue (non-critical).
 
-### Step 5: Return Output
-
-Return structured output:
+### Step 5: Return
 
 ```json
 {
@@ -117,13 +98,7 @@ Return structured output:
 
 ## Example
 
-**Input:**
-
-```json
-{
-  "issue_number": 487
-}
-```
+**Input:** `{ "issue_number": 487 }`
 
 **Output:**
 
@@ -140,8 +115,6 @@ Return structured output:
 ```
 
 ## Output Format
-
-After completing all steps, report:
 
 ```text
 SETUP COMPLETE

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: setup
+description: Prepares environment for issue work - creates branch and fetches issue details. Use at the start of any issue workflow in Rollercoaster.dev-mobile.
+allowed-tools: Bash, Read, Skill
+---
+
+# Setup Skill
+
+Prepares everything needed before implementation work begins.
+
+## Contract
+
+### Input
+
+| Field          | Type    | Required | Description                                         |
+| -------------- | ------- | -------- | --------------------------------------------------- |
+| `issue_number` | number  | Yes      | GitHub issue number                                 |
+| `branch_name`  | string  | No       | Custom branch name (auto-generated if not provided) |
+| `skip_notify`  | boolean | No       | Skip Telegram notification (default: false)         |
+
+### Output
+
+| Field          | Type     | Description     |
+| -------------- | -------- | --------------- |
+| `branch`       | string   | Git branch name |
+| `issue.number` | number   | Issue number    |
+| `issue.title`  | string   | Issue title     |
+| `issue.body`   | string   | Full issue body |
+| `issue.labels` | string[] | Issue labels    |
+
+### Side Effects
+
+1. Creates git branch (or checks out existing)
+2. Sends Telegram notification (unless skip_notify)
+
+## Workflow
+
+### Step 1: Fetch Issue
+
+```bash
+gh issue view <issue_number> --json number,title,body,labels,milestone,assignees
+```
+
+If issue not found: STOP, return error.
+
+Extract and store:
+
+- `issue.number`
+- `issue.title`
+- `issue.body`
+- `issue.labels` (array of label names)
+
+### Step 2: Generate Branch Name
+
+If `branch_name` not provided:
+
+- Extract short description from issue title (lowercase, hyphenated, max 30 chars)
+- Format: `feat/issue-<number>-<short-description>`
+
+Example: Issue "Add user authentication" → `feat/issue-123-add-user-auth`
+
+### Step 3: Create Branch
+
+Check current branch:
+
+```bash
+git branch --show-current
+```
+
+If not on target branch:
+
+```bash
+git checkout -b <branch_name>
+```
+
+If branch already exists:
+
+```bash
+git checkout <branch_name>
+```
+
+### Step 4: Send Notification (unless skip_notify)
+
+Use the `telegram` skill (via Skill tool) to send a notification:
+
+```text
+Started: Issue #<number>
+Title: <title>
+Branch: <branch>
+```
+
+**If notification fails:** Log warning, continue (non-critical).
+
+### Step 5: Return Output
+
+Return structured output:
+
+```json
+{
+  "branch": "<branch_name>",
+  "issue": {
+    "number": <number>,
+    "title": "<title>",
+    "body": "<body>",
+    "labels": ["<label1>", "<label2>"]
+  }
+}
+```
+
+## Error Handling
+
+| Condition             | Behavior                      |
+| --------------------- | ----------------------------- |
+| Issue not found       | Return error, no side effects |
+| Branch checkout fails | Return error with git status  |
+| Notification fails    | Warn, continue                |
+
+## Example
+
+**Input:**
+
+```json
+{
+  "issue_number": 487
+}
+```
+
+**Output:**
+
+```json
+{
+  "branch": "feat/issue-487-agent-architecture",
+  "issue": {
+    "number": 487,
+    "title": "refactor(claude-tools): implement robust agent architecture",
+    "body": "## Problem\n\nThe current Claude tools architecture...",
+    "labels": ["enhancement", "priority:high"]
+  }
+}
+```
+
+## Output Format
+
+After completing all steps, report:
+
+```text
+SETUP COMPLETE
+
+Issue: #<number> - <title>
+Branch: <branch>
+
+Ready for next phase.
+```


### PR DESCRIPTION
## Summary

- Port the graph-flow `auto-issue` skill set (5 skills + 2 agents + slash command) into this repo, dropping graph-flow MCP tool calls and visual-test scaffolding. Plans route to `apps/native-rd/docs/plans/dev-plans/`.
- Mirror the 5 SKILLs under `.agents/skills/` (Codex parity, same pattern as `sentry-triage`). Agents stay Claude-only.
- Caveman-compress the 13 ported files in a follow-up commit: trim prose; preserve frontmatter, contract tables, code blocks, the anti-pattern table, hardcoded plan path, `Skill(...)`/`Agent(...)` invocations, and DCO/`--no-verify` warnings verbatim.

## Commits

1. `1a0c2c8` feat(claude): port graph-flow auto-issue skill set
2. `da98004` refactor(claude): caveman-compress auto-issue skill set

## Files

- `.claude/skills/{auto-issue,setup,implement,review,finalize}/SKILL.md`
- `.claude/agents/{issue-researcher,auto-fixer}.md`
- `.claude/commands/auto-issue.md`
- `.agents/skills/{auto-issue,setup,implement,review,finalize}/SKILL.md` (Codex mirrors)

## Verification

- Frontmatter parses cleanly on all 7 skill/agent files
- `diff -r .claude/skills/<name>/SKILL.md .agents/skills/<name>/SKILL.md` empty for all 5 pairs after compression
- DCO `--no-verify` guardrails preserved in `implement`, `auto-issue`, `auto-fixer`, and the anti-pattern table in `commands/auto-issue.md`
- Dry-run smoke test on issue #125 was executed in the port session: plan written to `apps/native-rd/docs/plans/dev-plans/issue-125-language-picker-promise-rejection.md` with all 10 template sections; no commits, no PR; cleaned up afterward
- `turbo type-check` cache-hit clean on the compression commit (lint-staged ran prettier and turbo type-check via husky)

## Test Plan

- [ ] Type-check passes (CI)
- [ ] Lint passes (CI)
- [ ] Tests pass (CI)
- [ ] DCO check passes on both commits (CI)
- [ ] Reviewer can spot-check that no graph-flow MCP calls (`a-board-update`, `c-update`) remain: `grep -RE 'a-board-update|c-update|graph-flow:init' .claude .agents` returns empty

## Notes for reviewer

- This PR does **not** wire `/auto-issue` into CI or set up any scheduling. It only ports the skill artifacts and trims their prose. First end-to-end run on a real issue is still gated on a fresh smoke test (deferred — would create a real Telegram + branch).
- Skill-name collisions: local `review` shadows the global "Review a pull request" skill within this project. Confirmed working in graph-flow. Flag if you want a different name (e.g. `auto-review`).
- Out of scope (logged in approved plan, not pulled in): visual-test (Maestro-based RN screenshots), GitHub Projects v2 board updates, Codex parity for `.claude/agents/` (agents are Claude-only by design), Layer 2 post-PR review path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)