### PR TITLE
docs(native-rd): scaffold codebase tour & review framework

### DIFF
--- a/apps/native-rd/docs/architecture/tour/01-goals.md
+++ b/apps/native-rd/docs/architecture/tour/01-goals.md
@@ -1,0 +1,59 @@
+# Slice 1 — Goals domain
+
+**Status:** not-started
+**Drafted:** —
+**Reviewed:** —
+
+## Scope
+
+Tight scope: the core goal-tracking UI and its immediate data layer.
+
+**In scope:**
+
+- `src/screens/GoalsScreen`
+- `src/screens/NewGoalModal`
+- `src/screens/ConfirmDeleteModal`
+- `src/components/GoalCard`
+- `src/components/StepCard`, `src/components/StepList`
+- `src/components/FAB`, `src/components/FABMenu`
+- `src/navigation/GoalsStack`
+- Goal-related queries in `src/db/queries.ts` and the relevant `src/db/schema.ts` tables
+
+**Deferred:**
+
+- `CompletionFlowScreen` — overlaps badge issuance (slice 3)
+- `EditModeScreen`, `FocusModeScreen` — separate UX modes, revisited after slice 1
+- `GoalEvidenceCard` — overlaps evidence rendering (slice 2)
+- `TimelineJourneyScreen` — primarily evidence-timeline, slice 2
+
+## File map
+
+_(filled in during prep)_
+
+## Mental model
+
+_(filled in after walkthrough)_
+
+## RN concepts encountered
+
+_(filled in during walkthrough)_
+
+## Lens scan
+
+### type-safety
+
+### RN/Expo idiom
+
+### perf hot paths
+
+### a11y / ND-a11y
+
+### test coverage gaps
+
+## Findings
+
+- _(none yet)_
+
+## Open questions
+
+- _(none yet)_

--- a/apps/native-rd/docs/architecture/tour/02-evidence.md
+++ b/apps/native-rd/docs/architecture/tour/02-evidence.md
@@ -1,0 +1,55 @@
+# Slice 2 — Evidence & capture
+
+**Status:** not-started
+**Drafted:** —
+**Reviewed:** —
+
+## Scope
+
+Evidence capture flows + evidence display.
+
+**In scope (provisional — may split into 2a capture / 2b display at prep time):**
+
+- Capture screens: `CapturePhoto`, `CaptureVideoScreen`, `CaptureFile`, `CaptureLinkScreen`, `CaptureTextNote`, `CapturePlaceholder`, `VoiceMemoScreen`
+- Evidence components: `EvidenceContent`, `EvidenceDrawer`, `EvidenceGrid`, `EvidenceItem`, `EvidenceThumbnail`, `EvidenceTypePicker`, `EvidenceViewerScreen`
+- Media playback: `AudioPlayer`, `AudioPlayerModal`, `VideoPlayer*`, `PhotoViewerModal`, `TextNoteViewerModal`, `VideoPreview`, `VideoRecorder`, `ViewerStripThumb`, `ViewerThumbnailStrip`
+- `TimelineJourneyScreen`, `TimelineEvidenceCard`, `TimelineStep`, `TimelineNode`, `MiniTimeline`
+- Evidence-related queries + schema
+- Expo permissions surface: camera, microphone, media-library, document-picker
+
+**Deferred:**
+
+- Badge issuance from evidence — slice 3
+- Goal/step linkage UI — slice 1
+
+## File map
+
+_(filled in during prep)_
+
+## Mental model
+
+_(filled in after walkthrough)_
+
+## RN concepts encountered
+
+_(filled in during walkthrough)_
+
+## Lens scan
+
+### type-safety
+
+### RN/Expo idiom
+
+### perf hot paths
+
+### a11y / ND-a11y
+
+### test coverage gaps
+
+## Findings
+
+- _(none yet)_
+
+## Open questions
+
+- _(none yet)_

--- a/apps/native-rd/docs/architecture/tour/03-badges.md
+++ b/apps/native-rd/docs/architecture/tour/03-badges.md
@@ -1,0 +1,56 @@
+# Slice 3 — Badges + signing/baking
+
+**Status:** not-started
+**Drafted:** —
+**Reviewed:** —
+
+## Scope
+
+Badge creation, design, display, and the OpenBadges signing/baking pipeline.
+
+**In scope:**
+
+- `BadgeDesignerScreen`, `BadgeDetailScreen`, `BadgeEarnedModal`, `BadgesScreen`
+- `src/components/BadgeCard`
+- `src/navigation/BadgesStack`
+- `CompletionFlowScreen` (badge issuance entry point — co-reviewed with slice 1's goal-completion flow)
+- `src/badges/**` and the workspace package `@rollercoaster-dev/openbadges-core`
+- `src/crypto/**` (Ed25519 keys, PNG baking, hashing)
+- `KeyProvider` interface + `SecureStoreKeyProvider` integration plan
+- `src/stores/pendingDesignStore.ts`
+
+**Deferred:**
+
+- Verification flow if it lives elsewhere (TBD at prep)
+
+## File map
+
+_(filled in during prep)_
+
+## Mental model
+
+_(filled in after walkthrough)_
+
+## RN concepts encountered
+
+_(filled in during walkthrough — expect: native modules for crypto, async storage vs SecureStore, Buffer/jose interop, RN polyfills)_
+
+## Lens scan
+
+### type-safety
+
+### RN/Expo idiom
+
+### perf hot paths
+
+### a11y / ND-a11y
+
+### test coverage gaps
+
+## Findings
+
+- _(none yet)_
+
+## Open questions
+
+- _(none yet)_

--- a/apps/native-rd/docs/architecture/tour/03-badges.md
+++ b/apps/native-rd/docs/architecture/tour/03-badges.md
@@ -16,7 +16,7 @@ Badge creation, design, display, and the OpenBadges signing/baking pipeline.
 - `CompletionFlowScreen` (badge issuance entry point — co-reviewed with slice 1's goal-completion flow)
 - `src/badges/**` and the workspace package `@rollercoaster-dev/openbadges-core`
 - `src/crypto/**` (Ed25519 keys, PNG baking, hashing)
-- `KeyProvider` interface + `SecureStoreKeyProvider` integration plan
+- `KeyProvider` interface + `SecureStoreKeyProvider` implementation (`src/crypto/`)
 - `src/stores/pendingDesignStore.ts`
 
 **Deferred:**

--- a/apps/native-rd/docs/architecture/tour/04-theming-a11y.md
+++ b/apps/native-rd/docs/architecture/tour/04-theming-a11y.md
@@ -1,0 +1,55 @@
+# Slice 4 — Theming + ND accessibility
+
+**Status:** not-started
+**Drafted:** —
+**Reviewed:** —
+
+## Scope
+
+The 14-theme × 6-a11y-variant matrix and everything that serves it.
+
+**In scope:**
+
+- `src/themes/**` — adapter, compose, contrast tests, variants
+- `src/styles/**` — shadows, type, layout primitives
+- `@rollercoaster-dev/design-tokens` workspace package
+- `react-native-unistyles` v3 integration + Babel plugin
+- `src/utils/accessibility.ts` (contrast checker)
+- `src/components/ThemeChipGrid`, `src/components/ThemeSwitcher`
+- `src/__tests__/accessibility.test.tsx`, `src/themes/__tests__/contrast.test.ts`
+- Font stack: Anybody, Instrument Sans, DM Mono, Lexend, Atkinson Hyperlegible
+- ND variants: highContrast, largeText, dyslexia, lowVision, autismFriendly, lowInfo
+
+**Lens emphasis:** a11y/ND-a11y is the load-bearing lens here — expect this chapter to be heavier on that section.
+
+## File map
+
+_(filled in during prep)_
+
+## Mental model
+
+_(filled in after walkthrough)_
+
+## RN concepts encountered
+
+_(filled in during walkthrough — expect: Unistyles reactive theming, Babel plugin role, Yoga layout, font loading via `expo-font`, StyleSheet vs inline)_
+
+## Lens scan
+
+### type-safety
+
+### RN/Expo idiom
+
+### perf hot paths
+
+### a11y / ND-a11y
+
+### test coverage gaps
+
+## Findings
+
+- _(none yet)_
+
+## Open questions
+
+- _(none yet)_

--- a/apps/native-rd/docs/architecture/tour/05-infra.md
+++ b/apps/native-rd/docs/architecture/tour/05-infra.md
@@ -1,0 +1,53 @@
+# Slice 5 — Infra (i18n, Sentry, build, navigation, db, scripts)
+
+**Status:** not-started
+**Drafted:** —
+**Reviewed:** —
+
+## Scope
+
+Cross-cutting concerns that don't fit a domain slice.
+
+**In scope:**
+
+- i18n: `src/i18n/**`, `locales/*.json` (en/de), pseudo-locale generator
+- Sentry: `src/services/sentry.ts`, `sentry-filters.ts`, `sentry-report.ts`
+- Build pipeline: `scripts/run-ios.sh`, `scripts/run-android.sh`, EAS profiles, `app.config.*`, native projects
+- Navigation primitives: `TabNavigator`, `FocusPillTabBar`, `useTabScreenContentInset`
+- Evolu: `src/db/evolu.ts`, `src/db/schema.ts`, `src/db/queries.ts`, `src/db/index.ts`
+- `scripts/**` utilities (release notes, badge verify, a11y audit, etc.)
+- ErrorBoundary, Toast, top-level wiring in `App.tsx` / `index.ts`
+
+**Lens emphasis:** RN-idiom and perf (build/startup-path hot spots).
+
+## File map
+
+_(filled in during prep)_
+
+## Mental model
+
+_(filled in after walkthrough)_
+
+## RN concepts encountered
+
+_(filled in during walkthrough — expect: Metro bundler, EAS Build/Submit, react-navigation v7 deep architecture, Hermes vs JSC, dev-client vs Expo Go)_
+
+## Lens scan
+
+### type-safety
+
+### RN/Expo idiom
+
+### perf hot paths
+
+### a11y / ND-a11y
+
+### test coverage gaps
+
+## Findings
+
+- _(none yet)_
+
+## Open questions
+
+- _(none yet)_

--- a/apps/native-rd/docs/architecture/tour/05-infra.md
+++ b/apps/native-rd/docs/architecture/tour/05-infra.md
@@ -11,7 +11,7 @@ Cross-cutting concerns that don't fit a domain slice.
 **In scope:**
 
 - i18n: `src/i18n/**`, `locales/*.json` (en/de), pseudo-locale generator
-- Sentry: `src/services/sentry.ts`, `sentry-filters.ts`, `sentry-report.ts`
+- Sentry: `src/services/sentry.ts`, `src/services/sentry-filters.ts`, `src/services/sentry-report.ts`
 - Build pipeline: `scripts/run-ios.sh`, `scripts/run-android.sh`, EAS profiles, `app.config.*`, native projects
 - Navigation primitives: `TabNavigator`, `FocusPillTabBar`, `useTabScreenContentInset`
 - Evolu: `src/db/evolu.ts`, `src/db/schema.ts`, `src/db/queries.ts`, `src/db/index.ts`

--- a/apps/native-rd/docs/architecture/tour/README.md
+++ b/apps/native-rd/docs/architecture/tour/README.md
@@ -1,6 +1,6 @@
 # Codebase tour & review
 
-Evergreen walkthrough of `native-rd`, slice by slice. Doubles as React Native learning material and an audit log. The tour is intended to be read in order by a new contributor; the audit findings drive the linked GitHub milestone.
+Evergreen walkthrough of `native-rd`, slice by slice. Doubles as React Native learning material and an audit log. The tour is intended to be read in order by a new contributor; the audit findings are filed as a GitHub issue tree per slice (epic + sub-issues), tracked in-app as a Goal rather than as a GitHub milestone.
 
 ## Slices
 
@@ -31,7 +31,7 @@ Each slice runs the same protocol:
 
 1. **Prep** — enumerate files in scope, list RN concepts likely to need explanation, jot suspect findings to investigate during the walkthrough.
 2. **Live walkthrough** — file-by-file narration; questions drive depth; findings captured inline.
-3. **Writeup** — draft the chapter from the walkthrough; stage findings in [`checklist.md`](checklist.md); file findings as GH issues against the review milestone (epic + sub-issues + `blocked-by`, in one pass).
+3. **Writeup** — draft the chapter from the walkthrough; stage findings in [`checklist.md`](checklist.md); file findings as a GH issue tree (epic + sub-issues + `blocked-by`, in one pass). The epic per slice is linked from the in-app Goal step as evidence.
 
 ### Five lenses
 
@@ -63,7 +63,7 @@ Skim them or read deep — they don't gate the chapter narrative.
 
 ## Checklist staging
 
-[`checklist.md`](checklist.md) is the staging area for findings before they become GH issues. Once a slice's findings are filed against the review milestone, the staged entries are deleted (not archived). Filed issues are the source of truth; the staging file is ephemeral.
+[`checklist.md`](checklist.md) is the staging area for findings before they become GH issues. Once a slice's findings are filed as an epic + sub-issues, the staged entries are deleted (not archived). Filed issues are the source of truth; the staging file is ephemeral.
 
 ## Chapter template
 

--- a/apps/native-rd/docs/architecture/tour/README.md
+++ b/apps/native-rd/docs/architecture/tour/README.md
@@ -1,0 +1,70 @@
+# Codebase tour & review
+
+Evergreen walkthrough of `native-rd`, slice by slice. Doubles as React Native learning material and an audit log. The tour is intended to be read in order by a new contributor; the audit findings drive the linked GitHub milestone.
+
+## Slices
+
+| #   | Chapter                                                             | Status      |
+| --- | ------------------------------------------------------------------- | ----------- |
+| 1   | [Goals domain](01-goals.md)                                         | not-started |
+| 2   | [Evidence & capture](02-evidence.md)                                | not-started |
+| 3   | [Badges + signing/baking](03-badges.md)                             | not-started |
+| 4   | [Theming + ND accessibility](04-theming-a11y.md)                    | not-started |
+| 5   | [Infra (i18n, Sentry, build, navigation, db, scripts)](05-infra.md) | not-started |
+
+Chapter status is one of: `not-started` → `in-progress` → `drafted` → `reviewed`. Update the table when a chapter's status changes.
+
+## Tracked as a goal inside `native-rd`
+
+The review is itself a goal inside the app — dogfooding the goal / step / evidence / badge flow while auditing it.
+
+- **Goal:** _Tour & review the native-rd codebase_
+- **Steps:** one per slice (5 total — see table above)
+- **Evidence per step:** the filed GH issue tree for that slice (epic + sub-issues) plus any PRs that close them. Nothing else — GH artifacts are externally addressable, durable, and verifiable; chapter docs live in the repo as output but aren't evidence.
+- **Completion artifact:** a self-signed Open Badge, baked from a custom design (designed via `BadgeDesignerScreen` during or after slice 3), with the GH issue/PR URLs as evidence claims. The badge is the verifiable proof the review happened — the PNG carries it forever.
+
+The app goal is the primary progress tracker. GH issues are both work-output and evidence.
+
+## Methodology
+
+Each slice runs the same protocol:
+
+1. **Prep** — enumerate files in scope, list RN concepts likely to need explanation, jot suspect findings to investigate during the walkthrough.
+2. **Live walkthrough** — file-by-file narration; questions drive depth; findings captured inline.
+3. **Writeup** — draft the chapter from the walkthrough; stage findings in [`checklist.md`](checklist.md); file findings as GH issues against the review milestone (epic + sub-issues + `blocked-by`, in one pass).
+
+### Five lenses
+
+Every slice is scanned through these lenses. If a lens turns up nothing, say so explicitly in the chapter — silence is ambiguous.
+
+- **type-safety** — `any`, unsafe casts, missing return types, unchecked union narrowing
+- **RN/Expo idiom** — non-idiomatic patterns; missing platform-specific handling; misuse of Expo APIs
+- **perf hot paths** — render-thrash, large lists without virtualization, heavy synchronous work on the JS thread
+- **a11y / ND-a11y** — WCAG 2.1 AA compliance, roles, labels, touch targets, contrast, reduced-motion, ND-specific variants
+- **test coverage gaps** — uncovered branches in load-bearing code; missing regression tests tied to past bug fixes
+
+### Severity
+
+- **Critical** — concrete impact (crash, data loss, a11y regression hitting a real user group, security hole). Files immediately, escalated severity label.
+- **Important** — meaningful smell with a plausible failure path or maintenance cost. Files in the slice batch.
+- **Nice** — naming, minor inconsistencies, doc gaps. Files only if cheap; otherwise dropped, not parked.
+
+Anything below Nice is dropped. The checklist is not a graveyard.
+
+### Dual-channel RN explanation
+
+The walkthrough is paced at codebase-tour speed. RN platform concepts (Metro, native modules, Fabric / new arch, threading, Yoga layout, react-navigation primitives, gesture worklets, Reanimated, etc.) get captured in tagged callout blocks inside each chapter:
+
+> ★ RN concept ─ _name_
+>
+> Brief explanation, scoped to what's needed to read this slice. Links to canonical RN/Expo docs for deeper reading.
+
+Skim them or read deep — they don't gate the chapter narrative.
+
+## Checklist staging
+
+[`checklist.md`](checklist.md) is the staging area for findings before they become GH issues. Once a slice's findings are filed against the review milestone, the staged entries are deleted (not archived). Filed issues are the source of truth; the staging file is ephemeral.
+
+## Chapter template
+
+New chapters start from [`_chapter-template.md`](_chapter-template.md). Don't deviate from the structure without updating the template — consistency is the whole point of having a tour.

--- a/apps/native-rd/docs/architecture/tour/_chapter-template.md
+++ b/apps/native-rd/docs/architecture/tour/_chapter-template.md
@@ -1,0 +1,53 @@
+# Slice N — <Title>
+
+**Status:** not-started | in-progress | drafted | reviewed
+**Drafted:** YYYY-MM-DD
+**Reviewed:** YYYY-MM-DD
+
+## Scope
+
+What's in this slice. What's explicitly deferred to other slices and why.
+
+## File map
+
+| File                   | Role                                                   |
+| ---------------------- | ------------------------------------------------------ |
+| `src/path/to/file.tsx` | One-line summary of what this file is responsible for. |
+
+## Mental model
+
+Narrative walkthrough of how the slice fits together. Aimed at a new contributor — what to read first, what the data flow is, where state lives, what surprises the reader should expect. Prose, not bullet lists.
+
+## RN concepts encountered
+
+> ★ RN concept ─ _name_
+>
+> Brief explanation scoped to what's needed to read this slice. Link to canonical RN / Expo docs for deeper reading.
+
+Add one callout per concept. Concepts that recur across slices live in their first-encountered chapter; later chapters link back.
+
+## Lens scan
+
+One section per lens. If a lens turns up nothing, write _"No findings."_ — don't omit the section.
+
+### type-safety
+
+### RN/Expo idiom
+
+### perf hot paths
+
+### a11y / ND-a11y
+
+### test coverage gaps
+
+## Findings
+
+Bullet list. Each entry links to either a staged entry in `checklist.md` or a filed GH issue. Once everything is filed, all bullets point at GH.
+
+- _(none yet)_
+
+## Open questions
+
+Things that came up during the walkthrough that need a human decision, not a finding. Resolved questions move to the chapter prose; unresolved ones stay here.
+
+- _(none yet)_

--- a/apps/native-rd/docs/architecture/tour/checklist.md
+++ b/apps/native-rd/docs/architecture/tour/checklist.md
@@ -1,0 +1,32 @@
+# Tour findings — staging
+
+Staging area for findings before they're filed as GH issues against the review milestone. Once filed, **delete the entry from this file** — filed issues are the source of truth.
+
+See [README.md](README.md) for the severity and lens rubrics.
+
+## Finding template
+
+```
+### <Concise imperative title>
+
+- **Slice:** <number — name>
+- **Severity:** Critical | Important | Nice
+- **Lens:** type-safety | RN-idiom | perf | a11y | test-gaps
+- **Labels:** <comma-separated suggested labels>
+- **Files:** `path/to/file.tsx`, `path/to/other.ts`
+- **Scope:**
+  One to three sentences. What's wrong. What "fixed" looks like.
+  Concrete enough that another contributor can pick it up cold.
+- **Notes:**
+  Optional. Links, related findings, blocked-by relationships.
+```
+
+## Staged findings
+
+_(none yet)_
+
+## Recently filed (prune periodically)
+
+Brief log of issues filed from this checklist in the last ~2 weeks. Helps reviewers see what came out of which slice without spelunking the milestone.
+
+_(none yet)_

--- a/apps/native-rd/docs/architecture/tour/checklist.md
+++ b/apps/native-rd/docs/architecture/tour/checklist.md
@@ -1,6 +1,6 @@
 # Tour findings — staging
 
-Staging area for findings before they're filed as GH issues against the review milestone. Once filed, **delete the entry from this file** — filed issues are the source of truth.
+Staging area for findings before they're filed as a GH issue tree (epic + sub-issues) per slice. Once filed, **delete the entry from this file** — filed issues are the source of truth.
 
 See [README.md](README.md) for the severity and lens rubrics.
 
@@ -11,7 +11,7 @@ See [README.md](README.md) for the severity and lens rubrics.
 
 - **Slice:** <number — name>
 - **Severity:** Critical | Important | Nice
-- **Lens:** type-safety | RN-idiom | perf | a11y | test-gaps
+- **Lens:** type-safety | RN/Expo idiom | perf hot paths | a11y / ND-a11y | test coverage gaps
 - **Labels:** <comma-separated suggested labels>
 - **Files:** `path/to/file.tsx`, `path/to/other.ts`
 - **Scope:**
@@ -27,6 +27,6 @@ _(none yet)_
 
 ## Recently filed (prune periodically)
 
-Brief log of issues filed from this checklist in the last ~2 weeks. Helps reviewers see what came out of which slice without spelunking the milestone.
+Brief log of issues filed from this checklist in the last ~2 weeks. Helps reviewers see what came out of which slice without spelunking the issue tracker.
 
 _(none yet)_


### PR DESCRIPTION
## Summary

Adds the empty structure for a slice-by-slice walkthrough of `native-rd`:

- `README.md` — methodology, slice index, dogfooding section (the review is itself an in-app Goal)
- `_chapter-template.md` — chapter skeleton (5 lenses × Critical/Important/Nice severity)
- `01-goals.md` … `05-infra.md` — empty chapter stubs with provisional scope
- `checklist.md` — staging area for findings before they're filed as GH issues

No walkthrough content yet — slices fill in over subsequent PRs.

Framework was locked in a prior `/grill-me` session; this PR just commits the scaffold.