### PR TITLE
feat(native-rd): show real release version on Settings screen

### DIFF
--- a/apps/native-rd/jest.config.js
+++ b/apps/native-rd/jest.config.js
@@ -63,6 +63,7 @@ module.exports = {
     "^expo-video$": "<rootDir>/src/__tests__/mocks/expo-video.ts",
     "^expo-secure-store$": "<rootDir>/src/__tests__/mocks/expo-secure-store.ts",
     "^expo-localization$": "<rootDir>/src/__tests__/mocks/expo-localization.ts",
+    "^expo-application$": "<rootDir>/src/__tests__/mocks/expo-application.ts",
 
     // Navigation — native stack navigator
     "^@react-navigation/native$": "<rootDir>/src/__tests__/mocks/navigation.ts",

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -56,6 +56,7 @@
     "@storybook/react-native": "^10.4.4",
     "buffer": "^6.0.3",
     "expo": "~55.0.25",
+    "expo-application": "~55.0.15",
     "expo-asset": "~55.0.17",
     "expo-audio": "~55.0.14",
     "expo-build-properties": "~55.0.14",

--- a/apps/native-rd/src/__tests__/mocks/expo-application.ts
+++ b/apps/native-rd/src/__tests__/mocks/expo-application.ts
@@ -1,0 +1,6 @@
+import appJson from "../../../app.json";
+
+export const nativeApplicationVersion: string = appJson.expo.version;
+export const nativeBuildVersion = "1";
+export const applicationId = "dev.rollercoaster.app";
+export const applicationName = "Rollercoaster.dev";

--- a/apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import {
   Alert,
   Platform,
 } from "react-native";
+import * as Application from "expo-application";
 import * as Sentry from "@sentry/react-native";
 import { useTranslation } from "react-i18next";
 import { Text } from "../../components/Text";
@@ -110,7 +111,7 @@ export function SettingsScreen({
           <SettingsRow label={t("about.appLabel")} value="rollercoaster.dev" />
           <SettingsRow
             label={t("about.versionLabel")}
-            value="0.1.0"
+            value={Application.nativeApplicationVersion ?? "unknown"}
             onLongPress={
               sentryDebugToolsEnabled ? triggerSentryNativeCrash : undefined
             }

--- a/apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
+++ b/apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
@@ -186,7 +186,7 @@ describe("SettingsScreen", () => {
       screen.getByText(i18n.t("settings:about.versionLabel")),
     ).toBeOnTheScreen();
     expect(
-      screen.getByText(Application.nativeApplicationVersion as string),
+      screen.getByText(Application.nativeApplicationVersion ?? "unknown"),
     ).toBeOnTheScreen();
   });
 

--- a/apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
+++ b/apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert, Platform } from "react-native";
+import * as Application from "expo-application";
 import {
   renderWithProviders,
   screen,
@@ -184,7 +185,9 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByText(i18n.t("settings:about.versionLabel")),
     ).toBeOnTheScreen();
-    expect(screen.getByText("0.1.0")).toBeOnTheScreen();
+    expect(
+      screen.getByText(Application.nativeApplicationVersion as string),
+    ).toBeOnTheScreen();
   });
 
   it("renders the footer text", () => {

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@storybook/react-native": "^10.4.4",
         "buffer": "^6.0.3",
         "expo": "~55.0.25",
+        "expo-application": "~55.0.15",
         "expo-asset": "~55.0.17",
         "expo-audio": "~55.0.14",
         "expo-build-properties": "~55.0.14",
@@ -1548,6 +1549,8 @@
 
     "expo": ["expo@55.0.26", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "55.0.32", "@expo/config": "~55.0.17", "@expo/config-plugins": "~55.0.10", "@expo/devtools": "55.0.3", "@expo/fingerprint": "0.16.7", "@expo/local-build-cache-provider": "55.0.13", "@expo/log-box": "55.0.12", "@expo/metro": "~55.1.1", "@expo/metro-config": "55.0.23", "@expo/vector-icons": "^15.0.2", "@ungap/structured-clone": "^1.3.0", "babel-preset-expo": "~55.0.22", "expo-asset": "~55.0.17", "expo-constants": "~55.0.16", "expo-file-system": "~55.0.22", "expo-font": "~55.0.8", "expo-keep-awake": "~55.0.8", "expo-modules-autolinking": "55.0.24", "expo-modules-core": "55.0.25", "pretty-format": "^29.7.0", "react-refresh": "^0.14.2", "whatwg-url-minimum": "^0.1.2" }, "peerDependencies": { "@expo/dom-webview": "*", "@expo/metro-runtime": "*", "react": "*", "react-native": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/dom-webview", "@expo/metro-runtime", "react-native-webview"], "bin": { "expo": "bin/cli", "fingerprint": "bin/fingerprint", "expo-modules-autolinking": "bin/autolinking" } }, "sha512-MuVW6Uzd/Jh6E37ICOYAiTOm9nflNMUNzf6wH5ld/IXFyuF2Lo86a8fCSMgHcvTGsSjRsJ5Uxhf+WHZcvGPfrg=="],
 
+    "expo-application": ["expo-application@55.0.15", "", { "peerDependencies": { "expo": "*" } }, "sha512-eWf5OGrat1r/TYr0daL684C6pJYiN2k30NmcISsD9fbtZLfA6Sbo/JebfYzP3OjO/T/i8j/9Pf3ePqUYPLfZnw=="],
+
     "expo-asset": ["expo-asset@55.0.17", "", { "dependencies": { "@expo/image-utils": "^0.8.14", "expo-constants": "~55.0.16" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-pK9HHJuFqjE8kDUcbMFsZj3Cz8WdXpvZHZmYl7ouFQp59P83BvHln6VnqPDGlO+/4929G0Lm8ZUzbONuNRhi9w=="],
 
     "expo-audio": ["expo-audio@55.0.14", "", { "peerDependencies": { "expo": "*", "expo-asset": "*", "react": "*", "react-native": "*" } }, "sha512-Biy6ffKXrnKHgcWSVWLKVdWLNhV/pj1JWJeotY6nDR6fVe8mjXQDCvi6EbaSFPdffVHym6UB2siKzWUNSnG+kQ=="],
@@ -1568,9 +1571,9 @@
 
     "expo-document-picker": ["expo-document-picker@55.0.13", "", { "peerDependencies": { "expo": "*" } }, "sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g=="],
 
-    "expo-file-system": ["expo-file-system@55.0.19", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-c4smCbMqELLI3YQrGpw21MwZIREXM2e53vQD/+KWQcae1q+hgw8J2TroEqcQ/jVOtFpZYVvyVfgu4HDKNEKmNw=="],
+    "expo-file-system": ["expo-file-system@55.0.22", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-T5Rfv3vqcFyhVrl/tEEeglc/J8LJbcZQgC3TMT5jxzIgUgWmIgJEgncGYqB/YNXFgUTL2LiuCvqrU51Dzp83NQ=="],
 
-    "expo-font": ["expo-font@55.0.7", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-oH39Xb+3i6Y69b7YRP+P+5WLx7621t+ep/RAgLwJJYpTjs7CnSohUG+873rEtqsTAuQGi63ms7x9ZeHj1E9LYw=="],
+    "expo-font": ["expo-font@55.0.8", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-WyP75pnKqhLNktYwDn3xKAUNt5rLihRDv8XWGhhz6VEhVqypixpT86NA3uGtiDTlM3gGjhrYCY7o7ypXgCUOZg=="],
 
     "expo-haptics": ["expo-haptics@55.0.14", "", { "peerDependencies": { "expo": "*" } }, "sha512-KjDItBsA9mi1f5nRwf8g1wOdfEcLHwvEdt5Jl1sMCDETR/homcGOl+F3QIiPOl/PRlbGVieQsjTtF4DGtHOj6g=="],
 
@@ -2898,8 +2901,6 @@
 
     "@expo/prebuild-config/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "@expo/router-server/expo-font": ["expo-font@55.0.8", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-WyP75pnKqhLNktYwDn3xKAUNt5rLihRDv8XWGhhz6VEhVqypixpT86NA3uGtiDTlM3gGjhrYCY7o7ypXgCUOZg=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
@@ -3071,10 +3072,6 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "expo/expo-file-system": ["expo-file-system@55.0.22", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-T5Rfv3vqcFyhVrl/tEEeglc/J8LJbcZQgC3TMT5jxzIgUgWmIgJEgncGYqB/YNXFgUTL2LiuCvqrU51Dzp83NQ=="],
-
-    "expo/expo-font": ["expo-font@55.0.8", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-WyP75pnKqhLNktYwDn3xKAUNt5rLihRDv8XWGhhz6VEhVqypixpT86NA3uGtiDTlM3gGjhrYCY7o7ypXgCUOZg=="],
 
     "expo/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"0.1.0"` on the Settings screen with `Application.nativeApplicationVersion` from `expo-application`, so the displayed version always matches what's actually baked into the native binary (`CFBundleShortVersionString` / `versionName`) at prebuild from `app.json`'s `expo.version`.
- Currently renders as `0.1.7`; will auto-track future `app.json` bumps with no further code changes.
- Adds a Jest mock for `expo-application` that derives from `app.json` so future version bumps don't rot the test. The assertion now reads from the mocked module rather than a literal — it exercises the wiring instead of a magic string.

### Why `expo-application` over `Constants.expoConfig`

`Constants.expoConfig.version` reads from the JS bundle config — that drifts away from reality once you ship OTA updates via EAS Update. `Application.nativeApplicationVersion` reads from the native shell, which only changes via a new store binary. For a Settings/About display, that's the version users would report to support.

## Test plan

- [x] `bun run type-check` passes
- [x] `bun run lint` passes (no new warnings in touched files)
- [x] `bash scripts/jest-node.sh --testPathPatterns SettingsScreen` — 22/22 tests pass
- [ ] On-device visual verification via `npx expo run:ios` — Settings → About → Version row shows `0.1.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)