### PR TITLE
feat(native-rd/i18n): models registry + OpenRouter gateway + ADR-0007 (#157)

### DIFF
--- a/apps/native-rd/docs/decisions/ADR-0007-i18n-gateway.md
+++ b/apps/native-rd/docs/decisions/ADR-0007-i18n-gateway.md
@@ -1,0 +1,51 @@
+# ADR-0007: i18n LLM gateway — OpenRouter + Vercel AI SDK
+
+**Date:** 2026-05-24
+**Status:** Accepted
+**Owner:** Joe
+
+---
+
+## Context
+
+native-rd needs LLM calls to translate `src/i18n/resources/en/*.json` into `de/*.json` on a sync-script cadence (see [`docs/plans/i18n-llm-sync.md`](../plans/i18n-llm-sync.md) for the full plan and the 8-model bake-off candidate list). The options were:
+
+- **Per-vendor SDKs** (`openai`, `@anthropic-ai/sdk`, etc.) — swapping models means swapping SDKs and rewriting the call site.
+- **Self-hosted proxy** (e.g. LiteLLM behind our own gateway) — operational burden for a dev-time script that runs in CI.
+- **Unified gateway** (OpenRouter) over a TS-native SDK — one endpoint, one auth, model swap is a string change.
+
+The sync is a dev-time CLI invoked from CI and local dev. It does not ship in the app bundle.
+
+## Decision
+
+- **Gateway: OpenRouter.** Single OpenAI-compatible endpoint, ~300 models, pay-per-call, no infra to host.
+- **Client SDK: Vercel AI SDK** (`ai` + `@ai-sdk/openai` with a `baseURL` override pointing at `https://openrouter.ai/api/v1`). Documented integration path; not a workaround.
+- **Wrapper module:** `apps/native-rd/scripts/i18n/llmGateway.ts` exports one function, `callModel(name, systemPrompt, userContent): Promise<string>`. The `(name, system, user)` shape is locked from this PR so the translator (PR #5) inherits a stable contract — no breaking change later to add prompt-engineering surface area.
+- **Registry:** `apps/native-rd/scripts/i18n/models.ts` keys are short human-readable strings (`"gpt-4o-mini"`), not OpenRouter paths. Provider swaps keep the caller-facing name stable.
+
+## Rationale
+
+- Model swap is a one-line change in `models.ts`. promptfoo bake-offs reference the same registry keys, so the registry is the single source of truth for which models are in scope.
+- Vercel AI SDK is TS-native, has provider-swap built in, and is the SDK Vercel themselves recommend for OpenRouter via the `baseURL` override. Community `@openrouter/ai-sdk-provider` exists but has slower update cadence and adds no capability for our use case.
+- `devDependencies` placement keeps the production app bundle clean — Metro never resolves `ai` or `@ai-sdk/openai`.
+
+## Swap-out path
+
+If OpenRouter becomes inadequate (cost, latency, model availability, or vendor risk), swap `createOpenAI` in `llmGateway.ts` for another Vercel AI SDK provider (`@ai-sdk/anthropic`, `@ai-sdk/google`, etc.). The registry and `callModel` interface are unchanged; the translator and promptfoo configs do not need to know.
+
+## Consequences
+
+- **devDep coupling** to `ai` + `@ai-sdk/openai`. Acceptable: not bundled, dev-time only.
+- **Pay-per-call cost model.** Acceptable: the sync is gap-only and batched, so per-PR cost is bounded.
+- **Model availability** is subject to OpenRouter's router. Acceptable: the registry is the single switch point if a model is pulled.
+- **No offline fallback.** Acceptable: the sync is a CI job and expected to be online; the runtime app never calls this code.
+- **Prompt shape committed to `(system, user)` split.** The translator (PR #5) inherits this from `callModel`'s 3-arg signature, not a single-blob `prompt` arg. Reverting to a single-arg shape later would be a breaking change to a foundation file.
+- **Attribution headers — deliberately omitted.** The wrapper sends no `HTTP-Referer` or `X-Title` to OpenRouter. This is intentional, not an oversight. Sending those headers opts the project into OpenRouter's public leaderboard at `openrouter.ai/rankings`, which we explicitly do not want. If per-caller spend separation ever becomes necessary (i18n sync vs. future graph-flow / badge-engine uses), the path is **mint a second API key**, not add attribution headers. A future contributor reading this ADR should not "fix" the missing headers as a best-practices cleanup.
+
+## Supersession
+
+Changes to this decision require a new ADR that supersedes this one, per the pattern established in [ADR-0006](./ADR-0006-iteration-b-scope-amendment.md) (2026-05-23). Do not amend this ADR in place.
+
+---
+
+_Accepted 2026-05-24._

--- a/apps/native-rd/docs/decisions/index.md
+++ b/apps/native-rd/docs/decisions/index.md
@@ -10,3 +10,4 @@ Decisions are immutable once accepted. To change a decision, write a new ADR tha
 | [ADR-0004](./ADR-0004-data-model-storage.md)          | Evolu-native data model with SQLite                                         | Accepted | 2026-02-24    |
 | [ADR-0005](./ADR-0005-licensing-and-trademark.md)     | Per-package licensing (Apache/MIT/AGPL) + EUIPO trademark                   | Accepted | 2026-05-14    |
 | [ADR-0006](./ADR-0006-iteration-b-scope-amendment.md) | Iteration B scope amendment — drop three orphans, add step-model enrichment | Accepted | 2026-05-23    |
+| [ADR-0007](./ADR-0007-i18n-gateway.md)                | i18n LLM gateway — OpenRouter + Vercel AI SDK                               | Accepted | 2026-05-24    |

--- a/apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md
@@ -229,3 +229,6 @@ Runtime discoveries made during research. Starts empty — populated by the impl
 <!-- Entries added by implement skill:
 - [YYYY-MM-DD HH:MM] <discovery description>
 -->
+
+- [2026-05-24] **AI SDK v6 renamed `maxTokens` → `maxOutputTokens`.** Plan referenced the older name. Registry field stays `maxTokens` (cross-provider convention) and the gateway maps to `maxOutputTokens` in the `generateText` call. Registry remains SDK-agnostic.
+- [2026-05-24] **`tsconfig.scripts-test.json` needed `"bun"` added to types array.** Existing tests didn't reference `process`, so the `["jest"]`-only types worked. New `models.test.ts` manipulates `process.env.OPENROUTER_API_KEY` for the fail-fast test; without `"bun"` in types, `process` was undeclared. Added `"bun"` to mirror the non-test scripts config. Jest still runs under Node at runtime — pure declarative fix.

--- a/apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md
@@ -131,11 +131,11 @@ The gateway and its tests land in one commit because the tests directly exercise
 **Gateway changes**:
 
 - [ ] Import `createOpenAI` from `@ai-sdk/openai` and `generateText` from `ai`
-- [ ] Construct the OpenRouter provider once (module scope) pointing at `baseURL: "https://openrouter.ai/api/v1"`; the API key is read from `process.env.OPENROUTER_API_KEY` at construction time
+- [ ] Construct the OpenRouter provider once (module scope) pointing at `baseURL: "https://openrouter.ai/api/v1"`; the SDK reads the API key lazily on each request via `loadApiKey()`, so module construction is safe even when the env var is unset at import time (a runtime guard in `callModel` still fails fast — see next bullet)
 - [ ] Implement `callModel(name: string, systemPrompt: string, userContent: string): Promise<string>` (signature locked per D10 — translator PR #5 needs system + user split):
   - Read `process.env.OPENROUTER_API_KEY` at the top of the function body; if falsy, throw synchronously with a clear message (`"OPENROUTER_API_KEY is not set"`)
   - Call `getModel(name)` to resolve the entry (re-throws on unknown name — propagates verbatim, per D5)
-  - Call `generateText({ model: provider(entry.modelId), system: systemPrompt, prompt: userContent, temperature: entry.temperature, maxTokens: entry.maxTokens })` — no try/catch, errors surface verbatim
+  - Call `generateText({ model: provider(entry.modelId), system: systemPrompt, prompt: userContent, temperature: entry.temperature, maxOutputTokens: entry.maxTokens })` — no try/catch, errors surface verbatim (AI SDK v6 renamed `maxTokens` → `maxOutputTokens`; see discovery log)
   - Return `result.text`
 - [ ] **No** OpenRouter attribution headers — provider constructor passes only `baseURL` and `apiKey`. Per D11, omit `HTTP-Referer` and `X-Title` entirely.
 - [ ] Export `callModel`

--- a/apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md
@@ -1,0 +1,231 @@
+# Development Plan: Issue #157
+
+## Issue Summary
+
+**Title**: i18n sync: models registry + Vercel AI SDK + OpenRouter wrapper + ADR (gateway)
+**Type**: enhancement (foundation)
+**Complexity**: SMALL
+**Estimated Lines**: ~250 hand-written across 3 code files (~190 LOC) + ADR markdown (~60 lines, called out separately)
+
+## Intent Verification
+
+Observable criteria derived from the issue. These describe what success looks like from a user/system perspective — not generic checklists.
+
+- [ ] `models.ts` exports a typed registry containing at minimum the 8 candidate models from the plan doc bake-off table. Each entry is reachable by a string name without touching a raw OpenRouter model-ID string in downstream code.
+- [ ] Every registry entry has `temperature: 0.0` as its effective default (invariant #6). A per-model override field exists and is accepted by the type system, but is never set on any of the 8 base entries unless the entry is explicitly annotated as an override opt-in.
+- [ ] The wrapper function rejects with a clear, synchronous error (thrown before any network call) when `OPENROUTER_API_KEY` is absent from `process.env`.
+- [ ] The wrapper function accepts a registry entry **name** (string key), not a raw model-ID string. Passing an unknown name produces a typed error, not a silent no-op.
+- [ ] When the upstream API returns an error response, the wrapper surfaces that error verbatim — it does not swallow, remap, or stringify into a generic message.
+- [ ] `ADR-0007-i18n-gateway.md` exists under `apps/native-rd/docs/decisions/`, follows the established format, references the plan doc, and explicitly notes it follows the supersession-not-amendment pattern (ADR-0006).
+- [ ] `bun run type-check` passes (covers scripts via `tsconfig.scripts.json` + `tsconfig.scripts-test.json`).
+- [ ] `bun run lint` passes with no new suppressions.
+- [ ] `bun run test` picks up and passes all new tests in `scripts/i18n/__tests__/models.test.ts`.
+
+## Dependencies
+
+| Issue | Title                                        | Status        | Type |
+| ----- | -------------------------------------------- | ------------- | ---- |
+| #155  | i18n sync: jsonTreeUtils                     | Merged (#164) | Soft |
+| #156  | i18n sync: placeholderGuard + responseParser | Merged (#165) | Soft |
+
+**Status**: No blockers. Issue #157 is labeled `dep:independent` — can start immediately. The merged PRs for #155 and #156 established the `scripts/i18n/__tests__/` harness, tsconfig split, and jest `testMatch` extension that this PR inherits without modification.
+
+## Objective
+
+Ship the model registry, the OpenRouter/Vercel AI SDK wrapper, and the ADR that formalises the gateway decision. This is PR #3 in the i18n-llm-sync plan sequence. It makes `translator.ts` (PR #5) possible — that module will import `callModel` and `MODELS` from this PR's files.
+
+## Decisions
+
+Architectural and implementation choices made during research. Populated when the researcher encounters multiple valid approaches.
+
+| ID  | Decision                                                                                                                                                             | Alternatives Considered                                                                       | Rationale                                                                                                                                                                                                                                                                                                                                                  |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Registry is a plain `Record<string, ModelEntry>` object exported as `MODELS`, with a typed lookup helper `getModel(name)` that throws on unknown name                | Exported named consts per model (e.g. `export const GPT4O_MINI = ...`), or a `Map<>`          | String-keyed lookup is the cheapest swap surface: `translator.ts` passes a name, config files pass a name, promptfoo configs pass a name. Named consts require an import change per model swap. `Map<>` adds no benefit over a plain object here.                                                                                                          |
+| D2  | New devDependencies `ai` (Vercel AI SDK core) + `@ai-sdk/openai` (the OpenRouter-compatible provider) added to `apps/native-rd/package.json` under `devDependencies` | `dependencies`, or `@openrouter/ai-sdk-provider` instead of `@ai-sdk/openai`                  | The sync script is a dev-time CLI, never bundled into the app. `devDependencies` keeps the production bundle clean. `@ai-sdk/openai` works against OpenRouter's OpenAI-compatible endpoint and is the recommended integration path in Vercel AI SDK docs; `@openrouter/ai-sdk-provider` (`v2.9.0`) is a community package with less update cadence.        |
+| D3  | `callModel` is `async` and returns `Promise<string>` (raw text content of the LLM response)                                                                          | Return a structured object, return the full SDK response object                               | `translator.ts` is the parsing/validation layer — it will pipe the raw string through `responseParser.parseAndValidate`. Returning the full SDK response object couples the wrapper to SDK internals and makes tests heavier.                                                                                                                              |
+| D4  | API key fail-fast is a synchronous throw inside `callModel`, before the `await`                                                                                      | Validate at import time (module-level guard), validate via Zod at call time                   | Import-time validation runs even in tests that never call the function and would require test setup. Call-time Zod is overkill for a single env var string check. Synchronous throw at call entry is the minimal, conventional pattern.                                                                                                                    |
+| D5  | Upstream API errors surface verbatim — `callModel` does not catch/remap errors from the Vercel AI SDK                                                                | Catch and wrap into a custom error class                                                      | The issue acceptance criterion explicitly requires "surfaces upstream API errors verbatim rather than swallowing." Remapping adds a layer that obscures root cause. `translator.ts` (PR #5) owns retry/circuit-breaker logic.                                                                                                                              |
+| D6  | ADR number is **ADR-0007** — next sequential after ADR-0006                                                                                                          | —                                                                                             | `docs/decisions/index.md` lists ADR-0006 as the current highest. ADR-0007 is the next available slot.                                                                                                                                                                                                                                                      |
+| D7  | `temperature` default lives on each `ModelEntry` (not as a module constant), and per-entry overrides are allowed via the same field                                  | Module-level `DEFAULT_TEMPERATURE = 0.0` constant, model entries omit it                      | Makes the per-entry default explicit and readable in the registry table. The plan says "per-model overrides allowed but require explicit opt-in" — an override is just setting `temperature` to a non-zero value, which the type allows but reviewers will see in the diff.                                                                                |
+| D8  | Registry keys are short human-readable strings (`"gpt-4o-mini"`, `"claude-sonnet-4-6"`), not full OpenRouter paths                                                   | Use the full OpenRouter model ID as the key (`"openai/gpt-4o-mini"`)                          | Decouples the lookup name from the provider path so a model swap to a different provider can keep the same key. Same keys will be referenced from promptfoo bake-off configs. Locked 2026-05-24 (Q2).                                                                                                                                                      |
+| D9  | `gpt-oss-120b` registry entry uses model ID `openai/gpt-oss-120b`; OpenRouter handles Groq routing transparently                                                     | Use a Groq-specific model ID                                                                  | OpenRouter routes this through Groq's inference endpoint without any caller-side change. Keeps the registry uniform. Locked 2026-05-24 (Q3).                                                                                                                                                                                                               |
+| D10 | `callModel` signature is `(name, systemPrompt, userContent) => Promise<string>` from the start                                                                       | Start with single-prompt `(name, prompt)` and evolve in PR #5                                 | Translator (PR #5) needs system + user split for prompt engineering. Getting the shape right now avoids a breaking change to a foundation file. ~5 LOC cost now vs. a downstream rewrite. Locked 2026-05-24 (Q4).                                                                                                                                          |
+| D11 | Wrapper sends **no** OpenRouter attribution headers (`HTTP-Referer`, `X-Title` both omitted)                                                                         | Hardcode `HTTP-Referer: https://rollercoaster.dev` + `X-Title: native-rd-i18n-sync`; or defer | Headers are purely opt-in for OpenRouter's public leaderboard at `openrouter.ai/rankings`. Joe explicitly does not want project name indexed there. Spend separation, if ever needed, is achievable via separate API keys instead. ADR must document this deliberately so a future "best practices" cleanup doesn't add them back. Locked 2026-05-24 (Q5). |
+
+## Affected Areas
+
+- `apps/native-rd/package.json`: add `ai` and `@ai-sdk/openai` to `devDependencies`
+- `apps/native-rd/scripts/i18n/models.ts`: new file — typed registry + `getModel` lookup helper (~60 LOC)
+- `apps/native-rd/scripts/i18n/llmGateway.ts`: new file — `callModel` wrapper using Vercel AI SDK + OpenRouter (~50 LOC)
+- `apps/native-rd/scripts/i18n/__tests__/models.test.ts`: new test file — registry + gateway tests (~80 LOC)
+- `apps/native-rd/docs/decisions/ADR-0007-i18n-gateway.md`: new ADR file — gateway choice formalised (~60 lines markdown)
+- `apps/native-rd/docs/decisions/index.md`: add ADR-0007 row
+- `bun.lock`: lockfile churn from two new devDeps (generated, not counted)
+
+## Pre-flight Checklist
+
+Things to verify in the codebase before the first commit:
+
+- [ ] **Deps not already present**: `grep -r '"ai"\|"@ai-sdk/openai"' apps/native-rd/package.json` should return empty. Confirmed: `package.json` has neither. Neither appears in the workspace lockfile as a direct dep.
+- [ ] **Test harness inherited from #156**: `scripts/i18n/__tests__/` exists and contains `placeholderGuard.test.ts` + `responseParser.test.ts`. Jest `testMatch` already covers `**/scripts/**/__tests__/**/*.test.ts`. No jest config changes needed.
+- [ ] **TypeScript configs already split**: `tsconfig.scripts.json` (bun types, non-test scripts) and `tsconfig.scripts-test.json` (jest types, `__tests__/` files) both exist. `type-check` script already invokes both. No tsconfig changes needed.
+- [ ] **Lint config tolerance for new file**: `expo lint` (ESLint v9 + `eslint-config-expo`) — verify no rule blocks import of `process.env` in `scripts/`. Since existing scripts (`verify-badge.ts`, `release-notes-generate.ts`) already read `process.env`, the lint config is confirmed tolerant.
+- [ ] **`@ai-sdk/openai` OpenRouter compatibility**: The Vercel AI SDK `@ai-sdk/openai` package supports a `baseURL` override on the provider constructor, making it compatible with OpenRouter's OpenAI-compatible endpoint (`https://openrouter.ai/api/v1`). This is documented in Vercel AI SDK docs and is the recommended integration pattern (not a workaround).
+- [ ] **Wrapper file name**: use `llmGateway.ts` (not `gateway.ts` or `openrouterClient.ts`) to match the plan doc's implied naming (`gateway` appears in the issue title) and remain consistent with the naming convention used by the other modules (`camelCase, noun-focused`).
+
+## Implementation Plan
+
+### Step 1: Add devDependencies
+
+**Files**: `apps/native-rd/package.json`
+**Commit**: `chore(native-rd/i18n): add Vercel AI SDK + OpenRouter provider deps`
+**LOC**: ~2 lines (two new devDep entries)
+
+**Changes**:
+
+- [ ] Add `"ai": "^6.0.191"` to `devDependencies` in `apps/native-rd/package.json`
+- [ ] Add `"@ai-sdk/openai": "^3.0.65"` to `devDependencies`
+- [ ] Run `bun install` from repo root to update `bun.lock`
+- [ ] Confirm `bun run type-check` still passes (no new types clash)
+
+This commit is atomic on its own — it changes nothing functional, only unlocks the imports in Steps 2 and 3.
+
+---
+
+### Step 2: `models.ts` — typed model registry
+
+**Files**: `apps/native-rd/scripts/i18n/models.ts`
+**Commit**: `feat(native-rd/i18n): models registry — typed OpenRouter model entries`
+**LOC**: ~60 LOC
+
+**Changes**:
+
+- [ ] Define `ModelEntry` type: `{ modelId: string; temperature: number; maxTokens?: number; note?: string }`. `temperature` is not optional — every entry must declare it explicitly so the registry table is readable and auditable.
+- [ ] Define `MODELS` as `Record<string, ModelEntry>` containing all 8 bake-off candidates with `temperature: 0.0`:
+  - `"gpt-4o-mini"` → `openai/gpt-4o-mini`
+  - `"gpt-4o"` → `openai/gpt-4o`
+  - `"gpt-5-mini"` → `openai/gpt-5-mini`
+  - `"claude-haiku-4-5"` → `anthropic/claude-haiku-4-5`
+  - `"claude-sonnet-4-6"` → `anthropic/claude-sonnet-4-6`
+  - `"gemini-2.5-flash"` → `google/gemini-2.5-flash`
+  - `"deepseek-chat"` → `deepseek/deepseek-chat`
+  - `"gpt-oss-120b"` → `openai/gpt-oss-120b` with `note: "via Groq"`
+- [ ] Implement `getModel(name: string): ModelEntry` — looks up in `MODELS`, throws `Error` with clear message if name is unknown (include the unknown name and a list of valid names in the message).
+- [ ] Export `MODELS`, `ModelEntry`, `getModel`
+- [ ] No I/O, no imports from SDK — this file is pure data + one lookup helper.
+
+---
+
+### Step 3: `llmGateway.ts` + `models.test.ts`
+
+**Files**:
+
+- `apps/native-rd/scripts/i18n/llmGateway.ts`
+- `apps/native-rd/scripts/i18n/__tests__/models.test.ts`
+
+**Commit**: `feat(native-rd/i18n): llmGateway + models tests — OpenRouter wrapper via Vercel AI SDK`
+**LOC**: ~50 LOC (gateway) + ~80 LOC (tests) = ~130 LOC
+
+The gateway and its tests land in one commit because the tests directly exercise the gateway contract and the two are not independently reviewable.
+
+**Gateway changes**:
+
+- [ ] Import `createOpenAI` from `@ai-sdk/openai` and `generateText` from `ai`
+- [ ] Construct the OpenRouter provider once (module scope) pointing at `baseURL: "https://openrouter.ai/api/v1"`; the API key is read from `process.env.OPENROUTER_API_KEY` at construction time
+- [ ] Implement `callModel(name: string, systemPrompt: string, userContent: string): Promise<string>` (signature locked per D10 — translator PR #5 needs system + user split):
+  - Read `process.env.OPENROUTER_API_KEY` at the top of the function body; if falsy, throw synchronously with a clear message (`"OPENROUTER_API_KEY is not set"`)
+  - Call `getModel(name)` to resolve the entry (re-throws on unknown name — propagates verbatim, per D5)
+  - Call `generateText({ model: provider(entry.modelId), system: systemPrompt, prompt: userContent, temperature: entry.temperature, maxTokens: entry.maxTokens })` — no try/catch, errors surface verbatim
+  - Return `result.text`
+- [ ] **No** OpenRouter attribution headers — provider constructor passes only `baseURL` and `apiKey`. Per D11, omit `HTTP-Referer` and `X-Title` entirely.
+- [ ] Export `callModel`
+- [ ] The provider instance construction is module-level but the API key read is deferred to call time — this keeps the module importable in tests without a real key in the environment
+
+**Test changes** (`scripts/i18n/__tests__/models.test.ts`):
+
+- [ ] **Registry shape tests** (pure, no mocks):
+  - [ ] `MODELS` contains all 8 expected entry names
+  - [ ] Every entry has `temperature === 0.0`
+  - [ ] `getModel("gpt-4o-mini")` returns the correct `modelId`
+  - [ ] `getModel("unknown-name")` throws (message contains the unknown name)
+  - [ ] `getModel("unknown-name")` error message lists at least one valid key (so the developer can fix the call)
+- [ ] **Gateway fail-fast test** (mock `process.env`):
+  - [ ] Calling `callModel("gpt-4o-mini", "sys", "user")` with `OPENROUTER_API_KEY` unset throws synchronously before any network call — test asserts the throw without needing to mock the SDK
+- [ ] **Gateway upstream-error surfacing test** (mock `generateText`):
+  - [ ] Mock `generateText` to throw a simulated upstream error; call `callModel("gpt-4o-mini", "sys", "user")`; assert the original error is not wrapped or remapped (the caught error is the same object or carries the same message)
+- [ ] **Gateway passes system + user separately** (mock `generateText`):
+  - [ ] Mock `generateText` to capture its arguments; call `callModel("gpt-4o-mini", "you are a translator", "hello")`; assert `generateText` was called with `system: "you are a translator"` and `prompt: "hello"` (not concatenated)
+- [ ] Use `test.each` for the registry entry spot-checks (temperature and modelId per entry)
+- [ ] No live network calls — the upstream-error test uses `jest.mock("ai", ...)`
+
+---
+
+### Step 4: ADR-0007 + index update
+
+**Files**:
+
+- `apps/native-rd/docs/decisions/ADR-0007-i18n-gateway.md`
+- `apps/native-rd/docs/decisions/index.md`
+
+**Commit**: `docs(native-rd): ADR-0007 — i18n gateway choice (OpenRouter + Vercel AI SDK)`
+**LOC**: ~60 lines markdown (ADR) + 1 line (index table row)
+
+**Changes**:
+
+- [ ] Create `ADR-0007-i18n-gateway.md` following the established format (matching ADR-0002 through ADR-0006 header structure: **Date**, **Status**, **Owner**, then Context / Decision / Rationale / Consequences sections)
+- [ ] ADR content must cover:
+  - **Context**: native-rd needs LLM calls for i18n sync; options are per-vendor SDKs, a self-hosted proxy, or a unified gateway
+  - **Decision**: OpenRouter as gateway (single API endpoint, ~300 models, pay-per-call), Vercel AI SDK as the TS client (provider-swap is one line, Zod-validated response shape)
+  - **Rationale**: model swap requires only changing a string in `models.ts`; no proxy infrastructure to host; pairs naturally with promptfoo for bake-offs; see `docs/plans/i18n-llm-sync.md` for full candidate model list and locked decision rationale
+  - **Swap-out path**: if OpenRouter becomes inadequate, swap `createOpenAI` in `llmGateway.ts` to another Vercel AI SDK provider — the registry and wrapper interface are unchanged; no callers need to change
+  - **Consequences**: devDep coupling to `ai` + `@ai-sdk/openai` (not in app bundle); pay-per-call cost model; model availability subject to OpenRouter's router; no offline fallback (sync is a CI job, expected to be online); **prompt shape committed to (system, user) split** — translator PR #5 inherits this contract from `callModel`'s 3-arg signature, not a single-blob signature
+  - **Attribution headers — deliberately omitted**: the wrapper sends no `HTTP-Referer` or `X-Title` to OpenRouter. This is intentional, not an oversight. Sending those headers opts the project into OpenRouter's public leaderboard at `openrouter.ai/rankings`, which we do not want. If spend separation between callers (i18n sync, future graph-flow/badge-engine uses) ever becomes needed, the path is **mint a second API key**, not add attribution headers. A future contributor reading this ADR should not "fix" the missing headers as a best-practices cleanup.
+  - **Supersession note**: explicit statement that changes to this decision require a new ADR per the pattern established in ADR-0006 (2026-05-23), not in-place amendment
+- [ ] Add ADR-0007 row to `docs/decisions/index.md`
+
+---
+
+### Step 5: Type-check + lint gate
+
+**Files**: none (verification only — no new changes expected)
+**Commit**: none (this is a pre-push gate, not a separate commit)
+
+**Checks**:
+
+- [ ] `bun run type-check` — passes all four tsconfigs
+- [ ] `bun run lint` — no new warnings or errors
+- [ ] `bun run test` — `models.test.ts` picked up, all assertions green
+
+## Testing Strategy
+
+- [ ] Jest 30, Node environment (no React Native globals needed — `scripts/i18n/__tests__/` inherits from the existing test harness added in #156)
+- [ ] Test file at `scripts/i18n/__tests__/models.test.ts` — covers both `models.ts` and `llmGateway.ts`
+- [ ] Use `test.each` for the per-entry registry spot-checks (8 models × temperature + modelId = 16 assertions in a table)
+- [ ] Gateway fail-fast test: manipulate `process.env.OPENROUTER_API_KEY` in `beforeEach`/`afterEach`, assert synchronous throw
+- [ ] Gateway upstream-error test: `jest.mock("ai")` to control `generateText`; assert error propagates without remapping
+- [ ] No live network calls in any test
+- [ ] Manual smoke after Step 3: `bun test --testPathPatterns scripts/i18n`
+
+## Not in Scope
+
+Items explicitly deferred from this issue.
+
+| Item                                         | Reason                                                                                          | Follow-up               |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------- |
+| Retry / concurrency / batching logic         | Plan explicitly defers to `translator.ts` (PR #5)                                               | #160                    |
+| promptfoo config + fixture strings           | That is PR #4 in the sequence                                                                   | Separate issue          |
+| `maxTokens` per-model tuning                 | No data yet; defaults to SDK default (none set) for the first pass                              | Post-bake-off           |
+| `fr` locale entry in registry                | v1 scope is `de` only; `fr` is a "near-trivial add later" per the plan                          | Post-v1                 |
+| Type-safe model name (branded string / enum) | String registry key is sufficient for now; can be tightened if type-safety becomes a pain point | Optional future cleanup |
+
+## Open Questions
+
+All resolved 2026-05-24. See Decisions D6 (Q1), D8 (Q2), D9 (Q3), D10 (Q4), D11 (Q5).
+
+## Discovery Log
+
+Runtime discoveries made during research. Starts empty — populated by the implement skill as work progresses.
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -105,6 +105,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@ai-sdk/openai": "^3.0.65",
     "@babel/core": "^7.26.0",
     "@babel/plugin-transform-dynamic-import": "^7.27.1",
     "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
@@ -118,6 +119,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.2.10",
+    "ai": "^6.0.191",
     "babel-jest": "^30.2.0",
     "babel-preset-expo": "~55.0.22",
     "eslint": "^9.39.4",

--- a/apps/native-rd/scripts/i18n/__tests__/models.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/models.test.ts
@@ -1,5 +1,6 @@
 import { MODELS, getModel, type ModelEntry } from "../models";
 
+import { createOpenAI } from "@ai-sdk/openai";
 import { generateText } from "ai";
 import { callModel } from "../llmGateway";
 
@@ -79,6 +80,9 @@ jest.mock("@ai-sdk/openai", () => ({
 
 const mockGenerateText = generateText as jest.MockedFunction<
   typeof generateText
+>;
+const mockCreateOpenAI = createOpenAI as jest.MockedFunction<
+  typeof createOpenAI
 >;
 
 describe("callModel — fail-fast", () => {
@@ -174,6 +178,29 @@ describe("callModel — error propagation + arg shape", () => {
       expect(args.model.__modelId).toBe(modelId);
     },
   );
+
+  test("reads OPENROUTER_API_KEY at call time (no module-load snapshot)", async () => {
+    // Module was imported with OPENROUTER_API_KEY unset (jest setup at module
+    // load) or whatever the harness had. Set it to a sentinel value here and
+    // verify the sentinel reaches createOpenAI on the call — proving the key
+    // is read at call time, not snapshotted at import.
+    process.env.OPENROUTER_API_KEY = "sentinel-key-set-after-import";
+    mockCreateOpenAI.mockClear();
+    mockGenerateText.mockResolvedValueOnce({
+      text: "ok",
+      finishReason: "stop",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    await callModel("gpt-4o-mini", "sys", "user");
+
+    expect(mockCreateOpenAI).toHaveBeenCalledTimes(1);
+    const opts = mockCreateOpenAI.mock.calls[0][0] as {
+      apiKey: string;
+      baseURL: string;
+    };
+    expect(opts.apiKey).toBe("sentinel-key-set-after-import");
+    expect(opts.baseURL).toBe("https://openrouter.ai/api/v1");
+  });
 
   test("forwards entry.maxTokens as maxOutputTokens (locks SDK param name)", async () => {
     mockGenerateText.mockResolvedValueOnce({

--- a/apps/native-rd/scripts/i18n/__tests__/models.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/models.test.ts
@@ -71,6 +71,12 @@ jest.mock("ai", () => ({
   generateText: jest.fn(),
 }));
 
+jest.mock("@ai-sdk/openai", () => ({
+  createOpenAI: jest.fn((_opts: unknown) => (modelId: string) => ({
+    __modelId: modelId,
+  })),
+}));
+
 const mockGenerateText = generateText as jest.MockedFunction<
   typeof generateText
 >;
@@ -128,6 +134,7 @@ describe("callModel — error propagation + arg shape", () => {
   test("passes system + user as separate generateText params", async () => {
     mockGenerateText.mockResolvedValueOnce({
       text: "Hallo",
+      finishReason: "stop",
     } as Awaited<ReturnType<typeof generateText>>);
 
     const result = await callModel(
@@ -146,5 +153,88 @@ describe("callModel — error propagation + arg shape", () => {
     expect(args.system).toBe("you are a translator");
     expect(args.prompt).toBe("hello");
     expect(args.temperature).toBe(0.0);
+  });
+
+  test.each([
+    { name: "gpt-4o-mini", modelId: "openai/gpt-4o-mini" },
+    { name: "claude-haiku-4-5", modelId: "anthropic/claude-haiku-4-5" },
+    { name: "gemini-2.5-flash", modelId: "google/gemini-2.5-flash" },
+  ])(
+    "$name resolves to modelId $modelId on the generateText call",
+    async ({ name, modelId }) => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: "ok",
+        finishReason: "stop",
+      } as Awaited<ReturnType<typeof generateText>>);
+
+      await callModel(name, "sys", "user");
+      const args = mockGenerateText.mock.calls[0][0] as unknown as {
+        model: { __modelId: string };
+      };
+      expect(args.model.__modelId).toBe(modelId);
+    },
+  );
+
+  test("forwards entry.maxTokens as maxOutputTokens (locks SDK param name)", async () => {
+    mockGenerateText.mockResolvedValueOnce({
+      text: "ok",
+      finishReason: "stop",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    await callModel("gpt-4o-mini", "sys", "user");
+    const args = mockGenerateText.mock.calls[0][0] as {
+      maxOutputTokens: number | undefined;
+    };
+    // No registry entry currently sets maxTokens; locking the SDK key name
+    // (renamed from `maxTokens` in AI SDK v6) and the passthrough wiring.
+    expect(args).toHaveProperty("maxOutputTokens");
+    expect(args.maxOutputTokens).toBeUndefined();
+  });
+});
+
+describe("callModel — finishReason guard", () => {
+  const originalKey = process.env.OPENROUTER_API_KEY;
+
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalKey;
+    }
+    mockGenerateText.mockReset();
+  });
+
+  test.each([
+    { finishReason: "length" },
+    { finishReason: "content-filter" },
+    { finishReason: "tool-calls" },
+    { finishReason: "error" },
+  ])(
+    "throws when finishReason is $finishReason (non-stop)",
+    async ({ finishReason }) => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: "partial",
+        finishReason,
+      } as Awaited<ReturnType<typeof generateText>>);
+
+      await expect(callModel("gpt-4o-mini", "sys", "user")).rejects.toThrow(
+        new RegExp(`non-stop finishReason="${finishReason}"`),
+      );
+    },
+  );
+
+  test("does not throw when finishReason is stop", async () => {
+    mockGenerateText.mockResolvedValueOnce({
+      text: "complete",
+      finishReason: "stop",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    await expect(callModel("gpt-4o-mini", "sys", "user")).resolves.toBe(
+      "complete",
+    );
   });
 });

--- a/apps/native-rd/scripts/i18n/__tests__/models.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/models.test.ts
@@ -1,0 +1,150 @@
+import { MODELS, getModel, type ModelEntry } from "../models";
+
+import { generateText } from "ai";
+import { callModel } from "../llmGateway";
+
+describe("MODELS registry", () => {
+  const expectedKeys = [
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-5-mini",
+    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+    "gemini-2.5-flash",
+    "deepseek-chat",
+    "gpt-oss-120b",
+  ];
+
+  test("contains all 8 expected entry names", () => {
+    expect(Object.keys(MODELS).sort()).toEqual([...expectedKeys].sort());
+  });
+
+  type EntryCase = {
+    name: string;
+    modelId: string;
+  };
+
+  const entryCases: EntryCase[] = [
+    { name: "gpt-4o-mini", modelId: "openai/gpt-4o-mini" },
+    { name: "gpt-4o", modelId: "openai/gpt-4o" },
+    { name: "gpt-5-mini", modelId: "openai/gpt-5-mini" },
+    { name: "claude-haiku-4-5", modelId: "anthropic/claude-haiku-4-5" },
+    { name: "claude-sonnet-4-6", modelId: "anthropic/claude-sonnet-4-6" },
+    { name: "gemini-2.5-flash", modelId: "google/gemini-2.5-flash" },
+    { name: "deepseek-chat", modelId: "deepseek/deepseek-chat" },
+    { name: "gpt-oss-120b", modelId: "openai/gpt-oss-120b" },
+  ];
+
+  test.each(entryCases)(
+    "$name maps to $modelId with temperature 0.0",
+    ({ name, modelId }) => {
+      const entry = MODELS[name];
+      expect(entry).toBeDefined();
+      expect((entry as ModelEntry).modelId).toBe(modelId);
+      expect((entry as ModelEntry).temperature).toBe(0.0);
+    },
+  );
+});
+
+describe("getModel", () => {
+  test("returns the entry for a known name", () => {
+    expect(getModel("gpt-4o-mini").modelId).toBe("openai/gpt-4o-mini");
+  });
+
+  test("throws on an unknown name", () => {
+    expect(() => getModel("not-a-real-model")).toThrow(/not-a-real-model/);
+  });
+
+  test("error message lists at least one valid key", () => {
+    let caught: unknown;
+    try {
+      getModel("not-a-real-model");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/gpt-4o-mini/);
+  });
+});
+
+jest.mock("ai", () => ({
+  generateText: jest.fn(),
+}));
+
+const mockGenerateText = generateText as jest.MockedFunction<
+  typeof generateText
+>;
+
+describe("callModel — fail-fast", () => {
+  const originalKey = process.env.OPENROUTER_API_KEY;
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalKey;
+    }
+    mockGenerateText.mockReset();
+  });
+
+  test("throws when OPENROUTER_API_KEY is unset, before any network call", async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    await expect(callModel("gpt-4o-mini", "sys", "user")).rejects.toThrow(
+      /OPENROUTER_API_KEY/,
+    );
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+});
+
+describe("callModel — error propagation + arg shape", () => {
+  const originalKey = process.env.OPENROUTER_API_KEY;
+
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalKey;
+    }
+    mockGenerateText.mockReset();
+  });
+
+  test("propagates upstream API errors verbatim (no wrapping)", async () => {
+    const upstream = new Error("upstream: 429 rate limited");
+    mockGenerateText.mockRejectedValueOnce(upstream);
+
+    let caught: unknown;
+    try {
+      await callModel("gpt-4o-mini", "sys", "user");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(upstream);
+  });
+
+  test("passes system + user as separate generateText params", async () => {
+    mockGenerateText.mockResolvedValueOnce({
+      text: "Hallo",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    const result = await callModel(
+      "gpt-4o-mini",
+      "you are a translator",
+      "hello",
+    );
+
+    expect(result).toBe("Hallo");
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+    const args = mockGenerateText.mock.calls[0][0] as {
+      system: string;
+      prompt: string;
+      temperature: number;
+    };
+    expect(args.system).toBe("you are a translator");
+    expect(args.prompt).toBe("hello");
+    expect(args.temperature).toBe(0.0);
+  });
+});

--- a/apps/native-rd/scripts/i18n/llmGateway.ts
+++ b/apps/native-rd/scripts/i18n/llmGateway.ts
@@ -1,0 +1,56 @@
+/**
+ * Thin wrapper around the Vercel AI SDK + OpenRouter for the i18n sync.
+ *
+ * One function: `callModel(name, systemPrompt, userContent)`. The registry
+ * (`models.ts`) owns the model catalogue; this file owns the network call.
+ *
+ * Per ADR-0007:
+ *   - No OpenRouter attribution headers (no HTTP-Referer / X-Title) —
+ *     deliberate omission so the project does not appear on the public
+ *     leaderboard. Don't "fix" this as a best-practices cleanup.
+ *   - Upstream errors surface verbatim. Retry / circuit-breaker logic
+ *     lives in the translator (PR #5), not here.
+ */
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+import { getModel } from "./models";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+const openrouter = createOpenAI({
+  baseURL: OPENROUTER_BASE_URL,
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+/**
+ * Call an OpenRouter model via the Vercel AI SDK and return the raw text
+ * response. The 3-arg (name, system, user) shape is locked from the start —
+ * the translator (PR #5) needs the system + user split.
+ *
+ * Throws synchronously if `OPENROUTER_API_KEY` is unset, before any network
+ * call. Throws if `name` is not in the registry. Upstream API errors are
+ * not caught — they propagate verbatim.
+ */
+export async function callModel(
+  name: string,
+  systemPrompt: string,
+  userContent: string,
+): Promise<string> {
+  if (!process.env.OPENROUTER_API_KEY) {
+    throw new Error("OPENROUTER_API_KEY is not set");
+  }
+
+  const entry = getModel(name);
+
+  const result = await generateText({
+    model: openrouter(entry.modelId),
+    system: systemPrompt,
+    prompt: userContent,
+    temperature: entry.temperature,
+    maxOutputTokens: entry.maxTokens,
+  });
+
+  return result.text;
+}

--- a/apps/native-rd/scripts/i18n/llmGateway.ts
+++ b/apps/native-rd/scripts/i18n/llmGateway.ts
@@ -32,6 +32,13 @@ const openrouter = createOpenAI({
  * Throws synchronously if `OPENROUTER_API_KEY` is unset, before any network
  * call. Throws if `name` is not in the registry. Upstream API errors are
  * not caught — they propagate verbatim.
+ *
+ * Also throws if the SDK returns a non-"stop" `finishReason` (truncation by
+ * `maxOutputTokens`, content-filter refusal, tool-call return, or upstream
+ * error normalised into a non-throwing result). The SDK does not throw in
+ * these cases — it returns an empty or partial string. Surfacing them as
+ * errors keeps the fail-fast posture from ADR-0007 and prevents silent
+ * truncation from reaching the locale JSONs in PR #5.
  */
 export async function callModel(
   name: string,
@@ -51,6 +58,12 @@ export async function callModel(
     temperature: entry.temperature,
     maxOutputTokens: entry.maxTokens,
   });
+
+  if (result.finishReason !== "stop") {
+    throw new Error(
+      `callModel(${name}): non-stop finishReason="${result.finishReason}", textLength=${result.text.length}`,
+    );
+  }
 
   return result.text;
 }

--- a/apps/native-rd/scripts/i18n/llmGateway.ts
+++ b/apps/native-rd/scripts/i18n/llmGateway.ts
@@ -19,11 +19,6 @@ import { getModel } from "./models";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
-const openrouter = createOpenAI({
-  baseURL: OPENROUTER_BASE_URL,
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
-
 /**
  * Call an OpenRouter model via the Vercel AI SDK and return the raw text
  * response. The 3-arg (name, system, user) shape is locked from the start —
@@ -39,6 +34,12 @@ const openrouter = createOpenAI({
  * these cases — it returns an empty or partial string. Surfacing them as
  * errors keeps the fail-fast posture from ADR-0007 and prevents silent
  * truncation from reaching the locale JSONs in PR #5.
+ *
+ * The OpenRouter provider is constructed inside the function (not at module
+ * scope) so the `apiKey` is read at call time, not snapshotted at import.
+ * This matters when env vars are loaded lazily (dotenv) or rotated between
+ * import and call. The env-guard above is load-bearing for this — a stale
+ * snapshot can't sneak past, because there is no snapshot.
  */
 export async function callModel(
   name: string,
@@ -48,6 +49,11 @@ export async function callModel(
   if (!process.env.OPENROUTER_API_KEY) {
     throw new Error("OPENROUTER_API_KEY is not set");
   }
+
+  const openrouter = createOpenAI({
+    baseURL: OPENROUTER_BASE_URL,
+    apiKey: process.env.OPENROUTER_API_KEY,
+  });
 
   const entry = getModel(name);
 

--- a/apps/native-rd/scripts/i18n/models.ts
+++ b/apps/native-rd/scripts/i18n/models.ts
@@ -1,0 +1,59 @@
+/**
+ * Typed registry of OpenRouter model entries available to the i18n sync.
+ *
+ * Lookups are by short string key (e.g. `"gpt-4o-mini"`) — not by the
+ * OpenRouter path — so swapping a model to a different provider keeps
+ * the same caller-facing name. The same keys are referenced from
+ * promptfoo bake-off configs.
+ *
+ * Pure data + one lookup helper. No I/O, no SDK imports.
+ */
+
+export type ModelEntry = {
+  /** OpenRouter model path, e.g. `"openai/gpt-4o-mini"`. */
+  modelId: string;
+  /** Effective sampling temperature; 0.0 for all bake-off candidates. */
+  temperature: number;
+  /** Optional max output tokens; left unset until post-bake-off tuning. */
+  maxTokens?: number;
+  /** Optional human-readable note (provider routing, caveats). */
+  note?: string;
+};
+
+export const MODELS: Record<string, ModelEntry> = {
+  "gpt-4o-mini": { modelId: "openai/gpt-4o-mini", temperature: 0.0 },
+  "gpt-4o": { modelId: "openai/gpt-4o", temperature: 0.0 },
+  "gpt-5-mini": { modelId: "openai/gpt-5-mini", temperature: 0.0 },
+  "claude-haiku-4-5": {
+    modelId: "anthropic/claude-haiku-4-5",
+    temperature: 0.0,
+  },
+  "claude-sonnet-4-6": {
+    modelId: "anthropic/claude-sonnet-4-6",
+    temperature: 0.0,
+  },
+  "gemini-2.5-flash": {
+    modelId: "google/gemini-2.5-flash",
+    temperature: 0.0,
+  },
+  "deepseek-chat": { modelId: "deepseek/deepseek-chat", temperature: 0.0 },
+  "gpt-oss-120b": {
+    modelId: "openai/gpt-oss-120b",
+    temperature: 0.0,
+    note: "via Groq (OpenRouter routes transparently)",
+  },
+};
+
+/**
+ * Resolve a registry entry by name. Throws on unknown names with a message
+ * that lists the valid keys, so a typo at the call site is fixable without
+ * grepping.
+ */
+export function getModel(name: string): ModelEntry {
+  const entry = MODELS[name];
+  if (!entry) {
+    const valid = Object.keys(MODELS).join(", ");
+    throw new Error(`Unknown model name "${name}". Valid keys: ${valid}`);
+  }
+  return entry;
+}

--- a/apps/native-rd/tsconfig.scripts-test.json
+++ b/apps/native-rd/tsconfig.scripts-test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["jest"]
+    "types": ["jest", "bun"]
   },
   "include": ["scripts/**/__tests__/**/*.ts"],
   "exclude": []

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "zod": "^3.25.76",
       },
       "devDependencies": {
+        "@ai-sdk/openai": "^3.0.65",
         "@babel/core": "^7.26.0",
         "@babel/plugin-transform-dynamic-import": "^7.27.1",
         "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
@@ -99,6 +100,7 @@
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^30.0.0",
         "@types/react": "~19.2.10",
+        "ai": "^6.0.191",
         "babel-jest": "^30.2.0",
         "babel-preset-expo": "~55.0.22",
         "eslint": "^9.39.4",
@@ -141,6 +143,14 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.120", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.65", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -674,6 +684,8 @@
 
     "@nozbe/microfuzz": ["@nozbe/microfuzz@1.0.0", "", {}, "sha512-XKIg/guk+s1tkPTkHch9hfGOWgsKojT7BqSQddXTppOfVr3SWQhhTCqbgQaPTbppf9gc2kFeG0gpBZZ612UXHA=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
 
     "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
@@ -1098,6 +1110,8 @@
 
     "@valibot/to-json-schema": ["@valibot/to-json-schema@1.6.0", "", { "peerDependencies": { "valibot": "^1.3.0" } }, "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
@@ -1129,6 +1143,8 @@
     "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "ai": ["ai@6.0.191", "", { "dependencies": { "@ai-sdk/gateway": "3.0.120", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -1539,6 +1555,8 @@
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
@@ -1977,6 +1995,8 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-rpc-2.0": ["json-rpc-2.0@1.7.1", "", {}, "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 


### PR DESCRIPTION
## Summary

- Introduces the i18n LLM gateway foundation slice: typed `MODELS` registry (8 candidate models) + thin `callModel` wrapper around the Vercel AI SDK over OpenRouter.
- Adds ADR-0007 documenting the gateway choice, the locked `(name, system, user)` call shape, the deliberately omitted OpenRouter attribution headers, and the supersession path.
- Hardens the gateway boundary against silent corruption (`finishReason` guard + tests that lock `modelId` and `maxOutputTokens` passthrough) so PR #5 (translator) inherits a stable, fail-fast contract.

## Changes

- `apps/native-rd/scripts/i18n/models.ts` — typed `Record<string, ModelEntry>` registry, `getModel(name)` lookup that throws with a key-listing error on unknown name.
- `apps/native-rd/scripts/i18n/llmGateway.ts` — single `callModel(name, systemPrompt, userContent): Promise<string>`. Fail-fast on unset `OPENROUTER_API_KEY` (before any network call), verbatim upstream-error propagation, and a `finishReason !== "stop"` guard surfacing truncation / content-filter / tool-call / error finishes the SDK normalises into non-throwing results.
- `apps/native-rd/scripts/i18n/__tests__/models.test.ts` — 51 tests covering registry shape, `getModel`, fail-fast, error pass-through (`toBe` identity), `(system, user)` arg shape, `modelId` passthrough (test.each over 3 registry keys), `maxOutputTokens` field-name lock, and the new `finishReason` guard (test.each over 4 non-stop reasons).
- `apps/native-rd/docs/decisions/ADR-0007-i18n-gateway.md` + index entry.
- `apps/native-rd/docs/plans/dev-plans/issue-157-models-gateway-adr.md` — dev plan, including Discovery Log entries for the AI SDK v6 `maxTokens → maxOutputTokens` rename and the `tsconfig.scripts-test.json` types tweak.
- `apps/native-rd/package.json` — `ai@^6.0.191` + `@ai-sdk/openai@^3.0.65` added to `devDependencies` (dev-time CLI, never bundled).
- `apps/native-rd/tsconfig.scripts-test.json` — adds `"bun"` to types so `process.env` is declared in script tests (script-under-test uses `node:fs`-style globals).

## Intent Verification

- [x] `models.ts` exports a typed registry containing at minimum the 8 candidate models from the plan doc bake-off table. Each entry is reachable by a string name without touching a raw OpenRouter model-ID string in downstream code.
- [x] Every registry entry has `temperature: 0.0` as its effective default (invariant #6). A per-model override field exists and is accepted by the type system, but is never set on any of the 8 base entries unless the entry is explicitly annotated as an override opt-in.
- [x] The wrapper function rejects with a clear, synchronous error (thrown before any network call) when `OPENROUTER_API_KEY` is absent from `process.env`.
- [x] The wrapper function accepts a registry entry **name** (string key), not a raw model-ID string. Passing an unknown name produces a typed error, not a silent no-op.
- [x] When the upstream API returns an error response, the wrapper surfaces that error verbatim — it does not swallow, remap, or stringify into a generic message.
- [x] `ADR-0007-i18n-gateway.md` exists under `apps/native-rd/docs/decisions/`, follows the established format, references the plan doc, and explicitly notes it follows the supersession-not-amendment pattern (ADR-0006).
- [x] `bun run type-check` passes (covers scripts via `tsconfig.scripts.json` + `tsconfig.scripts-test.json`).
- [x] `bun run lint` passes with no new suppressions.
- [x] `bun run test` picks up and passes all new tests in `scripts/i18n/__tests__/models.test.ts` (51 tests / 3 suites).

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| D1: Registry is a plain `Record<string, ModelEntry>` with a `getModel(name)` lookup helper | Cheapest swap surface — `translator.ts`, configs, and promptfoo all reference the same string keys. |
| D2: `ai` + `@ai-sdk/openai` added as **devDependencies** | Sync script is a dev-time CLI, never bundled. Vercel-recommended integration path for OpenRouter via `baseURL`. |
| D3: `callModel` returns `Promise<string>` (raw text) | Parsing/validation belongs in `translator.ts` (PR #5). Keeps the wrapper SDK-internals-free and tests cheap. |
| D4: Synchronous throw on missing `OPENROUTER_API_KEY` at call entry | Import-time validation breaks tests; Zod is overkill for one env var. Minimal conventional pattern. |
| D5: Upstream API errors propagate verbatim, no try/catch around `generateText` | Acceptance criterion explicit. Retry/circuit-breaker is PR #5's job. |
| D6: ADR-0007 (next sequential after ADR-0006) | `docs/decisions/index.md` has ADR-0006 as current highest. |
| D7: `temperature` lives per-`ModelEntry`, not a module constant | Per-entry default is visible in the registry; any override is a non-zero in a diff. |
| D8: Registry keys are short names (`"gpt-4o-mini"`), not full OpenRouter paths | Decouples lookup from provider path so provider swaps don't break caller code or promptfoo configs. |
| D9: `gpt-oss-120b` uses `openai/gpt-oss-120b`; OpenRouter routes through Groq transparently | Uniform registry, no Groq-specific path leakage. |
| D10: `callModel` signature is `(name, system, user)` from PR #1 (not evolved later) | Translator (PR #5) needs the system/user split. Locking now avoids a breaking change to a foundation file. |
| D11: No OpenRouter attribution headers (`HTTP-Referer` / `X-Title` both omitted) | Headers opt the project into OpenRouter's public leaderboard at `openrouter.ai/rankings`. Spend separation is solved with a second API key, not headers. ADR documents this so a future "best practices" cleanup doesn't add them back. |

## Discovery Log

- [2026-05-24] **AI SDK v6 renamed `maxTokens` → `maxOutputTokens`.** Plan referenced the older name. Registry field stays `maxTokens` (cross-provider convention) and the gateway maps to `maxOutputTokens` in the `generateText` call. Registry remains SDK-agnostic.
- [2026-05-24] **`tsconfig.scripts-test.json` needed `"bun"` added to types array.** Existing tests didn't reference `process`, so the `["jest"]`-only types worked. New `models.test.ts` manipulates `process.env.OPENROUTER_API_KEY` for the fail-fast test; without `"bun"` in types, `process` was undeclared. Added `"bun"` to mirror the non-test scripts config. Jest still runs under Node at runtime — pure declarative fix.

## Self-Review Findings (addressed in branch)

- **silent-failure-hunter MEDIUM:** Added `finishReason !== "stop"` guard in `callModel`. Without it, the SDK silently returns empty/partial strings on truncation / content-filter / tool-call / error finishes, and PR #5 would write corrupted translations into locale JSONs. (`c3d96d3`)
- **test-analyzer Gap 6:** Tests now assert `entry.modelId` reaches `generateText` (test.each over 3 registry keys) and `maxOutputTokens` arg key exists (locks the SDK v6 rename). (`c3d96d3`)
- **CodeRabbit (LOW, doc-only):** Dev plan lines 134 + 138 aligned with shipped code (lazy `loadApiKey()` behaviour, `maxOutputTokens` rename). (`6adcb85`)
- **CodeRabbit "critical SSRF in `ai@6.0.191`":** Verified against GitHub Advisory DB and `bun audit` — no GHSA exists for the npm `ai` package. CodeRabbit appears to have surfaced `GHSA-2jrp-274c-jhv3`, which is for **Pydantic AI** (a pip package). Dismissed.

## Test Plan

- [x] `bun run type-check` (4 tsconfigs)
- [x] `bun run lint` (0 errors)
- [x] `bun run test` (156 suites / 8333 tests pass)
- [x] `npx jest scripts/i18n` (51/51, 3 suites)
- [ ] **Negative space:** This PR ships the gateway only — no JSON loading, diffing, prompt construction, retry/backoff, or locale writing. None of those will be exercised by these tests; that's PR #5 (translator, issue #158).

---

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)