### PR TITLE
fix(native-rd/i18n): load .env.local in bakeoff wrapper

### DIFF
--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -37,7 +37,7 @@
     "release-notes:generate": "bun run scripts/release-notes-generate.ts",
     "release-notes:split": "bun run scripts/release-notes-split.ts",
     "i18n:lint-source": "bun run scripts/i18n/lintSource.cli.ts",
-    "i18n:bakeoff": "test -n \"$OPENROUTER_API_KEY\" || (echo 'i18n:bakeoff requires OPENROUTER_API_KEY in env' && exit 1) && mkdir -p scripts/i18n/promptfoo/reports && promptfoo eval --config scripts/i18n/promptfoo/promptfooconfig.yaml --output scripts/i18n/promptfoo/reports/$(date +%Y%m%d-%H%M%S).html"
+    "i18n:bakeoff": "bash scripts/i18n/run-bakeoff.sh"
   },
   "dependencies": {
     "@evolu/common": "^7.4.1",

--- a/apps/native-rd/scripts/i18n/run-bakeoff.sh
+++ b/apps/native-rd/scripts/i18n/run-bakeoff.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if [ -f .env.local ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env.local
+  set +a
+fi
+
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  echo "i18n:bakeoff requires OPENROUTER_API_KEY — set it in apps/native-rd/.env.local or export it in your shell" >&2
+  exit 1
+fi
+
+reports_dir="scripts/i18n/promptfoo/reports"
+mkdir -p "$reports_dir"
+output="$reports_dir/$(date +%Y%m%d-%H%M%S).html"
+
+exec ./node_modules/.bin/promptfoo eval \
+  --config scripts/i18n/promptfoo/promptfooconfig.yaml \
+  --output "$output"


### PR DESCRIPTION
## Summary

Cherry-pick of `fb0154b` from the abandoned `fix/i18n-bakeoff-env-load` branch. Single commit: introduces `scripts/i18n/run-bakeoff.sh` so `bun run i18n:bakeoff` picks up `OPENROUTER_API_KEY` from `apps/native-rd/.env.local` instead of requiring it in the shell.

Nothing else from that branch is included — the bake-off rig changes (rubric, simplify pass, shared placeholders/banned-phrases) are not in this PR.

## Test plan

- [ ] CI green