### PR TITLE
feat(native-rd): add i18n json tree utilities (#155)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
@@ -1,0 +1,58 @@
+# Development Plan: Issue #155
+
+## Intent Verification
+
+- [x] Module exposed at `apps/native-rd/scripts/i18n/jsonTreeUtils.ts`, pure functions only: no I/O, no LLM calls, no logging side effects.
+- [x] `deepFillMissingStrings` preserves every existing target string verbatim; rerunning against a fully translated tree returns an equivalent tree with no new gaps.
+- [x] `translatableSubtree` exposes only anonymized keys (`k0..kN`) in the LLM-facing dict; real paths live only in the returned path map.
+- [x] `mergeTranslations` round-trips via the path map without path drift; output source keys are emitted in source order.
+- [x] Tests cover nested objects, empty target, fully populated target, mixed target, arrays of strings, and identical English strings at different paths.
+- [ ] `bun run type-check && bun run lint && bun run test` are clean.
+
+## Implementation Plan
+
+- [x] Create or reconcile `apps/native-rd/scripts/i18n/jsonTreeUtils.ts` with exported JSON/tree types, `deepFillMissingStrings`, `translatableSubtree`, and `mergeTranslations`; do not overwrite any existing untracked draft.
+- [x] Model values as JSON-compatible translation trees: string leaves, arrays, and object records. Treat only strings as translatable leaves.
+- [x] Define "missing" strictly as an absent key/index. Existing target strings, including `""`, count as present and must not be overwritten.
+- [x] Make shape mismatches fail loudly with a thrown error instead of silently replacing target data. Examples: source branch vs target string, source string vs target object.
+- [x] Implement traversal in source order. Preserve target-only keys by appending them after source keys so stale/manual target entries are not deleted.
+- [x] Have `deepFillMissingStrings(source, target)` return a new target-shaped tree where missing source string leaves are filled with an internal translation-needed marker object.
+- [x] Have `translatableSubtree(source, target)` return `{ dict, pathMap }`, where `dict` is insertion-ordered as `k0`, `k1`, ... and `pathMap` is an opaque internal structure containing real paths plus enough source-order shape metadata for re-merge.
+- [x] Have `mergeTranslations(target, dict, pathMap)` return a new tree, write translated strings only into still-missing paths, preserve existing target strings, and throw if a dict key has no path-map entry or a path-map key has no translated string.
+- [x] Add tests in `apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts` importing `../../../scripts/i18n/jsonTreeUtils`; this fits the current Jest `testMatch` without config churn.
+- [x] Test immutability for all three exports: input source, target, dict, and path map are not mutated.
+- [ ] Run the focused test first with `bun run test --testPathPatterns src/i18n/__tests__/jsonTreeUtils.test.ts`, then run full `bun run type-check && bun run lint && bun run test`.
+
+## Decisions
+
+| ID  | Decision                                                                                | Rationale                                                                                                                                                           |
+| --- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Use absent key/index as the only missing signal.                                        | Preserves the idempotency guarantee; an empty string or English-looking target value may be intentional and must not be retranslated.                               |
+| D2  | Throw on source/target shape conflicts.                                                 | Replacing a target string with an object, or vice versa, would violate "no overwrites"; silently skipping would hide broken locale data.                            |
+| D3  | Keep the LLM-facing dict flat and key-anonymized; keep real paths only in the path map. | Matches invariant #3 from the parent i18n plan and prevents prompt context from leaking key names.                                                                  |
+| D4  | Make the path map opaque and include source-order metadata, not just `k -> path`.       | `mergeTranslations(target, dict, pathMap)` does not receive `source`; source-order output is otherwise impossible to guarantee for already-populated target leaves. |
+| D5  | Support arrays recursively, even though current `en` namespaces have no arrays.         | `TranslationTree` already allows arrays in `pseudoTransform.ts`, and the issue calls out arrays-of-strings as a coverage case if present.                           |
+| D6  | Place tests under `src/i18n/__tests__` instead of `scripts/i18n`.                       | Current Jest config only discovers `**/src/**/__tests__/**/*.test.{ts,tsx}`; this avoids changing test infrastructure for a pure utility module.                    |
+| D7  | Use an internal marker object for missing leaves instead of the raw source string.      | A raw English source string would be indistinguishable from an intentional existing target value and would weaken idempotency.                                      |
+
+## Discovery Log
+
+- Issue #155 is the first PR in the i18n LLM sync sequence and is scoped to pure tree operations only.
+- Parent plan invariants relevant here: gap-only translation, key anonymization, single JSON pipeline, and runtime untouched by sync metadata.
+- Current resources have 15 namespaces under `src/i18n/resources/en`, `de`, and `pseudo`.
+- Current `de/*.json` files are all `{}` stubs, so empty-target behavior is the initial real-world path.
+- Current `en/*.json` files contain 264 string leaves, max depth 4, and no arrays at the moment.
+- Duplicate English strings exist at different paths (`"Discard"`, `"Open Settings"`, etc.), so merge identity must be path-based, never value-based.
+- Existing pure tree precedent: `src/i18n/pseudoTransform.ts` exports a `TranslationTree` type and recursively handles objects and arrays without mutation.
+- Existing Jest discovery excludes `scripts/**` tests; test files should either live under `src/**/__tests__` or require a Jest config change. This plan chooses the former.
+- Local status showed untracked `apps/native-rd/scripts/i18n/jsonTreeUtils.ts` and `apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts` drafts during research; treat them as someone else's work unless ownership is confirmed.
+- [2026-05-24 13:50] Implemented the missing marker as an internal object rather than the raw source string so the utilities can distinguish a gap from an intentional existing English target value.
+
+## Not in Scope
+
+- Reading or writing locale files.
+- Calling an LLM or validating LLM output shape beyond the anonymized translation dict contract.
+- Placeholder validation for `{{name}}`; that belongs to `placeholderGuard.ts`.
+- Prompt building, register/intent sidecars, glossary logic, or model selection.
+- CI workflow changes or bot commit-back behavior.
+- Generating German translations.

--- a/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
@@ -48,6 +48,7 @@
 - Local status showed untracked `apps/native-rd/scripts/i18n/jsonTreeUtils.ts` and `apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts` drafts during research; treat them as someone else's work unless ownership is confirmed.
 - [2026-05-24 13:50] Implemented the missing marker as an internal object rather than the raw source string so the utilities can distinguish a gap from an intentional existing English target value.
 - [2026-05-24 13:54] Final validation passed. `bun run lint` exits 0 with pre-existing warnings elsewhere in the app; `bun run test` passes 153 suites / 8277 tests with the existing worker open-handle warning. Raw `bun test` crashes in Bun before Jest runs, so validation uses the package script.
+- [2026-05-24 13:58] Review fixes added exact translation-key validation, stale path-map failure, source-shape snapshotting, target-only value validation, sparse-array checks, and stronger source-order tests.
 
 ## Not in Scope
 

--- a/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
@@ -7,7 +7,7 @@
 - [x] `translatableSubtree` exposes only anonymized keys (`k0..kN`) in the LLM-facing dict; real paths live only in the returned path map.
 - [x] `mergeTranslations` round-trips via the path map without path drift; output source keys are emitted in source order.
 - [x] Tests cover nested objects, empty target, fully populated target, mixed target, arrays of strings, and identical English strings at different paths.
-- [ ] `bun run type-check && bun run lint && bun run test` are clean.
+- [x] `bun run type-check && bun run lint && bun run test` are clean.
 
 ## Implementation Plan
 
@@ -21,7 +21,7 @@
 - [x] Have `mergeTranslations(target, dict, pathMap)` return a new tree, write translated strings only into still-missing paths, preserve existing target strings, and throw if a dict key has no path-map entry or a path-map key has no translated string.
 - [x] Add tests in `apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts` importing `../../../scripts/i18n/jsonTreeUtils`; this fits the current Jest `testMatch` without config churn.
 - [x] Test immutability for all three exports: input source, target, dict, and path map are not mutated.
-- [ ] Run the focused test first with `bun run test --testPathPatterns src/i18n/__tests__/jsonTreeUtils.test.ts`, then run full `bun run type-check && bun run lint && bun run test`.
+- [x] Run the focused test first with `bun run test --testPathPatterns src/i18n/__tests__/jsonTreeUtils.test.ts`, then run full `bun run type-check && bun run lint && bun run test`.
 
 ## Decisions
 
@@ -47,6 +47,7 @@
 - Existing Jest discovery excludes `scripts/**` tests; test files should either live under `src/**/__tests__` or require a Jest config change. This plan chooses the former.
 - Local status showed untracked `apps/native-rd/scripts/i18n/jsonTreeUtils.ts` and `apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts` drafts during research; treat them as someone else's work unless ownership is confirmed.
 - [2026-05-24 13:50] Implemented the missing marker as an internal object rather than the raw source string so the utilities can distinguish a gap from an intentional existing English target value.
+- [2026-05-24 13:54] Final validation passed. `bun run lint` exits 0 with pre-existing warnings elsewhere in the app; `bun run test` passes 153 suites / 8277 tests with the existing worker open-handle warning. Raw `bun test` crashes in Bun before Jest runs, so validation uses the package script.
 
 ## Not in Scope
 

--- a/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-155-json-tree-utils.md
@@ -49,6 +49,7 @@
 - [2026-05-24 13:50] Implemented the missing marker as an internal object rather than the raw source string so the utilities can distinguish a gap from an intentional existing English target value.
 - [2026-05-24 13:54] Final validation passed. `bun run lint` exits 0 with pre-existing warnings elsewhere in the app; `bun run test` passes 153 suites / 8277 tests with the existing worker open-handle warning. Raw `bun test` crashes in Bun before Jest runs, so validation uses the package script.
 - [2026-05-24 13:58] Review fixes added exact translation-key validation, stale path-map failure, source-shape snapshotting, target-only value validation, sparse-array checks, and stronger source-order tests.
+- [2026-05-24 14:00] Post-review validation passed: `bun run type-check`, `bun run lint` (0 errors, pre-existing warnings), `bun run test` (153 suites / 8281 tests), and `bun run build`.
 
 ## Not in Scope
 

--- a/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
+++ b/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
@@ -49,6 +49,59 @@ function hasIndex(value: readonly unknown[], index: number): boolean {
   return Object.prototype.hasOwnProperty.call(value, index);
 }
 
+function hasOwnKey(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function assertNoSparseArray(value: readonly unknown[], label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    if (!hasIndex(value, index)) {
+      throw new Error(`${label} contains a sparse array hole`);
+    }
+  }
+}
+
+function assertFilledJsonTree(
+  value: unknown,
+  label: string,
+): asserts value is FilledJsonTree {
+  if (typeof value === "string" || isMissingTranslation(value)) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    assertNoSparseArray(value, label);
+    value.forEach((child) => assertFilledJsonTree(child, label));
+    return;
+  }
+
+  if (isRecord(value)) {
+    Object.values(value).forEach((child) => assertFilledJsonTree(child, label));
+    return;
+  }
+
+  throw new Error(`${label} contains a non-string leaf`);
+}
+
+function cloneJsonTree(source: JsonTree): JsonTree {
+  if (typeof source === "string") {
+    return source;
+  }
+
+  if (Array.isArray(source)) {
+    assertNoSparseArray(source, "Source tree");
+    return source.map(cloneJsonTree);
+  }
+
+  const result: Record<string, JsonTree> = {};
+
+  for (const [key, child] of Object.entries(source)) {
+    result[key] = cloneJsonTree(child);
+  }
+
+  return result;
+}
+
 function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
   if (typeof source === "string") {
     if (target === undefined || isMissingTranslation(target)) {
@@ -63,11 +116,14 @@ function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
   }
 
   if (Array.isArray(source)) {
+    assertNoSparseArray(source, "Source tree");
+
     if (target !== undefined && !Array.isArray(target)) {
       throw new Error("Target shape conflict at array branch");
     }
 
     const targetArray = target ?? [];
+    assertNoSparseArray(targetArray, "Target tree");
     const result = source.map((child, index) =>
       fillMissing(
         child,
@@ -76,7 +132,9 @@ function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
     );
 
     for (let index = source.length; index < targetArray.length; index += 1) {
-      result.push(targetArray[index] as FilledJsonTree);
+      const extraTargetValue = targetArray[index];
+      assertFilledJsonTree(extraTargetValue, "Target tree");
+      result.push(extraTargetValue);
     }
 
     return result;
@@ -94,8 +152,9 @@ function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
   }
 
   for (const [key, value] of Object.entries(targetObject)) {
-    if (!(key in result)) {
-      result[key] = value as FilledJsonTree;
+    if (!hasOwnKey(result, key)) {
+      assertFilledJsonTree(value, "Target tree");
+      result[key] = value;
     }
   }
 
@@ -127,11 +186,14 @@ function collectMissing(
   }
 
   if (Array.isArray(source)) {
+    assertNoSparseArray(source, "Source tree");
+
     if (target !== undefined && !Array.isArray(target)) {
       throw new Error("Target shape conflict at array branch");
     }
 
     const targetArray = target ?? [];
+    assertNoSparseArray(targetArray, "Target tree");
     source.forEach((child, index) => {
       collectMissing(
         child,
@@ -227,7 +289,7 @@ export function translatableSubtree(
   return {
     dict,
     pathMap: {
-      source,
+      source: cloneJsonTree(source),
       paths,
       keys,
     },
@@ -240,6 +302,13 @@ export function mergeTranslations(
   pathMap: TranslationPathMap,
 ): FilledJsonTree {
   let result = deepFillMissingStrings(pathMap.source, target);
+  const expectedKeys = new Set(pathMap.keys);
+
+  for (const key of Object.keys(dict)) {
+    if (!expectedKeys.has(key)) {
+      throw new Error(`Unexpected translation key ${key}`);
+    }
+  }
 
   for (const key of pathMap.keys) {
     const path = pathMap.paths[key];
@@ -253,9 +322,11 @@ export function mergeTranslations(
       throw new Error(`Missing translation for key ${key}`);
     }
 
-    if (isMissingTranslation(getAtPath(result, path))) {
-      result = setAtPath(result, path, translation);
+    if (!isMissingTranslation(getAtPath(result, path))) {
+      throw new Error(`Translation path for key ${key} is not missing`);
     }
+
+    result = setAtPath(result, path, translation);
   }
 
   return result;

--- a/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
+++ b/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
@@ -1,0 +1,262 @@
+const MISSING_TRANSLATION = "__rollercoasterMissingTranslation";
+
+type JsonObject = { readonly [key: string]: JsonTree };
+
+export type JsonTree = string | readonly JsonTree[] | JsonObject;
+
+export type TranslationDict = Record<string, string>;
+export type PathSegment = string | number;
+
+export type MissingTranslation = {
+  readonly [MISSING_TRANSLATION]: true;
+  readonly source: string;
+};
+
+export type FilledJsonTree =
+  | string
+  | readonly FilledJsonTree[]
+  | { readonly [key: string]: FilledJsonTree }
+  | MissingTranslation;
+
+export type TranslationPathMap = {
+  readonly source: JsonTree;
+  readonly paths: Readonly<Record<string, readonly PathSegment[]>>;
+  readonly keys: readonly string[];
+};
+
+export type TranslatableSubtree = {
+  readonly dict: TranslationDict;
+  readonly pathMap: TranslationPathMap;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isMissingTranslation(value: unknown): value is MissingTranslation {
+  return (
+    isRecord(value) &&
+    value[MISSING_TRANSLATION] === true &&
+    typeof value.source === "string"
+  );
+}
+
+function markMissing(source: string): MissingTranslation {
+  return { [MISSING_TRANSLATION]: true, source };
+}
+
+function hasIndex(value: readonly unknown[], index: number): boolean {
+  return Object.prototype.hasOwnProperty.call(value, index);
+}
+
+function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
+  if (typeof source === "string") {
+    if (target === undefined || isMissingTranslation(target)) {
+      return markMissing(source);
+    }
+
+    if (typeof target !== "string") {
+      throw new Error("Target shape conflict at string leaf");
+    }
+
+    return target;
+  }
+
+  if (Array.isArray(source)) {
+    if (target !== undefined && !Array.isArray(target)) {
+      throw new Error("Target shape conflict at array branch");
+    }
+
+    const targetArray = target ?? [];
+    const result = source.map((child, index) =>
+      fillMissing(
+        child,
+        hasIndex(targetArray, index) ? targetArray[index] : undefined,
+      ),
+    );
+
+    for (let index = source.length; index < targetArray.length; index += 1) {
+      result.push(targetArray[index] as FilledJsonTree);
+    }
+
+    return result;
+  }
+
+  if (target !== undefined && !isRecord(target)) {
+    throw new Error("Target shape conflict at object branch");
+  }
+
+  const targetObject = target ?? {};
+  const result: Record<string, FilledJsonTree> = {};
+
+  for (const [key, child] of Object.entries(source)) {
+    result[key] = fillMissing(child, targetObject[key]);
+  }
+
+  for (const [key, value] of Object.entries(targetObject)) {
+    if (!(key in result)) {
+      result[key] = value as FilledJsonTree;
+    }
+  }
+
+  return result;
+}
+
+function collectMissing(
+  source: JsonTree,
+  target: unknown,
+  path: readonly PathSegment[],
+  dict: TranslationDict,
+  paths: Record<string, readonly PathSegment[]>,
+  keys: string[],
+): void {
+  if (typeof source === "string") {
+    if (target === undefined || isMissingTranslation(target)) {
+      const key = `k${keys.length}`;
+      keys.push(key);
+      dict[key] = source;
+      paths[key] = path;
+      return;
+    }
+
+    if (typeof target !== "string") {
+      throw new Error("Target shape conflict at string leaf");
+    }
+
+    return;
+  }
+
+  if (Array.isArray(source)) {
+    if (target !== undefined && !Array.isArray(target)) {
+      throw new Error("Target shape conflict at array branch");
+    }
+
+    const targetArray = target ?? [];
+    source.forEach((child, index) => {
+      collectMissing(
+        child,
+        hasIndex(targetArray, index) ? targetArray[index] : undefined,
+        [...path, index],
+        dict,
+        paths,
+        keys,
+      );
+    });
+    return;
+  }
+
+  if (target !== undefined && !isRecord(target)) {
+    throw new Error("Target shape conflict at object branch");
+  }
+
+  const targetObject = target ?? {};
+  for (const [key, child] of Object.entries(source)) {
+    collectMissing(child, targetObject[key], [...path, key], dict, paths, keys);
+  }
+}
+
+function getAtPath(
+  value: FilledJsonTree,
+  path: readonly PathSegment[],
+): unknown {
+  let current: unknown = value;
+
+  for (const segment of path) {
+    if (Array.isArray(current) && typeof segment === "number") {
+      current = current[segment];
+      continue;
+    }
+
+    if (isRecord(current) && typeof segment === "string") {
+      current = current[segment];
+      continue;
+    }
+
+    return undefined;
+  }
+
+  return current;
+}
+
+function setAtPath(
+  value: FilledJsonTree,
+  path: readonly PathSegment[],
+  replacement: string,
+): FilledJsonTree {
+  if (path.length === 0) {
+    return replacement;
+  }
+
+  const [segment, ...rest] = path;
+
+  if (Array.isArray(value) && typeof segment === "number") {
+    const next = [...value];
+    next[segment] = setAtPath(next[segment], rest, replacement);
+    return next;
+  }
+
+  if (isRecord(value) && typeof segment === "string") {
+    const objectValue = value as Record<string, FilledJsonTree>;
+
+    return {
+      ...objectValue,
+      [segment]: setAtPath(objectValue[segment], rest, replacement),
+    };
+  }
+
+  return value;
+}
+
+export function deepFillMissingStrings(
+  source: JsonTree,
+  target: unknown,
+): FilledJsonTree {
+  return fillMissing(source, target);
+}
+
+export function translatableSubtree(
+  source: JsonTree,
+  target: unknown,
+): TranslatableSubtree {
+  const dict: TranslationDict = {};
+  const paths: Record<string, readonly PathSegment[]> = {};
+  const keys: string[] = [];
+
+  collectMissing(source, target, [], dict, paths, keys);
+
+  return {
+    dict,
+    pathMap: {
+      source,
+      paths,
+      keys,
+    },
+  };
+}
+
+export function mergeTranslations(
+  target: unknown,
+  dict: TranslationDict,
+  pathMap: TranslationPathMap,
+): FilledJsonTree {
+  let result = deepFillMissingStrings(pathMap.source, target);
+
+  for (const key of pathMap.keys) {
+    const path = pathMap.paths[key];
+    const translation = dict[key];
+
+    if (path === undefined) {
+      throw new Error(`Missing path for translation key ${key}`);
+    }
+
+    if (translation === undefined) {
+      throw new Error(`Missing translation for key ${key}`);
+    }
+
+    if (isMissingTranslation(getAtPath(result, path))) {
+      result = setAtPath(result, path, translation);
+    }
+  }
+
+  return result;
+}

--- a/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
+++ b/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
@@ -323,6 +323,10 @@ export function mergeTranslations(
       throw new Error(`Missing translation for key ${key}`);
     }
 
+    if (typeof translation !== "string") {
+      throw new Error(`Translation for key ${key} must be a string`);
+    }
+
     if (!isMissingTranslation(getAtPath(result, path))) {
       throw new Error(`Translation path for key ${key} is not missing`);
     }

--- a/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
+++ b/apps/native-rd/scripts/i18n/jsonTreeUtils.ts
@@ -102,6 +102,28 @@ function cloneJsonTree(source: JsonTree): JsonTree {
   return result;
 }
 
+function targetArrayForBranch(target: unknown): readonly unknown[] {
+  if (target !== undefined && !Array.isArray(target)) {
+    throw new Error("Target shape conflict at array branch");
+  }
+
+  const targetArray = target ?? [];
+  assertNoSparseArray(targetArray, "Target tree");
+  return targetArray;
+}
+
+function targetObjectForBranch(target: unknown): Record<string, unknown> {
+  if (target !== undefined && !isRecord(target)) {
+    throw new Error("Target shape conflict at object branch");
+  }
+
+  return target ?? {};
+}
+
+function targetChild(targetArray: readonly unknown[], index: number): unknown {
+  return hasIndex(targetArray, index) ? targetArray[index] : undefined;
+}
+
 function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
   if (typeof source === "string") {
     if (target === undefined || isMissingTranslation(target)) {
@@ -118,17 +140,9 @@ function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
   if (Array.isArray(source)) {
     assertNoSparseArray(source, "Source tree");
 
-    if (target !== undefined && !Array.isArray(target)) {
-      throw new Error("Target shape conflict at array branch");
-    }
-
-    const targetArray = target ?? [];
-    assertNoSparseArray(targetArray, "Target tree");
+    const targetArray = targetArrayForBranch(target);
     const result = source.map((child, index) =>
-      fillMissing(
-        child,
-        hasIndex(targetArray, index) ? targetArray[index] : undefined,
-      ),
+      fillMissing(child, targetChild(targetArray, index)),
     );
 
     for (let index = source.length; index < targetArray.length; index += 1) {
@@ -140,11 +154,7 @@ function fillMissing(source: JsonTree, target: unknown): FilledJsonTree {
     return result;
   }
 
-  if (target !== undefined && !isRecord(target)) {
-    throw new Error("Target shape conflict at object branch");
-  }
-
-  const targetObject = target ?? {};
+  const targetObject = targetObjectForBranch(target);
   const result: Record<string, FilledJsonTree> = {};
 
   for (const [key, child] of Object.entries(source)) {
@@ -188,16 +198,11 @@ function collectMissing(
   if (Array.isArray(source)) {
     assertNoSparseArray(source, "Source tree");
 
-    if (target !== undefined && !Array.isArray(target)) {
-      throw new Error("Target shape conflict at array branch");
-    }
-
-    const targetArray = target ?? [];
-    assertNoSparseArray(targetArray, "Target tree");
+    const targetArray = targetArrayForBranch(target);
     source.forEach((child, index) => {
       collectMissing(
         child,
-        hasIndex(targetArray, index) ? targetArray[index] : undefined,
+        targetChild(targetArray, index),
         [...path, index],
         dict,
         paths,
@@ -207,11 +212,7 @@ function collectMissing(
     return;
   }
 
-  if (target !== undefined && !isRecord(target)) {
-    throw new Error("Target shape conflict at object branch");
-  }
-
-  const targetObject = target ?? {};
+  const targetObject = targetObjectForBranch(target);
   for (const [key, child] of Object.entries(source)) {
     collectMissing(child, targetObject[key], [...path, key], dict, paths, keys);
   }

--- a/apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts
+++ b/apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts
@@ -226,6 +226,17 @@ describe("jsonTreeUtils", () => {
     ).toThrow("Unexpected translation key");
   });
 
+  test("throws on non-string translation values", () => {
+    const { pathMap } = translatableSubtree({ label: "Label" }, {});
+    const malformedDict = { k0: { text: "Neu" } } as unknown as Parameters<
+      typeof mergeTranslations
+    >[1];
+
+    expect(() => mergeTranslations({}, malformedDict, pathMap)).toThrow(
+      "must be a string",
+    );
+  });
+
   test("throws on malformed target-only values and sparse arrays", () => {
     expect(() => deepFillMissingStrings({}, { stale: 1 })).toThrow(
       "non-string leaf",

--- a/apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts
+++ b/apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts
@@ -37,15 +37,21 @@ describe("jsonTreeUtils", () => {
       ["status"],
     ]);
 
-    expect(
-      Object.keys(
-        mergeTranslations(
-          {},
-          { k0: "Speichern", k1: "Abbrechen", k2: "Bereit" },
-          pathMap,
-        ) as Record<string, unknown>,
-      ),
-    ).toEqual(["actions", "status"]);
+    const merged = mergeTranslations(
+      {},
+      { k0: "Speichern", k1: "Abbrechen", k2: "Bereit" },
+      pathMap,
+    ) as { actions: Record<string, unknown>; status: string };
+
+    expect(merged).toEqual({
+      actions: {
+        save: "Speichern",
+        cancel: "Abbrechen",
+      },
+      status: "Bereit",
+    });
+    expect(Object.keys(merged)).toEqual(["actions", "status"]);
+    expect(Object.keys(merged.actions)).toEqual(["save", "cancel"]);
   });
 
   test("preserves existing target values and only extracts missing leaves", () => {
@@ -108,6 +114,34 @@ describe("jsonTreeUtils", () => {
     expect(dict).toEqual({});
     expect(deepFillMissingStrings(source, target)).toEqual(target);
     expect(mergeTranslations(target, {}, pathMap)).toEqual(target);
+  });
+
+  test("reorders fully populated target leaves to match source order", () => {
+    const source = {
+      actions: {
+        save: "Save",
+        cancel: "Cancel",
+      },
+    };
+    const target = {
+      actions: {
+        cancel: "Abbrechen",
+        save: "Speichern",
+      },
+    };
+
+    const { pathMap } = translatableSubtree(source, target);
+    const merged = mergeTranslations(target, {}, pathMap) as {
+      actions: Record<string, unknown>;
+    };
+
+    expect(Object.keys(merged.actions)).toEqual(["save", "cancel"]);
+    expect(merged).toEqual({
+      actions: {
+        save: "Speichern",
+        cancel: "Abbrechen",
+      },
+    });
   });
 
   test("handles arrays of strings without overwriting populated indexes", () => {
@@ -178,6 +212,54 @@ describe("jsonTreeUtils", () => {
     expect(() =>
       translatableSubtree({ label: "Label" }, { label: { text: "Alt" } }),
     ).toThrow("Target shape conflict");
+  });
+
+  test("throws on stale path maps and unexpected translation keys", () => {
+    const { pathMap } = translatableSubtree({ label: "Label" }, {});
+
+    expect(() =>
+      mergeTranslations({ label: "Alt" }, { k0: "Neu" }, pathMap),
+    ).toThrow("is not missing");
+
+    expect(() =>
+      mergeTranslations({ label: "Alt" }, { k999: "Extra" }, pathMap),
+    ).toThrow("Unexpected translation key");
+  });
+
+  test("throws on malformed target-only values and sparse arrays", () => {
+    expect(() => deepFillMissingStrings({}, { stale: 1 })).toThrow(
+      "non-string leaf",
+    );
+
+    const sparseSource = ["Start", , "Finish"] as unknown as Parameters<
+      typeof translatableSubtree
+    >[0];
+
+    expect(() => translatableSubtree(sparseSource, [])).toThrow(
+      "sparse array hole",
+    );
+  });
+
+  test("path map keeps a snapshot of source shape", () => {
+    const source: { actions: Record<string, string> } = {
+      actions: {
+        save: "Save",
+      },
+    };
+    const { pathMap } = translatableSubtree(source, {});
+
+    source.actions = {
+      cancel: "Cancel",
+      save: "Save",
+    };
+
+    const merged = mergeTranslations({}, { k0: "Speichern" }, pathMap);
+
+    expect(merged).toEqual({
+      actions: {
+        save: "Speichern",
+      },
+    });
   });
 
   test("does not mutate source, target, dict, or path map", () => {

--- a/apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts
+++ b/apps/native-rd/src/i18n/__tests__/jsonTreeUtils.test.ts
@@ -1,0 +1,210 @@
+import {
+  deepFillMissingStrings,
+  mergeTranslations,
+  translatableSubtree,
+} from "../../../scripts/i18n/jsonTreeUtils";
+
+describe("jsonTreeUtils", () => {
+  test("fills an empty target and merges translations in source key order", () => {
+    const source = {
+      actions: {
+        save: "Save",
+        cancel: "Cancel",
+      },
+      status: "Ready",
+    };
+
+    const filled = deepFillMissingStrings(source, {});
+
+    expect(filled).toEqual({
+      actions: {
+        save: expect.objectContaining({ source: "Save" }),
+        cancel: expect.objectContaining({ source: "Cancel" }),
+      },
+      status: expect.objectContaining({ source: "Ready" }),
+    });
+
+    const { dict, pathMap } = translatableSubtree(source, {});
+
+    expect(dict).toEqual({
+      k0: "Save",
+      k1: "Cancel",
+      k2: "Ready",
+    });
+    expect(Object.values(pathMap.paths)).toEqual([
+      ["actions", "save"],
+      ["actions", "cancel"],
+      ["status"],
+    ]);
+
+    expect(
+      Object.keys(
+        mergeTranslations(
+          {},
+          { k0: "Speichern", k1: "Abbrechen", k2: "Bereit" },
+          pathMap,
+        ) as Record<string, unknown>,
+      ),
+    ).toEqual(["actions", "status"]);
+  });
+
+  test("preserves existing target values and only extracts missing leaves", () => {
+    const source = {
+      actions: {
+        save: "Save",
+        cancel: "Cancel",
+        delete: "Delete",
+      },
+      status: "Ready",
+    };
+    const target = {
+      actions: {
+        cancel: "Abbrechen",
+      },
+      status: "Bereit",
+    };
+
+    const filled = deepFillMissingStrings(source, target);
+    const { dict, pathMap } = translatableSubtree(source, target);
+    const merged = mergeTranslations(
+      target,
+      { k0: "Speichern", k1: "Loeschen" },
+      pathMap,
+    );
+
+    expect(filled).toMatchObject({
+      actions: {
+        save: expect.objectContaining({ source: "Save" }),
+        cancel: "Abbrechen",
+        delete: expect.objectContaining({ source: "Delete" }),
+      },
+      status: "Bereit",
+    });
+    expect(dict).toEqual({ k0: "Save", k1: "Delete" });
+    expect(merged).toEqual({
+      actions: {
+        save: "Speichern",
+        cancel: "Abbrechen",
+        delete: "Loeschen",
+      },
+      status: "Bereit",
+    });
+  });
+
+  test("is a no-op for a fully populated target", () => {
+    const source = {
+      actions: {
+        save: "Save",
+      },
+    };
+    const target = {
+      actions: {
+        save: "Speichern",
+      },
+    };
+
+    const { dict, pathMap } = translatableSubtree(source, target);
+
+    expect(dict).toEqual({});
+    expect(deepFillMissingStrings(source, target)).toEqual(target);
+    expect(mergeTranslations(target, {}, pathMap)).toEqual(target);
+  });
+
+  test("handles arrays of strings without overwriting populated indexes", () => {
+    const source = {
+      steps: ["Start", "Review", "Finish"],
+    };
+    const target = {
+      steps: ["Starten"],
+    };
+
+    const { dict, pathMap } = translatableSubtree(source, target);
+    const merged = mergeTranslations(
+      target,
+      { k0: "Pruefen", k1: "Abschliessen" },
+      pathMap,
+    );
+
+    expect(dict).toEqual({ k0: "Review", k1: "Finish" });
+    expect(merged).toEqual({
+      steps: ["Starten", "Pruefen", "Abschliessen"],
+    });
+  });
+
+  test("keeps identical source strings at different paths as separate keys", () => {
+    const source = {
+      primary: {
+        label: "Done",
+      },
+      secondary: {
+        label: "Done",
+      },
+    };
+
+    const { dict, pathMap } = translatableSubtree(source, {});
+    const merged = mergeTranslations(
+      {},
+      { k0: "Fertig", k1: "Erledigt" },
+      pathMap,
+    );
+
+    expect(dict).toEqual({ k0: "Done", k1: "Done" });
+    expect(merged).toEqual({
+      primary: { label: "Fertig" },
+      secondary: { label: "Erledigt" },
+    });
+  });
+
+  test("does not expose real key names in the translation dict", () => {
+    const source = {
+      deeply: {
+        nested: {
+          secretContextKey: "Translate me",
+        },
+      },
+    };
+
+    const { dict } = translatableSubtree(source, {});
+
+    expect(Object.keys(dict)).toEqual(["k0"]);
+    expect(JSON.stringify(dict)).not.toContain("secretContextKey");
+  });
+
+  test("throws instead of overwriting target shape conflicts", () => {
+    expect(() =>
+      deepFillMissingStrings({ nested: { label: "Label" } }, { nested: "Alt" }),
+    ).toThrow("Target shape conflict");
+
+    expect(() =>
+      translatableSubtree({ label: "Label" }, { label: { text: "Alt" } }),
+    ).toThrow("Target shape conflict");
+  });
+
+  test("does not mutate source, target, dict, or path map", () => {
+    const source = {
+      actions: {
+        save: "Save",
+        cancel: "Cancel",
+      },
+    };
+    const target = {
+      actions: {
+        cancel: "Abbrechen",
+      },
+    };
+
+    const sourceBefore = JSON.stringify(source);
+    const targetBefore = JSON.stringify(target);
+    const { dict, pathMap } = translatableSubtree(source, target);
+    const dictBefore = JSON.stringify(dict);
+    const pathMapBefore = JSON.stringify(pathMap);
+
+    deepFillMissingStrings(source, target);
+    mergeTranslations(target, { k0: "Speichern" }, pathMap);
+
+    expect(JSON.stringify(source)).toBe(sourceBefore);
+    expect(JSON.stringify(target)).toBe(targetBefore);
+    expect(JSON.stringify(dict)).toBe(dictBefore);
+    expect(JSON.stringify(pathMap)).toBe(pathMapBefore);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds pure i18n JSON tree utilities for gap-only translation planning and merge-back.
- Preserves existing target values while exposing only anonymous `k0..kN` translation dict keys.
- Adds focused coverage for source order, arrays, empty/mixed/full targets, collisions, immutability, and malformed merge inputs.

## Changes

- Created `apps/native-rd/scripts/i18n/jsonTreeUtils.ts` with `deepFillMissingStrings`, `translatableSubtree`, and `mergeTranslations`.
- Added path-map based merge behavior with source-shape snapshotting and exact translation-key validation.
- Added issue dev plan and review/validation notes.

## Intent Verification

- [x] Module exposed at `apps/native-rd/scripts/i18n/jsonTreeUtils.ts`, pure functions only: no I/O, no LLM calls, no logging side effects.
- [x] `deepFillMissingStrings` preserves every existing target string verbatim; rerunning against a fully translated tree returns an equivalent tree with no new gaps.
- [x] `translatableSubtree` exposes only anonymized keys (`k0..kN`) in the LLM-facing dict; real paths live only in the returned path map.
- [x] `mergeTranslations` round-trips via the path map without path drift; output source keys are emitted in source order.
- [x] Tests cover nested objects, empty target, fully populated target, mixed target, arrays of strings, and identical English strings at different paths.
- [x] `bun run type-check && bun run lint && bun run test` are clean.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Use absent key/index as the only missing signal. | Preserves idempotency; an empty string or English-looking target value may be intentional. |
| Keep the LLM-facing dict flat and key-anonymized. | Real paths stay only in the path map, matching the parent plan's key anonymization invariant. |
| Use an internal marker object for missing leaves. | A raw source string would be indistinguishable from an intentional existing target value. |
| Throw on shape conflicts and malformed merge inputs. | Silent partial merges would violate the idempotency guarantee. |

## Discovery Log

- Current `de/*.json` files are `{}` stubs, so empty-target behavior is the initial real-world path.
- Current `en/*.json` files contain no arrays, but array support is included because the issue explicitly calls it out.
- Duplicate English strings exist at different paths, so merge identity is path-based rather than value-based.
- Review fixes added exact translation-key validation, stale path-map failure, source-shape snapshotting, target-only value validation, sparse-array checks, and stronger source-order tests.

## Test Plan

- [x] `cd apps/native-rd && bun run type-check`
- [x] `cd apps/native-rd && bun run lint` (0 errors; existing warning baseline remains)
- [x] `cd apps/native-rd && bun run test` (153 suites / 8281 tests)
- [x] `cd apps/native-rd && bun run build` (Expo no-op build script)

Closes #155

Generated with Codex