### PR TITLE
feat(native-rd/i18n): sync.ts CLI — namespace walker + integration test (#161)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md
@@ -1,0 +1,178 @@
+# Development Plan: Issue #161
+
+## Issue Summary
+
+**Title**: i18n sync: sync.ts CLI + integration test
+**Type**: feature
+**Complexity**: SMALL
+**Estimated Lines**: ~300 hand-written (CLI + integration test, tests count)
+
+## Intent Verification
+
+Observable criteria derived from the issue. These describe what success looks like from a user/system perspective.
+
+- [ ] Running `bun run i18n:sync` with no flags walks all 15 namespaces in `src/i18n/resources/en/` and writes translated content to `src/i18n/resources/de/<ns>.json` for each namespace that has gaps.
+- [ ] Running `bun run i18n:sync --namespace common` translates only `common.json`; passing `--namespace nonexistent` exits non-zero with a clear error naming the unknown namespace.
+- [ ] Running `bun run i18n:sync --dry-run` calls `translateNamespace` (calls the LLM) but does not write any file to disk; the `de/` files remain unchanged.
+- [ ] Running `bun run i18n:sync --target fr` exits non-zero with a clear error naming `fr` as unsupported; `--target de` succeeds.
+- [ ] Running `bun run i18n:sync` twice in a row when nothing in `en/` has changed between runs results in zero file writes on the second run (idempotency verified by integration test).
+- [ ] An existing `de/` value is never overwritten: adding a new key to `en/<ns>.json` and running sync fills the new key; the existing German values remain verbatim (gap-only, verified by integration test).
+- [ ] When the LLM drops a `{{placeholder}}` token, the CLI exits non-zero and prints a clear error naming the offending key; no partial file is written (verified by integration test with mocked LLM).
+- [ ] Output JSON files preserve the same top-level key order as the `en/` source (deterministic git diffs, verified by integration test).
+- [ ] `bun run type-check` and `bun run lint` pass on the new files.
+
+## Dependencies
+
+| Issue | Title                                                       | Status                          | Type    |
+| ----- | ----------------------------------------------------------- | ------------------------------- | ------- |
+| #160  | i18n sync: translator + promptBuilder — batch orchestration | ✅ Met (CLOSED, commit 8523718) | Blocker |
+
+**Status**: All dependencies met.
+
+## Objective
+
+Ship `apps/native-rd/scripts/i18n/sync.ts` — the Bun CLI entry point that orchestrates the en→de sync pipeline — and a Jest integration test that covers idempotency, gap-only behaviour, placeholder mismatch exit, and key-order preservation. The test mocks `llmGateway.callModel` (the same pattern used in `translator.test.ts`) so no network or API key is required.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                       | Alternatives Considered                                 | Rationale                                                                                                                                                                                                                                                               |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | `sync.ts` owns `import.meta` (file-system bootstrap, arg parsing, `.env.local` loading); no `.cli.ts` split needed                                             | Split to `sync.cli.ts` + `sync.ts` (lintSource pattern) | The lintSource split exists because lintSource.ts is imported by its own test; sync.ts's logic is thin orchestration glue — the integration test exercises it by mocking `llmGateway` rather than importing `sync.ts` as a pure module. A single-file CLI is fine here. |
+| D2  | `--model` flag defaults to `claude-haiku-4-5`                                                                                                                  | Any registry entry                                      | Cheapest strong-register model in the bakeoff pool; a sensible CI default before the bakeoff verdict is in. Callers can override.                                                                                                                                       |
+| D3  | Register file path: `<appDir>/src/i18n/resources/_register/<ns>.yml`; missing register is a hard error                                                         | Warn and skip namespace                                 | Locked decision #2 in i18n-llm-sync.md: register files live at `src/i18n/resources/_register/`. Missing register means the namespace cannot be synced safely (no voice context). Hard-fail keeps the pipeline honest.                                                   |
+| D4  | Only `de` is a supported `--target` locale for v1; unsupported locale = non-zero exit                                                                          | Accept any string, pass through                         | Matches locked decision in plan: "de only for v1, fr is near-trivial add later". Hard-fail prevents silent mis-targeting.                                                                                                                                               |
+| D5  | Integration test: single test file at `scripts/i18n/__tests__/sync.test.ts`; mocks `llmGateway` and `node:fs` write path                                       | Separate fixture files on disk                          | Consistent with `translator.test.ts` pattern (`jest.mock("../llmGateway")`). No disk I/O in test means no temp-dir teardown complexity.                                                                                                                                 |
+| D6  | `.env.local` loading via the same `set -a / source` pattern from `run-bakeoff.sh` — handled in a wrapper shell script OR inline `dotenv` at the top of sync.ts | Bash wrapper only                                       | `sync.ts` uses `import.meta` so it already must run under Bun. Inline dotenv (using `bun`'s built-in `Bun.env` + a manual `.env.local` read) keeps it as a pure Bun script entry without a bash shim. See open question Q1.                                             |
+
+## Affected Areas
+
+- `apps/native-rd/scripts/i18n/sync.ts` — **new** — CLI entry point
+- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` — **new** — integration test
+- `apps/native-rd/package.json` — **modify** — add `"i18n:sync"` script entry
+
+## Implementation Plan
+
+### Step 1: sync.ts CLI + package.json entry
+
+**Files**:
+
+- `apps/native-rd/scripts/i18n/sync.ts` (new, ~150 LOC)
+- `apps/native-rd/package.json` (modify, +1 line)
+
+**Commit**: `feat(native-rd/i18n): add sync.ts CLI — namespace walker + gap-only writer`
+
+**Changes**:
+
+- [ ] Load `.env.local` from `<appDir>/.env.local` using `node:fs` + split-on-newline dotenv parse (same guard as `llmGateway.ts`: throw if `OPENROUTER_API_KEY` absent before any LLM call). Use `import.meta.dir` to anchor the app root (same pattern as `lintSource.cli.ts`).
+- [ ] Parse CLI flags with `process.argv` slice (no third-party arg parser — consistent with existing scripts that use manual `process.argv` slicing):
+  - `--namespace <name>` — scope to one namespace; error on unknown name
+  - `--dry-run` — skip disk writes, still call LLM
+  - `--target <locale>` — default `de`; reject anything else with non-zero exit
+  - `--model <name>` — default `claude-haiku-4-5`
+- [ ] Build namespace list: `readdirSync(<enDir>)` filtering `*.json`, strip `.json` extension → 15 names. If `--namespace` given, validate it is in this list.
+- [ ] Validate `--target`: only `"de"` accepted; print `"unsupported locale: <value>. Supported: de"` to stderr and `process.exit(1)`.
+- [ ] For each namespace in scope:
+  - Read `en/<ns>.json` → `JSON.parse`
+  - Read `de/<ns>.json` → `JSON.parse` (treat missing file as `{}`)
+  - Read `src/i18n/resources/_register/<ns>.yml` → string (missing register = throw with namespace name)
+  - Call `translateNamespace({ enTree, deTree, ns, modelName, registerText })`
+  - If `--dry-run`, skip write; otherwise `writeFileSync` with `JSON.stringify(result, null, 2) + "\n"` (preserves key order from `mergeTranslations` which inherits source key order via `deepFillMissingStrings`)
+  - Catch errors per-namespace: print `"[sync] namespace <ns>: <message>"` to stderr, set exit code to 1 (accumulate failures — don't abort on first; write completed namespaces before exiting)
+- [ ] Exit 0 if all namespaces succeeded; exit 1 if any failed.
+- [ ] Add to `package.json` scripts: `"i18n:sync": "bun run scripts/i18n/sync.ts"`
+
+**Key order note**: `JSON.stringify` preserves insertion order of object keys. `mergeTranslations` (in `jsonTreeUtils.ts`) builds the result via `deepFillMissingStrings` which iterates `Object.entries(source)` first, then appends extra target keys — this naturally preserves `en/` key order in the output. No additional sorting needed.
+
+### Step 2: Integration test
+
+**Files**:
+
+- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` (new, ~150 LOC)
+
+**Commit**: `test(native-rd/i18n): integration test for sync.ts — idempotency, gap-only, placeholder mismatch, key order`
+
+**Changes**:
+
+- [ ] `jest.mock("../llmGateway", () => ({ callModel: jest.fn() }))` — same pattern as `translator.test.ts`
+- [ ] `jest.mock("node:fs", ...)` — spy on `writeFileSync` to capture writes without touching disk. Also spy on `readFileSync` to return fixture data.
+- [ ] Fixture: a two-namespace mini-tree:
+  - `en/alpha.json`: `{ "greet": "Hello", "farewell": "Goodbye {{name}}" }`
+  - `en/beta.json`: `{ "save": "Save" }`
+  - `de/alpha.json`: `{}` (initially empty)
+  - `de/beta.json`: `{}` (initially empty)
+  - `_register/alpha.yml` + `_register/beta.yml`: minimal YAML stubs matching `RegisterData` shape
+- [ ] Test: **idempotency** — pre-fill `de/alpha.json` with `{ "greet": "Hallo", "farewell": "Auf Wiedersehen {{name}}" }`. Mock `callModel` to throw if called. Run sync on `alpha`. Assert `writeFileSync` not called; `callModel` not called.
+- [ ] Test: **gap-only** — pre-fill `de/alpha.json` with `{ "greet": "Hallo" }` (one key present). Mock `callModel` to return `JSON.stringify({ k0: "Auf Wiedersehen {{name}}" })`. Run sync on `alpha`. Assert written output contains `"greet": "Hallo"` (preserved) and `"farewell": "Auf Wiedersehen {{name}}"` (filled).
+- [ ] Test: **placeholder mismatch exits non-zero** — pre-fill `de/alpha.json` as `{}`. Mock `callModel` to return `JSON.stringify({ k0: "Hallo", k1: "Auf Wiedersehen" })` (drops `{{name}}`). Run sync on `alpha`. Assert `process.exitCode` is 1 (or `process.exit` was called with 1); assert `writeFileSync` not called for `alpha`.
+- [ ] Test: **key order preserved** — `en/beta.json` has keys `{ z: "Z", a: "A", m: "M" }`. Mock `callModel` to return keys in same order (`{ k0: "Z_de", k1: "A_de", k2: "M_de" }`). Assert written JSON string has `z` before `a` before `m`.
+- [ ] Test: **`--namespace` unknown name** — call with `--namespace nonexistent`. Assert exits 1 with error message containing "nonexistent".
+- [ ] Test: **`--target fr` unsupported** — call with `--target fr`. Assert exits 1 with message containing "unsupported locale".
+- [ ] Test: **`--dry-run`** — call with `--dry-run`. Mock `callModel` to return valid translations. Assert `callModel` was called (LLM still invoked), `writeFileSync` never called.
+
+**Note on testing `sync.ts` as a module**: Because `sync.ts` uses `import.meta` (for path anchoring), it cannot be `require()`'d by Jest's Node/babel-jest pipeline directly. The integration test instead imports the sync pipeline's constituent functions (`translateNamespace` from `translator.ts` + the file-walking logic) and tests at that boundary — or invokes `sync.ts` with `spyOn(process, 'exit')` and mocked `fs` to simulate the CLI contract. The exact approach (import-core-logic vs. full-module-invoke) is the open question Q2 below.
+
+## Testing Strategy
+
+- [ ] Unit tests: covered by the integration test in Step 2 (no separate unit tests for sync.ts — it is thin orchestration glue)
+- [ ] Test file: `scripts/i18n/__tests__/sync.test.ts` (mirrors scripts path under `__tests__/`)
+- [ ] jest config: `jest.config.js` already includes `"**/scripts/**/__tests__/**/*.test.ts"` — no config change needed
+- [ ] `tsconfig.scripts-test.json` already has `"types": ["jest", "bun"]` — no change needed
+- [ ] `tsconfig.scripts.json` already includes `scripts/**/*.ts` and excludes `__tests__/` — sync.ts covered automatically
+- [ ] Manual smoke test (requires `OPENROUTER_API_KEY` in `.env.local`): `bun run i18n:sync --namespace common --dry-run`
+- [ ] Manual smoke test (writes): `bun run i18n:sync --namespace welcome`
+
+## Not in Scope
+
+| Item                                                | Reason                                                                                                                                                      | Follow-up                                            |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Register YAMLs for all 15 namespaces                | Only `common.yml` exists today; sync hard-fails on missing register — the remaining 14 must be authored. Authoring voice register content is PR #8's scope. | Issue for PR #8                                      |
+| `--target fr` support                               | Locked to `de` only for v1                                                                                                                                  | None (design doc notes fr as near-trivial add later) |
+| Concurrent batching (parallel namespace processing) | Locked decision #5 in i18n-llm-sync.md: single-threaded for v1                                                                                              | Post-v1                                              |
+| CI workflow invocation (`i18n-sync.yml`)            | PR #9's scope                                                                                                                                               | Issue for PR #9                                      |
+| Sidecar intent loader (`en/*.intents.json`)         | PR #8's scope; `translateNamespace` already accepts `intents` param, sync.ts passes `undefined` for now                                                     | Issue for PR #8                                      |
+| Glossary loading                                    | PR #8's scope                                                                                                                                               | Issue for PR #8                                      |
+
+## Open Questions — Joe to answer before implementation
+
+**Q1 — `.env.local` loading in sync.ts**
+
+`run-bakeoff.sh` loads `.env.local` via bash `set -a / source`. The `package.json` entry `"i18n:sync": "bun run scripts/i18n/sync.ts"` invokes the script directly under Bun without a bash wrapper. Two options:
+
+- **Option A (inline)**: At the top of `sync.ts`, read `.env.local` manually with `node:fs` + string split, calling `process.env[key] = value` for each line. Bun does not auto-load `.env.local` for `bun run <script.ts>` (it does for `bun run <package-script>` entries that resolve to `bunx` — but we go through the `bun run scripts/i18n/sync.ts` path which is a direct file exec). Needs verification.
+- **Option B (wrapper)**: Add `scripts/i18n/run-sync.sh` mirroring `run-bakeoff.sh` (bash loads `.env.local`, execs `bun run scripts/i18n/sync.ts`), and point the package.json entry at the shell wrapper.
+
+Preference? Option A keeps everything in one file and matches how the eventual CI workflow will inject secrets via env (no `.env.local` in CI anyway). Leaning Option A unless Bun's env-load behavior for direct file execs is confirmed otherwise.
+
+**Q2 — Integration test strategy for `sync.ts` given `import.meta`**
+
+`sync.ts` will call `import.meta.dir` to anchor its paths. Jest + babel-jest transforms `import.meta` with `@babel/plugin-transform-modules-commonjs` but stubs `import.meta.dir` as `undefined` unless we add `import-meta-transform` or a babel plugin. Three options:
+
+- **Option A (extract)**: Move the file-walking + per-namespace orchestration logic into `syncCore.ts` (no `import.meta`, pure functions taking absolute paths as args). `sync.ts` is a thin CLI wrapper (just like `lintSource.cli.ts`). `syncCore.ts` is what the test imports. This is the same pattern that already works for `lintSource.ts`.
+- **Option B (spawn)**: Test by spawning `bun` as a child process and asserting on stdout/stderr/exit code + file contents. No `import.meta` issue; clean CLI contract test. Slower, requires disk fixtures.
+- **Option C (mock import.meta.dir)**: Use a Jest `moduleNameMapper` or manual mock to stub `import.meta.dir`. Fragile.
+
+The lintSource pattern (Option A / extract) is already proven in this codebase and the cleanest for a unit-style integration test. This would mean a `sync.cli.ts` + `syncCore.ts` split instead of a single `sync.ts`. Joe: do you want the cli/core split, or would you prefer Option B (spawn-based) to keep `sync.ts` as a single file?
+
+**Q3 — Missing register YAMLs for 14 of 15 namespaces**
+
+Only `common.yml` exists in `src/i18n/resources/_register/`. Per Decision D3, a missing register is a hard error. This means `bun run i18n:sync` (all 15 namespaces) will fail for 14 of them until those files exist. Three options:
+
+- **Option A**: Stub the 14 missing registers with the same minimal content as `common.yml` in this PR so the CLI is immediately runnable.
+- **Option B**: The sync.ts hard-fails on missing register and prints a clear error per namespace; PR #8 authors the real register content. `bun run i18n:sync --namespace common` works immediately; full-sweep is gated on PR #8.
+- **Option C**: `--namespace` required if registers are missing; default "all 15" only works after PR #8 lands.
+
+Option A (stub all registers now with placeholder content) makes the CLI immediately runnable for full-sweep smoke tests while making it clear the register content is a stub. Option B is cleaner but means the CLI is only useful for `--namespace common` until PR #8 lands.
+
+## Resolutions (autonomous mode, 2026-05-25)
+
+Open questions resolved before implementation:
+
+- **Q1 → Option A (inline `.env.local`)**: `sync.cli.ts` loads `.env.local` inline via `node:fs` + manual parse. CI injects secrets via env directly; no bash wrapper needed.
+- **Q2 → Option A (split: `syncCore.ts` + `sync.cli.ts`)**: Proven pattern in this codebase (`lintSource.ts` / `lintSource.cli.ts`). Overrides D1 — splitting is required to make the integration test importable without `import.meta` transform headaches. `syncCore.ts` exports pure functions taking absolute paths; `sync.cli.ts` is the thin CLI wrapper that owns `import.meta.dir` + arg parsing.
+- **Q3 → Option B (hard-fail on missing register)**: Authoring real register YAMLs is PR #8's scope. `bun run i18n:sync --namespace common` works end-to-end now; full-sweep is gated on PR #8. The integration test uses fixture registers so test coverage is unaffected. Each missing register produces a clear per-namespace error before exiting non-zero.
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md
@@ -11,15 +11,15 @@
 
 Observable criteria derived from the issue. These describe what success looks like from a user/system perspective.
 
-- [ ] Running `bun run i18n:sync` with no flags walks all 15 namespaces in `src/i18n/resources/en/` and writes translated content to `src/i18n/resources/de/<ns>.json` for each namespace that has gaps.
-- [ ] Running `bun run i18n:sync --namespace common` translates only `common.json`; passing `--namespace nonexistent` exits non-zero with a clear error naming the unknown namespace.
-- [ ] Running `bun run i18n:sync --dry-run` calls `translateNamespace` (calls the LLM) but does not write any file to disk; the `de/` files remain unchanged.
-- [ ] Running `bun run i18n:sync --target fr` exits non-zero with a clear error naming `fr` as unsupported; `--target de` succeeds.
-- [ ] Running `bun run i18n:sync` twice in a row when nothing in `en/` has changed between runs results in zero file writes on the second run (idempotency verified by integration test).
-- [ ] An existing `de/` value is never overwritten: adding a new key to `en/<ns>.json` and running sync fills the new key; the existing German values remain verbatim (gap-only, verified by integration test).
-- [ ] When the LLM drops a `{{placeholder}}` token, the CLI exits non-zero and prints a clear error naming the offending key; no partial file is written (verified by integration test with mocked LLM).
-- [ ] Output JSON files preserve the same top-level key order as the `en/` source (deterministic git diffs, verified by integration test).
-- [ ] `bun run type-check` and `bun run lint` pass on the new files.
+- [x] Running `bun run i18n:sync` with no flags walks all 15 namespaces in `src/i18n/resources/en/` and writes translated content to `src/i18n/resources/de/<ns>.json` for each namespace that has gaps. _(14/15 will hard-fail today on missing register YAMLs — PR #8 scope; CLI itself is correct.)_
+- [x] Running `bun run i18n:sync --namespace common` translates only `common.json`; passing `--namespace nonexistent` exits non-zero with a clear error naming the unknown namespace.
+- [x] Running `bun run i18n:sync --dry-run` calls `translateNamespace` (calls the LLM) but does not write any file to disk; the `de/` files remain unchanged.
+- [x] Running `bun run i18n:sync --target fr` exits non-zero with a clear error naming `fr` as unsupported; `--target de` succeeds.
+- [x] Running `bun run i18n:sync` twice in a row when nothing in `en/` has changed between runs results in zero file writes on the second run (idempotency verified by integration test).
+- [x] An existing `de/` value is never overwritten: adding a new key to `en/<ns>.json` and running sync fills the new key; the existing German values remain verbatim (gap-only, verified by integration test).
+- [x] When the LLM drops a `{{placeholder}}` token, the CLI exits non-zero and prints a clear error naming the offending key; no partial file is written (verified by integration test with mocked LLM).
+- [x] Output JSON files preserve the same top-level key order as the `en/` source (deterministic git diffs, verified by integration test using string-position assertions).
+- [x] `bun run type-check` and `bun run lint` pass on the new files.
 
 ## Dependencies
 
@@ -35,51 +35,59 @@ Ship `apps/native-rd/scripts/i18n/sync.ts` — the Bun CLI entry point that orch
 
 ## Decisions
 
-| ID  | Decision                                                                                                                                                       | Alternatives Considered                                 | Rationale                                                                                                                                                                                                                                                               |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| D1  | `sync.ts` owns `import.meta` (file-system bootstrap, arg parsing, `.env.local` loading); no `.cli.ts` split needed                                             | Split to `sync.cli.ts` + `sync.ts` (lintSource pattern) | The lintSource split exists because lintSource.ts is imported by its own test; sync.ts's logic is thin orchestration glue — the integration test exercises it by mocking `llmGateway` rather than importing `sync.ts` as a pure module. A single-file CLI is fine here. |
-| D2  | `--model` flag defaults to `claude-haiku-4-5`                                                                                                                  | Any registry entry                                      | Cheapest strong-register model in the bakeoff pool; a sensible CI default before the bakeoff verdict is in. Callers can override.                                                                                                                                       |
-| D3  | Register file path: `<appDir>/src/i18n/resources/_register/<ns>.yml`; missing register is a hard error                                                         | Warn and skip namespace                                 | Locked decision #2 in i18n-llm-sync.md: register files live at `src/i18n/resources/_register/`. Missing register means the namespace cannot be synced safely (no voice context). Hard-fail keeps the pipeline honest.                                                   |
-| D4  | Only `de` is a supported `--target` locale for v1; unsupported locale = non-zero exit                                                                          | Accept any string, pass through                         | Matches locked decision in plan: "de only for v1, fr is near-trivial add later". Hard-fail prevents silent mis-targeting.                                                                                                                                               |
-| D5  | Integration test: single test file at `scripts/i18n/__tests__/sync.test.ts`; mocks `llmGateway` and `node:fs` write path                                       | Separate fixture files on disk                          | Consistent with `translator.test.ts` pattern (`jest.mock("../llmGateway")`). No disk I/O in test means no temp-dir teardown complexity.                                                                                                                                 |
-| D6  | `.env.local` loading via the same `set -a / source` pattern from `run-bakeoff.sh` — handled in a wrapper shell script OR inline `dotenv` at the top of sync.ts | Bash wrapper only                                       | `sync.ts` uses `import.meta` so it already must run under Bun. Inline dotenv (using `bun`'s built-in `Bun.env` + a manual `.env.local` read) keeps it as a pure Bun script entry without a bash shim. See open question Q1.                                             |
+| ID  | Decision                                                                                               | Alternatives Considered          | Rationale                                                                                                                                                                                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | ~~`sync.ts` owns `import.meta`~~ **SUPERSEDED → split `syncCore.ts` + `sync.cli.ts`**                  | Original D1 was single-file      | The lintSource split pattern is needed in practice: babel-jest leaves `import.meta.dir` undefined, so the integration test must import a module that doesn't reference it. `syncCore.ts` holds the pure orchestration, `sync.cli.ts` is the thin wrapper.                                                                    |
+| D2  | `--model` flag defaults to `claude-haiku-4-5`                                                          | Any registry entry               | Cheapest strong-register model in the bakeoff pool; a sensible CI default before the bakeoff verdict is in. Callers can override.                                                                                                                                                                                            |
+| D3  | Register file path: `<appDir>/src/i18n/resources/_register/<ns>.yml`; missing register is a hard error | Warn and skip namespace          | Locked decision #2 in i18n-llm-sync.md: register files live at `src/i18n/resources/_register/`. Missing register means the namespace cannot be synced safely (no voice context). Hard-fail keeps the pipeline honest.                                                                                                        |
+| D4  | Only `de` is a supported `--target` locale for v1; unsupported locale = non-zero exit                  | Accept any string, pass through  | Matches locked decision in plan: "de only for v1, fr is near-trivial add later". Hard-fail prevents silent mis-targeting.                                                                                                                                                                                                    |
+| D5  | ~~Mock `node:fs`~~ **SUPERSEDED → tmpdir fixtures via `mkdtempSync`**                                  | Mock `node:fs` writes            | Real fs I/O against `os.tmpdir()` gives byte-equality assertions (key-order test) and matches what the CLI actually does. Per-test cleanup via `rmSync` in `afterEach` is cheaper than fs-mock teardown complexity.                                                                                                          |
+| D6  | `.env.local` loading inline in `sync.cli.ts` via `node:fs` (no bash wrapper)                           | Bash wrapper                     | CI uses env directly; no `.env.local` in CI. Existing `process.env` values win — avoids stale `.env.local` clobbering exported secrets. Mirrors `set -a` ergonomically without a shim.                                                                                                                                       |
+| D7  | Per-namespace failures accumulate; one failing ns does not abort siblings                              | Abort on first failure           | Locked behavior per the plan: `runSync` runs all requested namespaces, collects outcomes, and exits 1 iff any failed. Lets a single bad register YAML not block the other 14 from progressing.                                                                                                                               |
+| D8  | `syncCore.discoverNamespaces` delegates to `lintSource.discoverNamespaces`                             | Local readdir/filter duplication | Simplify pass found 3 copies of the readdir+filter pattern in the repo. The dedup is a small import + extension-strip; reuses `EN_DIR_REL` constant from lintSource too. (Pure-utility coupling — does not couple failure semantics, which is what the lintSource→placeholderGuard decoupling rule actually guards against.) |
 
 ## Affected Areas
 
-- `apps/native-rd/scripts/i18n/sync.ts` — **new** — CLI entry point
-- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` — **new** — integration test
+- `apps/native-rd/scripts/i18n/syncCore.ts` — **new** — pure orchestration (parseArgs, discoverNamespaces, resolveNamespaces, syncOneNamespace, runSync, formatOutcome)
+- `apps/native-rd/scripts/i18n/sync.cli.ts` — **new** — thin CLI wrapper (paths, `.env.local`, exit codes)
+- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` — **new** — integration test (17 tests)
 - `apps/native-rd/package.json` — **modify** — add `"i18n:sync"` script entry
 
 ## Implementation Plan
 
-### Step 1: sync.ts CLI + package.json entry
+### Step 1: syncCore.ts + sync.cli.ts + package.json entry
 
 **Files**:
 
-- `apps/native-rd/scripts/i18n/sync.ts` (new, ~150 LOC)
+- `apps/native-rd/scripts/i18n/syncCore.ts` (new, 215 LOC after simplify pass)
+- `apps/native-rd/scripts/i18n/sync.cli.ts` (new, 129 LOC after review fixes)
 - `apps/native-rd/package.json` (modify, +1 line)
 
-**Commit**: `feat(native-rd/i18n): add sync.ts CLI — namespace walker + gap-only writer`
+**Commit**: `feat(native-rd/i18n): add sync.ts CLI — namespace walker + gap-only writer` (570fa23)
 
 **Changes**:
 
-- [ ] Load `.env.local` from `<appDir>/.env.local` using `node:fs` + split-on-newline dotenv parse (same guard as `llmGateway.ts`: throw if `OPENROUTER_API_KEY` absent before any LLM call). Use `import.meta.dir` to anchor the app root (same pattern as `lintSource.cli.ts`).
-- [ ] Parse CLI flags with `process.argv` slice (no third-party arg parser — consistent with existing scripts that use manual `process.argv` slicing):
+- [x] Load `.env.local` from `<appDir>/.env.local` using `node:fs` + split-on-newline dotenv parse. `llmGateway.ts` already guards `OPENROUTER_API_KEY` at call time, so no extra guard in `sync.cli.ts`. Uses `import.meta.dir` to anchor app root.
+- [x] Parse CLI flags with `process.argv` slice (`parseArgs` in `syncCore.ts`):
   - `--namespace <name>` — scope to one namespace; error on unknown name
   - `--dry-run` — skip disk writes, still call LLM
   - `--target <locale>` — default `de`; reject anything else with non-zero exit
   - `--model <name>` — default `claude-haiku-4-5`
-- [ ] Build namespace list: `readdirSync(<enDir>)` filtering `*.json`, strip `.json` extension → 15 names. If `--namespace` given, validate it is in this list.
-- [ ] Validate `--target`: only `"de"` accepted; print `"unsupported locale: <value>. Supported: de"` to stderr and `process.exit(1)`.
-- [ ] For each namespace in scope:
+- [x] Build namespace list: `discoverNamespaces` (delegates to `lintSource`) — strips `.json` extension. `--namespace` validated via `resolveNamespaces`.
+- [x] Validate `--target`: `isSupportedTarget` typeguard against the `SUPPORTED_TARGETS` allowlist (currently `["de"]`); exits 1 with clear error otherwise.
+- [x] For each namespace in scope (`syncOneNamespace`):
   - Read `en/<ns>.json` → `JSON.parse`
   - Read `de/<ns>.json` → `JSON.parse` (treat missing file as `{}`)
-  - Read `src/i18n/resources/_register/<ns>.yml` → string (missing register = throw with namespace name)
+  - **Idempotency short-circuit**: if `translatableSubtree(en, de).pathMap.keys.length === 0`, return `{ kind: "no-gaps" }` _before_ touching the register or the LLM
+  - Read `src/i18n/resources/_register/<ns>.yml` → string (missing register = throw with namespace name + PR #8 reference)
   - Call `translateNamespace({ enTree, deTree, ns, modelName, registerText })`
-  - If `--dry-run`, skip write; otherwise `writeFileSync` with `JSON.stringify(result, null, 2) + "\n"` (preserves key order from `mergeTranslations` which inherits source key order via `deepFillMissingStrings`)
-  - Catch errors per-namespace: print `"[sync] namespace <ns>: <message>"` to stderr, set exit code to 1 (accumulate failures — don't abort on first; write completed namespaces before exiting)
-- [ ] Exit 0 if all namespaces succeeded; exit 1 if any failed.
-- [ ] Add to `package.json` scripts: `"i18n:sync": "bun run scripts/i18n/sync.ts"`
+  - If `--dry-run`, skip write → `{ kind: "dry-run" }`
+  - Otherwise `writeFileSync` with `JSON.stringify(result, null, 2) + "\n"` → `{ kind: "wrote" }`
+  - Catch errors per-namespace: returns `{ kind: "failed", message }` (never throws from `syncOneNamespace`)
+- [x] `runSync` accumulates outcomes; exits 0 iff `outcomes.every(o => o.kind !== "failed")`.
+- [x] Empty namespace list (e.g. en/ exists but no `.json` files) exits 1 with clear error (review-pass addition).
+- [x] Outer `main().catch` preserves stack trace alongside the message (review-pass addition).
+- [x] Add to `package.json` scripts: `"i18n:sync": "bun run scripts/i18n/sync.cli.ts"`
 
 **Key order note**: `JSON.stringify` preserves insertion order of object keys. `mergeTranslations` (in `jsonTreeUtils.ts`) builds the result via `deepFillMissingStrings` which iterates `Object.entries(source)` first, then appends extra target keys — this naturally preserves `en/` key order in the output. No additional sorting needed.
 
@@ -87,39 +95,38 @@ Ship `apps/native-rd/scripts/i18n/sync.ts` — the Bun CLI entry point that orch
 
 **Files**:
 
-- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` (new, ~150 LOC)
+- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` (new, 380 LOC after review-pass additions)
 
-**Commit**: `test(native-rd/i18n): integration test for sync.ts — idempotency, gap-only, placeholder mismatch, key order`
+**Commits**: `test(native-rd/i18n): integration test for sync — idempotency, gap-only, placeholders, key order` (90c9ca6) + `test(native-rd/i18n): cover discoverNamespaces + idempotency-without-register` (7386796)
 
 **Changes**:
 
-- [ ] `jest.mock("../llmGateway", () => ({ callModel: jest.fn() }))` — same pattern as `translator.test.ts`
-- [ ] `jest.mock("node:fs", ...)` — spy on `writeFileSync` to capture writes without touching disk. Also spy on `readFileSync` to return fixture data.
-- [ ] Fixture: a two-namespace mini-tree:
-  - `en/alpha.json`: `{ "greet": "Hello", "farewell": "Goodbye {{name}}" }`
-  - `en/beta.json`: `{ "save": "Save" }`
-  - `de/alpha.json`: `{}` (initially empty)
-  - `de/beta.json`: `{}` (initially empty)
-  - `_register/alpha.yml` + `_register/beta.yml`: minimal YAML stubs matching `RegisterData` shape
-- [ ] Test: **idempotency** — pre-fill `de/alpha.json` with `{ "greet": "Hallo", "farewell": "Auf Wiedersehen {{name}}" }`. Mock `callModel` to throw if called. Run sync on `alpha`. Assert `writeFileSync` not called; `callModel` not called.
-- [ ] Test: **gap-only** — pre-fill `de/alpha.json` with `{ "greet": "Hallo" }` (one key present). Mock `callModel` to return `JSON.stringify({ k0: "Auf Wiedersehen {{name}}" })`. Run sync on `alpha`. Assert written output contains `"greet": "Hallo"` (preserved) and `"farewell": "Auf Wiedersehen {{name}}"` (filled).
-- [ ] Test: **placeholder mismatch exits non-zero** — pre-fill `de/alpha.json` as `{}`. Mock `callModel` to return `JSON.stringify({ k0: "Hallo", k1: "Auf Wiedersehen" })` (drops `{{name}}`). Run sync on `alpha`. Assert `process.exitCode` is 1 (or `process.exit` was called with 1); assert `writeFileSync` not called for `alpha`.
-- [ ] Test: **key order preserved** — `en/beta.json` has keys `{ z: "Z", a: "A", m: "M" }`. Mock `callModel` to return keys in same order (`{ k0: "Z_de", k1: "A_de", k2: "M_de" }`). Assert written JSON string has `z` before `a` before `m`.
-- [ ] Test: **`--namespace` unknown name** — call with `--namespace nonexistent`. Assert exits 1 with error message containing "nonexistent".
-- [ ] Test: **`--target fr` unsupported** — call with `--target fr`. Assert exits 1 with message containing "unsupported locale".
-- [ ] Test: **`--dry-run`** — call with `--dry-run`. Mock `callModel` to return valid translations. Assert `callModel` was called (LLM still invoked), `writeFileSync` never called.
+- [x] `jest.mock("../llmGateway", () => ({ callModel: jest.fn() }))` — same pattern as `translator.test.ts`.
+- [x] tmpdir fixture via `mkdtempSync(join(tmpdir(), "sync-test-"))` per test; `afterEach` cleans up via `rmSync`. (Replaced the original "mock `node:fs`" plan — see D5.)
+- [x] `parseArgs` tests: defaults, every supported flag, unknown-flag rejection, missing-value rejection.
+- [x] `isSupportedTarget` tests: `de` only; `fr`/empty rejected.
+- [x] `resolveNamespaces` tests: all/singleton/unknown.
+- [x] `discoverNamespaces` test: sorted bare names, excludes `.intents.json` sidecars (review-pass addition — pins AC #1).
+- [x] **Idempotency** — pre-fill de tree with full coverage. Assert `kind === "no-gaps"`, no LLM call, byte-equal file.
+- [x] **Idempotency short-circuits before register read** (review-pass addition) — no-gaps namespace succeeds even when its register YAML is absent. Pins the documented gap-check-before-register-read ordering.
+- [x] **Gap-only** — pre-fill de with one of two keys. Assert preserved + filled.
+- [x] **Placeholder mismatch** — LLM drops `{{name}}`. Assert `kind === "failed"`, message matches `/placeholder mismatch.*missing=\[name\]/`, file unwritten.
+- [x] **Key order preserved** — en has `{ z, a, m }`. Mocked LLM returns same order. String-position assertions (`indexOf`) — `toEqual` would not catch reorderings.
+- [x] **--dry-run** — LLM still called, file bytes unchanged.
+- [x] **Missing register → per-namespace failure** — message matches `/register file not found.*alpha/`, no LLM call.
+- [x] **Sibling namespaces not aborted by a failed peer** — alpha fails, beta succeeds, both outcomes captured.
 
-**Note on testing `sync.ts` as a module**: Because `sync.ts` uses `import.meta` (for path anchoring), it cannot be `require()`'d by Jest's Node/babel-jest pipeline directly. The integration test instead imports the sync pipeline's constituent functions (`translateNamespace` from `translator.ts` + the file-walking logic) and tests at that boundary — or invokes `sync.ts` with `spyOn(process, 'exit')` and mocked `fs` to simulate the CLI contract. The exact approach (import-core-logic vs. full-module-invoke) is the open question Q2 below.
+**Note on testing `sync.cli.ts` directly**: Because it owns `import.meta.dir`, it is not imported by the test. Q2 resolution: extract `syncCore.ts` and test there. `sync.cli.ts` is exercised only via manual smoke (see Testing Strategy below).
 
 ## Testing Strategy
 
-- [ ] Unit tests: covered by the integration test in Step 2 (no separate unit tests for sync.ts — it is thin orchestration glue)
-- [ ] Test file: `scripts/i18n/__tests__/sync.test.ts` (mirrors scripts path under `__tests__/`)
-- [ ] jest config: `jest.config.js` already includes `"**/scripts/**/__tests__/**/*.test.ts"` — no config change needed
-- [ ] `tsconfig.scripts-test.json` already has `"types": ["jest", "bun"]` — no change needed
-- [ ] `tsconfig.scripts.json` already includes `scripts/**/*.ts` and excludes `__tests__/` — sync.ts covered automatically
-- [ ] Manual smoke test (requires `OPENROUTER_API_KEY` in `.env.local`): `bun run i18n:sync --namespace common --dry-run`
-- [ ] Manual smoke test (writes): `bun run i18n:sync --namespace welcome`
+- [x] Unit tests: covered by the integration test in Step 2 (no separate unit tests for `sync.cli.ts` — it is thin glue with `import.meta`).
+- [x] Test file: `scripts/i18n/__tests__/sync.test.ts` — 17 tests, all passing.
+- [x] jest config: `jest.config.js` already includes `"**/scripts/**/__tests__/**/*.test.ts"` — no config change needed.
+- [x] `tsconfig.scripts-test.json` already has `"types": ["jest", "bun"]` — no change needed.
+- [x] `tsconfig.scripts.json` already includes `scripts/**/*.ts` and excludes `__tests__/` — both new files covered automatically.
+- [ ] Manual smoke test (requires `OPENROUTER_API_KEY` in `.env.local`): `bun run i18n:sync --namespace common --dry-run` — **deferred to merge-time human verification**.
+- [ ] Manual smoke test (writes): `bun run i18n:sync --namespace common` — **deferred**; only `common` will succeed today (the other 14 namespaces hard-fail on missing register YAMLs — PR #8 scope).
 
 ## Not in Scope
 
@@ -173,6 +180,9 @@ Open questions resolved before implementation:
 
 ## Discovery Log
 
-<!-- Entries added by implement skill:
-- [YYYY-MM-DD HH:MM] <discovery description>
--->
+- [2026-05-25 implement] D1 superseded: `import.meta.dir` doesn't survive babel-jest's transform, so the `syncCore` + `sync.cli` split (lintSource pattern) was required, not optional. Plan's original "single-file is fine" was wrong about jest's handling.
+- [2026-05-25 implement] D5 superseded: rather than `jest.mock("node:fs", ...)`, used `mkdtempSync` + real fs against a tmpdir. Lets the key-order test do a byte-level `indexOf` assertion that a mock would not have captured. Per-test setup is sub-ms.
+- [2026-05-25 simplify-pass] D8 added: `discoverNamespaces` in `syncCore.ts` was duplicated from `lintSource.ts`. Three simplify agents flagged it as the only material dup in the diff. Resolved by delegating to lintSource's version and stripping `.json` at this layer. Also imported `EN_DIR_REL` from lintSource to avoid hard-coding `"src/i18n/resources/en"` twice. Note: `generate-pseudo-locale.ts` has a third copy of the same readdir+filter — out of scope here, worth folding into the shared module if a follow-up touches that file.
+- [2026-05-25 review-pass] Two critical test gaps (gap rating 8) added: a direct `discoverNamespaces` test (pins the `.intents.json` exclusion) and a "no-gaps short-circuits before register read" test (pins the ordering inside `syncOneNamespace`). Both would only have surfaced as silent regressions otherwise.
+- [2026-05-25 review-pass] Two small `sync.cli.ts` hardenings landed: outer `main().catch` preserves stack trace; empty namespace-list exits 1 with a clear error rather than silent exit 0.
+- [2026-05-25 review-pass] Non-critical findings deliberately deferred (PR description lists them): `loadDotEnvLocal` malformed-line silence, shadowed-key silence, post-loop-only outcome logging, missing `formatOutcome` direct test.

--- a/apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md
@@ -11,7 +11,7 @@
 
 Observable criteria derived from the issue. These describe what success looks like from a user/system perspective.
 
-- [x] Running `bun run i18n:sync` with no flags walks all 15 namespaces in `src/i18n/resources/en/` and writes translated content to `src/i18n/resources/de/<ns>.json` for each namespace that has gaps. _(14/15 will hard-fail today on missing register YAMLs — PR #8 scope; CLI itself is correct.)_
+- [x] Running `bun run i18n:sync` with no flags walks all 15 namespaces in `src/i18n/resources/en/` and writes translated content to `src/i18n/resources/de/<ns>.json` for each namespace that has gaps. _(14/15 will hard-fail today on missing register YAMLs — wave 8 scope; CLI itself is correct.)_
 - [x] Running `bun run i18n:sync --namespace common` translates only `common.json`; passing `--namespace nonexistent` exits non-zero with a clear error naming the unknown namespace.
 - [x] Running `bun run i18n:sync --dry-run` calls `translateNamespace` (calls the LLM) but does not write any file to disk; the `de/` files remain unchanged.
 - [x] Running `bun run i18n:sync --target fr` exits non-zero with a clear error naming `fr` as unsupported; `--target de` succeeds.
@@ -79,7 +79,7 @@ Ship `apps/native-rd/scripts/i18n/sync.ts` — the Bun CLI entry point that orch
   - Read `en/<ns>.json` → `JSON.parse`
   - Read `de/<ns>.json` → `JSON.parse` (treat missing file as `{}`)
   - **Idempotency short-circuit**: if `translatableSubtree(en, de).pathMap.keys.length === 0`, return `{ kind: "no-gaps" }` _before_ touching the register or the LLM
-  - Read `src/i18n/resources/_register/<ns>.yml` → string (missing register = throw with namespace name + PR #8 reference)
+  - Read `src/i18n/resources/_register/<ns>.yml` → string (missing register = throw with namespace name + pointer to `apps/native-rd/docs/plans/i18n-llm-sync.md`)
   - Call `translateNamespace({ enTree, deTree, ns, modelName, registerText })`
   - If `--dry-run`, skip write → `{ kind: "dry-run" }`
   - Otherwise `writeFileSync` with `JSON.stringify(result, null, 2) + "\n"` → `{ kind: "wrote" }`
@@ -126,18 +126,18 @@ Ship `apps/native-rd/scripts/i18n/sync.ts` — the Bun CLI entry point that orch
 - [x] `tsconfig.scripts-test.json` already has `"types": ["jest", "bun"]` — no change needed.
 - [x] `tsconfig.scripts.json` already includes `scripts/**/*.ts` and excludes `__tests__/` — both new files covered automatically.
 - [ ] Manual smoke test (requires `OPENROUTER_API_KEY` in `.env.local`): `bun run i18n:sync --namespace common --dry-run` — **deferred to merge-time human verification**.
-- [ ] Manual smoke test (writes): `bun run i18n:sync --namespace common` — **deferred**; only `common` will succeed today (the other 14 namespaces hard-fail on missing register YAMLs — PR #8 scope).
+- [ ] Manual smoke test (writes): `bun run i18n:sync --namespace common` — **deferred**; only `common` will succeed today (the other 14 namespaces hard-fail on missing register YAMLs — wave 8 scope).
 
 ## Not in Scope
 
-| Item                                                | Reason                                                                                                                                                      | Follow-up                                            |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Register YAMLs for all 15 namespaces                | Only `common.yml` exists today; sync hard-fails on missing register — the remaining 14 must be authored. Authoring voice register content is PR #8's scope. | Issue for PR #8                                      |
-| `--target fr` support                               | Locked to `de` only for v1                                                                                                                                  | None (design doc notes fr as near-trivial add later) |
-| Concurrent batching (parallel namespace processing) | Locked decision #5 in i18n-llm-sync.md: single-threaded for v1                                                                                              | Post-v1                                              |
-| CI workflow invocation (`i18n-sync.yml`)            | PR #9's scope                                                                                                                                               | Issue for PR #9                                      |
-| Sidecar intent loader (`en/*.intents.json`)         | PR #8's scope; `translateNamespace` already accepts `intents` param, sync.ts passes `undefined` for now                                                     | Issue for PR #8                                      |
-| Glossary loading                                    | PR #8's scope                                                                                                                                               | Issue for PR #8                                      |
+| Item                                                | Reason                                                                                                                                                       | Follow-up                                            |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| Register YAMLs for all 15 namespaces                | Only `common.yml` exists today; sync hard-fails on missing register — the remaining 14 must be authored. Authoring voice register content is wave 8's scope. | Issue for wave 8                                     |
+| `--target fr` support                               | Locked to `de` only for v1                                                                                                                                   | None (design doc notes fr as near-trivial add later) |
+| Concurrent batching (parallel namespace processing) | Locked decision #5 in i18n-llm-sync.md: single-threaded for v1                                                                                               | Post-v1                                              |
+| CI workflow invocation (`i18n-sync.yml`)            | wave 9's scope                                                                                                                                               | Issue for wave 9                                     |
+| Sidecar intent loader (`en/*.intents.json`)         | wave 8's scope; `translateNamespace` already accepts `intents` param, sync.ts passes `undefined` for now                                                     | Issue for wave 8                                     |
+| Glossary loading                                    | wave 8's scope                                                                                                                                               | Issue for wave 8                                     |
 
 ## Open Questions — Joe to answer before implementation
 
@@ -165,10 +165,10 @@ The lintSource pattern (Option A / extract) is already proven in this codebase a
 Only `common.yml` exists in `src/i18n/resources/_register/`. Per Decision D3, a missing register is a hard error. This means `bun run i18n:sync` (all 15 namespaces) will fail for 14 of them until those files exist. Three options:
 
 - **Option A**: Stub the 14 missing registers with the same minimal content as `common.yml` in this PR so the CLI is immediately runnable.
-- **Option B**: The sync.ts hard-fails on missing register and prints a clear error per namespace; PR #8 authors the real register content. `bun run i18n:sync --namespace common` works immediately; full-sweep is gated on PR #8.
-- **Option C**: `--namespace` required if registers are missing; default "all 15" only works after PR #8 lands.
+- **Option B**: The sync.ts hard-fails on missing register and prints a clear error per namespace; wave 8 authors the real register content. `bun run i18n:sync --namespace common` works immediately; full-sweep is gated on wave 8.
+- **Option C**: `--namespace` required if registers are missing; default "all 15" only works after wave 8 lands.
 
-Option A (stub all registers now with placeholder content) makes the CLI immediately runnable for full-sweep smoke tests while making it clear the register content is a stub. Option B is cleaner but means the CLI is only useful for `--namespace common` until PR #8 lands.
+Option A (stub all registers now with placeholder content) makes the CLI immediately runnable for full-sweep smoke tests while making it clear the register content is a stub. Option B is cleaner but means the CLI is only useful for `--namespace common` until wave 8 lands.
 
 ## Resolutions (autonomous mode, 2026-05-25)
 
@@ -176,7 +176,7 @@ Open questions resolved before implementation:
 
 - **Q1 → Option A (inline `.env.local`)**: `sync.cli.ts` loads `.env.local` inline via `node:fs` + manual parse. CI injects secrets via env directly; no bash wrapper needed.
 - **Q2 → Option A (split: `syncCore.ts` + `sync.cli.ts`)**: Proven pattern in this codebase (`lintSource.ts` / `lintSource.cli.ts`). Overrides D1 — splitting is required to make the integration test importable without `import.meta` transform headaches. `syncCore.ts` exports pure functions taking absolute paths; `sync.cli.ts` is the thin CLI wrapper that owns `import.meta.dir` + arg parsing.
-- **Q3 → Option B (hard-fail on missing register)**: Authoring real register YAMLs is PR #8's scope. `bun run i18n:sync --namespace common` works end-to-end now; full-sweep is gated on PR #8. The integration test uses fixture registers so test coverage is unaffected. Each missing register produces a clear per-namespace error before exiting non-zero.
+- **Q3 → Option B (hard-fail on missing register)**: Authoring real register YAMLs is wave 8's scope. `bun run i18n:sync --namespace common` works end-to-end now; full-sweep is gated on wave 8. The integration test uses fixture registers so test coverage is unaffected. Each missing register produces a clear per-namespace error before exiting non-zero.
 
 ## Discovery Log
 

--- a/apps/native-rd/package.json
+++ b/apps/native-rd/package.json
@@ -37,7 +37,8 @@
     "release-notes:generate": "bun run scripts/release-notes-generate.ts",
     "release-notes:split": "bun run scripts/release-notes-split.ts",
     "i18n:lint-source": "bun run scripts/i18n/lintSource.cli.ts",
-    "i18n:bakeoff": "bash scripts/i18n/run-bakeoff.sh"
+    "i18n:bakeoff": "bash scripts/i18n/run-bakeoff.sh",
+    "i18n:sync": "bun run scripts/i18n/sync.cli.ts"
   },
   "dependencies": {
     "@evolu/common": "^7.4.1",

--- a/apps/native-rd/scripts/i18n/__tests__/responseParser.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/responseParser.test.ts
@@ -1,4 +1,8 @@
-import { parseAndValidate, type ParseError } from "../responseParser";
+import {
+  parseAndValidate,
+  stripFencedCode,
+  type ParseError,
+} from "../responseParser";
 
 describe("parseAndValidate — ok cases", () => {
   test("valid response object matching expectedKeys → ok with typed dict", () => {
@@ -13,6 +17,65 @@ describe("parseAndValidate — ok cases", () => {
 
   test("empty expectedKeys with empty response → ok (empty-batch edge)", () => {
     expect(parseAndValidate({}, [])).toEqual({ ok: true, data: {} });
+  });
+
+  test("JSON wrapped in ```json fence parses successfully (Anthropic Haiku default)", () => {
+    const raw = '```json\n{"k0":"Hallo","k1":"Welt"}\n```';
+    expect(parseAndValidate(raw, ["k0", "k1"])).toEqual({
+      ok: true,
+      data: { k0: "Hallo", k1: "Welt" },
+    });
+  });
+
+  test("JSON wrapped in untagged ``` fence parses successfully", () => {
+    const raw = '```\n{"k0":"Hallo"}\n```';
+    expect(parseAndValidate(raw, ["k0"])).toEqual({
+      ok: true,
+      data: { k0: "Hallo" },
+    });
+  });
+
+  test("JSON wrapped in ~~~ fence parses successfully", () => {
+    const raw = '~~~json\n{"k0":"Hallo"}\n~~~';
+    expect(parseAndValidate(raw, ["k0"])).toEqual({
+      ok: true,
+      data: { k0: "Hallo" },
+    });
+  });
+
+  test("fenced JSON with surrounding whitespace parses", () => {
+    const raw = '\n\n  ```json\n{"k0":"Hallo"}\n```  \n';
+    expect(parseAndValidate(raw, ["k0"])).toEqual({
+      ok: true,
+      data: { k0: "Hallo" },
+    });
+  });
+});
+
+describe("stripFencedCode", () => {
+  test("strips ```json fence", () => {
+    expect(stripFencedCode('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  test("strips untagged ``` fence", () => {
+    expect(stripFencedCode('```\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  test("strips ~~~ fence", () => {
+    expect(stripFencedCode('~~~\n{"a":1}\n~~~')).toBe('{"a":1}');
+  });
+
+  test("returns input unchanged when no fence", () => {
+    expect(stripFencedCode('{"a":1}')).toBe('{"a":1}');
+  });
+
+  test("does not strip mismatched fence delimiters", () => {
+    // ``` opening with ~~~ closing must NOT be treated as a single fence
+    expect(stripFencedCode('```\n{"a":1}\n~~~')).toBe('```\n{"a":1}\n~~~');
+  });
+
+  test("does not strip a single backtick that looks like a fence prefix", () => {
+    expect(stripFencedCode('`{"a":1}`')).toBe('`{"a":1}`');
   });
 });
 

--- a/apps/native-rd/scripts/i18n/__tests__/sync.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/sync.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { callModel } from "../llmGateway";
 import {
   SUPPORTED_TARGETS,
+  discoverNamespaces,
   isSupportedTarget,
   parseArgs,
   resolveNamespaces,
@@ -119,6 +120,19 @@ describe("target validation", () => {
   });
 });
 
+describe("discoverNamespaces", () => {
+  test("returns sorted bare names, excludes .intents.json sidecars", () => {
+    writeJson(fixture.enPath("welcome"), {});
+    writeJson(fixture.enPath("common"), {});
+    // intents sidecar must not be discovered as a namespace
+    writeFileSync(join(fixture.paths.enDir, "common.intents.json"), "{}");
+    expect(discoverNamespaces(fixture.paths.enDir)).toEqual([
+      "common",
+      "welcome",
+    ]);
+  });
+});
+
 describe("resolveNamespaces", () => {
   test("returns all when requested is undefined", () => {
     expect(resolveNamespaces(["common", "welcome"], undefined)).toEqual([
@@ -167,6 +181,26 @@ describe("runSync — idempotency", () => {
     expect(readFileSync(fixture.targetPath("alpha"), "utf8")).toBe(
       `${JSON.stringify({ greet: "Hallo", farewell: "Auf Wiedersehen {{name}}" }, null, 2)}\n`,
     );
+  });
+});
+
+describe("runSync — idempotency short-circuits before register read", () => {
+  test("no-gaps namespace succeeds even when its register file is absent", async () => {
+    writeJson(fixture.enPath("alpha"), { greet: "Hello" });
+    writeJson(fixture.targetPath("alpha"), { greet: "Hallo" });
+    // intentionally NO writeRegister — if the gap check moved below
+    // readRegisterText, this would fail with "register file not found".
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    expect(summary.hasFailures).toBe(false);
+    expect(summary.outcomes[0]).toEqual({ kind: "no-gaps", ns: "alpha" });
+    expect(mockCallModel).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/native-rd/scripts/i18n/__tests__/sync.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/sync.test.ts
@@ -109,6 +109,21 @@ describe("parseArgs", () => {
       /--namespace requires a value/,
     );
   });
+
+  test("flag followed by another flag throws — must not consume the next flag as a value", () => {
+    // Without this guard, `--model --dry-run --namespace common` would bind
+    // modelName="--dry-run" and leave dryRun=false, turning an intended
+    // dry-run into a real write.
+    expect(() =>
+      parseArgs(["--model", "--dry-run", "--namespace", "common"]),
+    ).toThrow(/--model requires a value/);
+    expect(() => parseArgs(["--target", "--dry-run"])).toThrow(
+      /--target requires a value/,
+    );
+    expect(() => parseArgs(["--namespace", "--dry-run"])).toThrow(
+      /--namespace requires a value/,
+    );
+  });
 });
 
 describe("target validation", () => {

--- a/apps/native-rd/scripts/i18n/__tests__/sync.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/sync.test.ts
@@ -1,0 +1,333 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { callModel } from "../llmGateway";
+import {
+  SUPPORTED_TARGETS,
+  isSupportedTarget,
+  parseArgs,
+  resolveNamespaces,
+  runSync,
+  type SyncPaths,
+} from "../syncCore";
+
+jest.mock("../llmGateway", () => ({
+  callModel: jest.fn(),
+}));
+
+const mockCallModel = callModel as jest.MockedFunction<typeof callModel>;
+
+const STUB_REGISTER = `
+speaker: app
+audience: neurodivergent-adults
+formality: informal
+banned_phrasings: []
+`.trim();
+
+type Fixture = {
+  paths: SyncPaths;
+  enPath: (ns: string) => string;
+  targetPath: (ns: string) => string;
+  cleanup: () => void;
+};
+
+function makeFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "sync-test-"));
+  const enDir = join(root, "en");
+  const targetDir = join(root, "de");
+  const registerDir = join(root, "_register");
+  mkdirSync(enDir);
+  mkdirSync(targetDir);
+  mkdirSync(registerDir);
+  return {
+    paths: { enDir, targetDir, registerDir },
+    enPath: (ns) => join(enDir, `${ns}.json`),
+    targetPath: (ns) => join(targetDir, `${ns}.json`),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeRegister(fixture: Fixture, ns: string): void {
+  writeFileSync(join(fixture.paths.registerDir, `${ns}.yml`), STUB_REGISTER);
+}
+
+let fixture: Fixture;
+
+beforeEach(() => {
+  fixture = makeFixture();
+  mockCallModel.mockReset();
+});
+
+afterEach(() => {
+  fixture.cleanup();
+});
+
+describe("parseArgs", () => {
+  test("defaults: no flags → all-namespaces, target=de, model=claude-haiku-4-5", () => {
+    const args = parseArgs([]);
+    expect(args.namespace).toBeUndefined();
+    expect(args.dryRun).toBe(false);
+    expect(args.target).toBe("de");
+    expect(args.modelName).toBe("claude-haiku-4-5");
+  });
+
+  test("parses every supported flag", () => {
+    const args = parseArgs([
+      "--namespace",
+      "common",
+      "--dry-run",
+      "--target",
+      "fr",
+      "--model",
+      "gpt-4o-mini",
+    ]);
+    expect(args.namespace).toBe("common");
+    expect(args.dryRun).toBe(true);
+    expect(args.target).toBe("fr");
+    expect(args.modelName).toBe("gpt-4o-mini");
+  });
+
+  test("unknown flag throws — typo is a hard error, not a silent default", () => {
+    expect(() => parseArgs(["--namspace", "common"])).toThrow(/unknown flag/);
+  });
+
+  test("--namespace without a value throws", () => {
+    expect(() => parseArgs(["--namespace"])).toThrow(
+      /--namespace requires a value/,
+    );
+  });
+});
+
+describe("target validation", () => {
+  test("only de is supported in v1", () => {
+    expect(SUPPORTED_TARGETS).toEqual(["de"]);
+    expect(isSupportedTarget("de")).toBe(true);
+    expect(isSupportedTarget("fr")).toBe(false);
+    expect(isSupportedTarget("")).toBe(false);
+  });
+});
+
+describe("resolveNamespaces", () => {
+  test("returns all when requested is undefined", () => {
+    expect(resolveNamespaces(["common", "welcome"], undefined)).toEqual([
+      "common",
+      "welcome",
+    ]);
+  });
+
+  test("returns the singleton when requested is in available", () => {
+    expect(resolveNamespaces(["common", "welcome"], "common")).toEqual([
+      "common",
+    ]);
+  });
+
+  test("throws on unknown namespace, listing available options", () => {
+    expect(() => resolveNamespaces(["common", "welcome"], "nope")).toThrow(
+      /unknown namespace: nope.*Available: common, welcome/,
+    );
+  });
+});
+
+describe("runSync — idempotency", () => {
+  test("no-op when target already covers every source leaf", async () => {
+    writeJson(fixture.enPath("alpha"), {
+      greet: "Hello",
+      farewell: "Goodbye {{name}}",
+    });
+    writeJson(fixture.targetPath("alpha"), {
+      greet: "Hallo",
+      farewell: "Auf Wiedersehen {{name}}",
+    });
+    writeRegister(fixture, "alpha");
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    expect(summary.hasFailures).toBe(false);
+    expect(summary.outcomes[0]).toEqual({ kind: "no-gaps", ns: "alpha" });
+    expect(mockCallModel).not.toHaveBeenCalled();
+
+    // Target file untouched: byte-equal to what we wrote.
+    expect(readFileSync(fixture.targetPath("alpha"), "utf8")).toBe(
+      `${JSON.stringify({ greet: "Hallo", farewell: "Auf Wiedersehen {{name}}" }, null, 2)}\n`,
+    );
+  });
+});
+
+describe("runSync — gap-only", () => {
+  test("preserves existing target values verbatim, fills only missing keys", async () => {
+    writeJson(fixture.enPath("alpha"), {
+      greet: "Hello",
+      farewell: "Goodbye {{name}}",
+    });
+    writeJson(fixture.targetPath("alpha"), { greet: "Hallo" });
+    writeRegister(fixture, "alpha");
+
+    mockCallModel.mockResolvedValueOnce(
+      JSON.stringify({ k0: "Auf Wiedersehen {{name}}" }),
+    );
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    expect(summary.hasFailures).toBe(false);
+    expect(summary.outcomes[0].kind).toBe("wrote");
+
+    const written = JSON.parse(
+      readFileSync(fixture.targetPath("alpha"), "utf8"),
+    );
+    expect(written).toEqual({
+      greet: "Hallo",
+      farewell: "Auf Wiedersehen {{name}}",
+    });
+    expect(mockCallModel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runSync — placeholder mismatch", () => {
+  test("failure outcome, no write, exit-code-mapping sets hasFailures", async () => {
+    writeJson(fixture.enPath("alpha"), { welcome: "Hello {{name}}!" });
+    writeJson(fixture.targetPath("alpha"), {});
+    writeRegister(fixture, "alpha");
+
+    mockCallModel.mockResolvedValueOnce(JSON.stringify({ k0: "Hallo!" }));
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    expect(summary.hasFailures).toBe(true);
+    const outcome = summary.outcomes[0];
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.message).toMatch(/placeholder mismatch.*missing=\[name\]/);
+
+    // Target file must not have been written — it still contains the
+    // pre-sync empty object we wrote ourselves.
+    expect(
+      JSON.parse(readFileSync(fixture.targetPath("alpha"), "utf8")),
+    ).toEqual({});
+  });
+});
+
+describe("runSync — key order", () => {
+  test("written JSON preserves the en/ source key order", async () => {
+    writeJson(fixture.enPath("beta"), { z: "Z", a: "A", m: "M" });
+    writeJson(fixture.targetPath("beta"), {});
+    writeRegister(fixture, "beta");
+
+    mockCallModel.mockResolvedValueOnce(
+      JSON.stringify({ k0: "Z_de", k1: "A_de", k2: "M_de" }),
+    );
+
+    await runSync({
+      paths: fixture.paths,
+      namespaces: ["beta"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    const writtenText = readFileSync(fixture.targetPath("beta"), "utf8");
+    // String-position assertions catch order regressions that an .toEqual
+    // would miss (object equality ignores key order).
+    const zIdx = writtenText.indexOf('"z"');
+    const aIdx = writtenText.indexOf('"a"');
+    const mIdx = writtenText.indexOf('"m"');
+    expect(zIdx).toBeGreaterThan(-1);
+    expect(zIdx).toBeLessThan(aIdx);
+    expect(aIdx).toBeLessThan(mIdx);
+  });
+});
+
+describe("runSync — dry-run", () => {
+  test("calls the LLM but writes nothing; target file content unchanged", async () => {
+    writeJson(fixture.enPath("alpha"), { greet: "Hello" });
+    writeJson(fixture.targetPath("alpha"), {});
+    writeRegister(fixture, "alpha");
+
+    const beforeBytes = readFileSync(fixture.targetPath("alpha"), "utf8");
+    mockCallModel.mockResolvedValueOnce(JSON.stringify({ k0: "Hallo" }));
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha"],
+      modelName: "claude-haiku-4-5",
+      dryRun: true,
+    });
+
+    expect(summary.hasFailures).toBe(false);
+    expect(summary.outcomes[0]).toEqual({ kind: "dry-run", ns: "alpha" });
+    expect(mockCallModel).toHaveBeenCalledTimes(1);
+    expect(readFileSync(fixture.targetPath("alpha"), "utf8")).toBe(beforeBytes);
+  });
+});
+
+describe("runSync — missing register hard-fails per namespace", () => {
+  test("absent register produces a failed outcome naming the namespace", async () => {
+    writeJson(fixture.enPath("alpha"), { greet: "Hello" });
+    writeJson(fixture.targetPath("alpha"), {});
+    // intentionally no writeRegister(fixture, "alpha")
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    expect(summary.hasFailures).toBe(true);
+    const outcome = summary.outcomes[0];
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.message).toMatch(/register file not found.*alpha/);
+    expect(mockCallModel).not.toHaveBeenCalled();
+  });
+
+  test("one namespace failing does not abort sibling namespaces", async () => {
+    // alpha has no register → fails. beta has a register → succeeds.
+    writeJson(fixture.enPath("alpha"), { greet: "Hello" });
+    writeJson(fixture.targetPath("alpha"), {});
+    writeJson(fixture.enPath("beta"), { save: "Save" });
+    writeJson(fixture.targetPath("beta"), {});
+    writeRegister(fixture, "beta");
+
+    mockCallModel.mockResolvedValueOnce(JSON.stringify({ k0: "Speichern" }));
+
+    const summary = await runSync({
+      paths: fixture.paths,
+      namespaces: ["alpha", "beta"],
+      modelName: "claude-haiku-4-5",
+      dryRun: false,
+    });
+
+    expect(summary.hasFailures).toBe(true);
+    expect(summary.outcomes.map((o) => o.kind)).toEqual(["failed", "wrote"]);
+    expect(existsSync(fixture.targetPath("beta"))).toBe(true);
+    expect(
+      JSON.parse(readFileSync(fixture.targetPath("beta"), "utf8")),
+    ).toEqual({ save: "Speichern" });
+  });
+});

--- a/apps/native-rd/scripts/i18n/promptBuilder.ts
+++ b/apps/native-rd/scripts/i18n/promptBuilder.ts
@@ -93,7 +93,7 @@ function formatGlossary(glossary: string): string {
  */
 export function buildSystemPrompt(input: PromptBuilderInput): string {
   const sections: string[] = [
-    "You translate UI strings from English to German. Preserve every `{{placeholder}}` token exactly. Return JSON with the same key set as the input.",
+    "You translate UI strings from English to German. Preserve every `{{placeholder}}` token exactly. Return JSON with the same key set as the input. Output raw JSON only — do not wrap the response in markdown code fences (no ```json, no ```).",
     formatRegister(input.register),
   ];
 

--- a/apps/native-rd/scripts/i18n/responseParser.ts
+++ b/apps/native-rd/scripts/i18n/responseParser.ts
@@ -33,9 +33,27 @@ export type ParseResult =
 export const llmResponseSchema = z.record(z.string(), z.string().min(1));
 
 /**
+ * Strip a single outer markdown code fence so models that wrap JSON in
+ * ```` ```json … ``` ```` (Anthropic Haiku's default for structured output,
+ * and a common default elsewhere) still parse. Untagged ``` and `~~~` work
+ * too. If the input is not fenced, returns it unchanged.
+ *
+ * Only the *outermost* fence is stripped. The body is whatever the model
+ * put inside it — if that body is still not valid JSON, we still surface
+ * malformed-json downstream.
+ */
+export function stripFencedCode(raw: string): string {
+  const trimmed = raw.trim();
+  const match = trimmed.match(
+    /^(```|~~~)(?:[a-zA-Z0-9_-]+)?\s*\n?([\s\S]*?)\n?\1\s*$/,
+  );
+  return match ? match[2].trim() : trimmed;
+}
+
+/**
  * Validate a raw LLM response (either a JSON string or pre-parsed value)
  * against `expectedKeys`. Returns the typed dict only when:
- *   - input parses as JSON (if a string)
+ *   - input parses as JSON (if a string; markdown code fences are stripped first)
  *   - shape is `Record<string, string>` with all values non-empty
  *   - key set matches `expectedKeys` exactly
  */
@@ -46,7 +64,7 @@ export function parseAndValidate(
   let parsed: unknown = raw;
   if (typeof raw === "string") {
     try {
-      parsed = JSON.parse(raw);
+      parsed = JSON.parse(stripFencedCode(raw));
     } catch (e) {
       return {
         ok: false,

--- a/apps/native-rd/scripts/i18n/sync.cli.ts
+++ b/apps/native-rd/scripts/i18n/sync.cli.ts
@@ -90,6 +90,11 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  if (namespaces.length === 0) {
+    console.error(`[sync] no namespaces found in ${enDir}`);
+    process.exit(1);
+  }
+
   const summary = await runSync({
     paths: { enDir, targetDir, registerDir },
     namespaces,
@@ -111,9 +116,14 @@ async function main(): Promise<void> {
 
 if (import.meta.main) {
   main().catch((e) => {
-    console.error(
-      `[sync] unexpected error: ${e instanceof Error ? e.message : String(e)}`,
-    );
+    // Preserve stack on unexpected errors — without it the operator gets
+    // a bare message ("EACCES" / "ENOENT") with no file:line to diagnose.
+    if (e instanceof Error) {
+      console.error(`[sync] unexpected error: ${e.message}`);
+      if (e.stack) console.error(e.stack);
+    } else {
+      console.error(`[sync] unexpected error: ${String(e)}`);
+    }
     process.exit(1);
   });
 }

--- a/apps/native-rd/scripts/i18n/sync.cli.ts
+++ b/apps/native-rd/scripts/i18n/sync.cli.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+/**
+ * CLI entrypoint for the i18n sync pipeline.
+ *
+ * Owns `import.meta.dir` path bootstrap + `.env.local` injection. All
+ * orchestration lives in `syncCore.ts` so jest can import it without the
+ * `import.meta` transform headache (same split as `lintSource.cli.ts`).
+ *
+ * Exit codes:
+ *   0 — every requested namespace succeeded (wrote, no-gaps, or dry-run)
+ *   1 — at least one namespace failed (parse, register, placeholder, etc.)
+ *       or argv / target validation failed
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  SUPPORTED_TARGETS,
+  discoverNamespaces,
+  formatOutcome,
+  isSupportedTarget,
+  parseArgs,
+  resolveNamespaces,
+  runSync,
+} from "./syncCore";
+
+/**
+ * Mirror the bash `set -a / source .env.local` pattern from `run-bakeoff.sh`
+ * inline so the package.json entry can stay `bun run scripts/i18n/sync.cli.ts`
+ * without a wrapper script. CI does not use `.env.local` — secrets are
+ * injected directly into the environment by the workflow runner — so the
+ * absence of the file is not an error.
+ *
+ * Existing `process.env` values win: real exported secrets are not clobbered
+ * by stale `.env.local` entries, matching bash `set -a` semantics for this
+ * use (which would overwrite — but in our flow CI runs without the file).
+ */
+function loadDotEnvLocal(envPath: string): void {
+  if (!existsSync(envPath)) return;
+  const raw = readFileSync(envPath, "utf8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const appDir = join(import.meta.dir, "..", "..");
+  loadDotEnvLocal(join(appDir, ".env.local"));
+
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    console.error(`[sync] ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
+
+  if (!isSupportedTarget(args.target)) {
+    console.error(
+      `[sync] unsupported locale: ${args.target}. Supported: ${SUPPORTED_TARGETS.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  const enDir = join(appDir, "src/i18n/resources/en");
+  const targetDir = join(appDir, "src/i18n/resources", args.target);
+  const registerDir = join(appDir, "src/i18n/resources/_register");
+
+  let namespaces: string[];
+  try {
+    namespaces = resolveNamespaces(discoverNamespaces(enDir), args.namespace);
+  } catch (e) {
+    console.error(`[sync] ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
+
+  const summary = await runSync({
+    paths: { enDir, targetDir, registerDir },
+    namespaces,
+    modelName: args.modelName,
+    dryRun: args.dryRun,
+  });
+
+  for (const outcome of summary.outcomes) {
+    const line = formatOutcome(outcome);
+    if (outcome.kind === "failed") {
+      console.error(line);
+    } else {
+      console.log(line);
+    }
+  }
+
+  process.exit(summary.hasFailures ? 1 : 0);
+}
+
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error(
+      `[sync] unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/apps/native-rd/scripts/i18n/sync.cli.ts
+++ b/apps/native-rd/scripts/i18n/sync.cli.ts
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { EN_DIR_REL } from "./lintSource";
 import {
   SUPPORTED_TARGETS,
   discoverNamespaces,
@@ -77,7 +78,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const enDir = join(appDir, "src/i18n/resources/en");
+  const enDir = join(appDir, EN_DIR_REL);
   const targetDir = join(appDir, "src/i18n/resources", args.target);
   const registerDir = join(appDir, "src/i18n/resources/_register");
 

--- a/apps/native-rd/scripts/i18n/syncCore.ts
+++ b/apps/native-rd/scripts/i18n/syncCore.ts
@@ -12,10 +12,11 @@
  * path observably free of network traffic.
  */
 
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { translatableSubtree, type JsonTree } from "./jsonTreeUtils";
+import { discoverNamespaces as discoverNamespaceFiles } from "./lintSource";
 import { translateNamespace } from "./translator";
 
 export const SUPPORTED_TARGETS = ["de"] as const;
@@ -58,29 +59,27 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   let target = "de";
   let modelName = DEFAULT_MODEL_NAME;
 
+  function requireValue(flag: string, value: string | undefined): string {
+    if (value === undefined || value === "") {
+      throw new Error(`${flag} requires a value`);
+    }
+    return value;
+  }
+
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
       case "--namespace":
-        namespace = argv[++i];
-        if (namespace === undefined) {
-          throw new Error("--namespace requires a value");
-        }
+        namespace = requireValue("--namespace", argv[++i]);
         break;
       case "--dry-run":
         dryRun = true;
         break;
       case "--target":
-        target = argv[++i] ?? "";
-        if (target === "") {
-          throw new Error("--target requires a value");
-        }
+        target = requireValue("--target", argv[++i]);
         break;
       case "--model":
-        modelName = argv[++i] ?? "";
-        if (modelName === "") {
-          throw new Error("--model requires a value");
-        }
+        modelName = requireValue("--model", argv[++i]);
         break;
       default:
         throw new Error(`unknown flag: ${arg}`);
@@ -95,10 +94,9 @@ export function isSupportedTarget(target: string): target is SupportedTarget {
 }
 
 export function discoverNamespaces(absEnDir: string): string[] {
-  return readdirSync(absEnDir)
-    .filter((f) => f.endsWith(".json") && !f.endsWith(".intents.json"))
-    .map((f) => f.slice(0, -".json".length))
-    .sort();
+  return discoverNamespaceFiles(absEnDir).map((f) =>
+    f.slice(0, -".json".length),
+  );
 }
 
 /**

--- a/apps/native-rd/scripts/i18n/syncCore.ts
+++ b/apps/native-rd/scripts/i18n/syncCore.ts
@@ -60,7 +60,10 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   let modelName = DEFAULT_MODEL_NAME;
 
   function requireValue(flag: string, value: string | undefined): string {
-    if (value === undefined || value === "") {
+    // Reject the next-flag token too — otherwise `--model --dry-run` would
+    // silently bind `--dry-run` as the model name and leave dryRun=false,
+    // turning an intended dry run into a write.
+    if (value === undefined || value === "" || value.startsWith("--")) {
       throw new Error(`${flag} requires a value`);
     }
     return value;

--- a/apps/native-rd/scripts/i18n/syncCore.ts
+++ b/apps/native-rd/scripts/i18n/syncCore.ts
@@ -1,0 +1,228 @@
+/**
+ * Pure orchestration for the en→target i18n sync pipeline.
+ *
+ * The CLI entrypoint (`sync.cli.ts`) anchors paths via `import.meta.dir` and
+ * forwards them here. Tests import `syncCore.ts` directly with absolute
+ * paths to a tmpdir fixture — the split keeps jest + babel-jest off the
+ * `import.meta` hazard (same pattern as `lintSource.ts`/`lintSource.cli.ts`).
+ *
+ * Idempotency lives in this module: a namespace whose target tree already
+ * covers every source-side string-leaf produces zero writes and zero LLM
+ * calls. Detection runs *before* `translateNamespace` to keep the no-op
+ * path observably free of network traffic.
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { translatableSubtree, type JsonTree } from "./jsonTreeUtils";
+import { translateNamespace } from "./translator";
+
+export const SUPPORTED_TARGETS = ["de"] as const;
+export type SupportedTarget = (typeof SUPPORTED_TARGETS)[number];
+
+export const DEFAULT_MODEL_NAME = "claude-haiku-4-5";
+
+export type SyncPaths = {
+  readonly enDir: string;
+  readonly targetDir: string;
+  readonly registerDir: string;
+};
+
+export type CliArgs = {
+  readonly namespace: string | undefined;
+  readonly dryRun: boolean;
+  readonly target: string;
+  readonly modelName: string;
+};
+
+export type NamespaceOutcome =
+  | { kind: "no-gaps"; ns: string }
+  | { kind: "wrote"; ns: string; path: string }
+  | { kind: "dry-run"; ns: string }
+  | { kind: "failed"; ns: string; message: string };
+
+export type SyncSummary = {
+  readonly outcomes: readonly NamespaceOutcome[];
+  readonly hasFailures: boolean;
+};
+
+/**
+ * Parse the subset of CLI flags the sync entrypoint needs. Unknown flags
+ * surface as a thrown error so a typo (`--namspace common`) does not
+ * silently fall back to defaults.
+ */
+export function parseArgs(argv: readonly string[]): CliArgs {
+  let namespace: string | undefined;
+  let dryRun = false;
+  let target = "de";
+  let modelName = DEFAULT_MODEL_NAME;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--namespace":
+        namespace = argv[++i];
+        if (namespace === undefined) {
+          throw new Error("--namespace requires a value");
+        }
+        break;
+      case "--dry-run":
+        dryRun = true;
+        break;
+      case "--target":
+        target = argv[++i] ?? "";
+        if (target === "") {
+          throw new Error("--target requires a value");
+        }
+        break;
+      case "--model":
+        modelName = argv[++i] ?? "";
+        if (modelName === "") {
+          throw new Error("--model requires a value");
+        }
+        break;
+      default:
+        throw new Error(`unknown flag: ${arg}`);
+    }
+  }
+
+  return { namespace, dryRun, target, modelName };
+}
+
+export function isSupportedTarget(target: string): target is SupportedTarget {
+  return (SUPPORTED_TARGETS as readonly string[]).includes(target);
+}
+
+export function discoverNamespaces(absEnDir: string): string[] {
+  return readdirSync(absEnDir)
+    .filter((f) => f.endsWith(".json") && !f.endsWith(".intents.json"))
+    .map((f) => f.slice(0, -".json".length))
+    .sort();
+}
+
+/**
+ * Resolve which namespaces to sync. If `requested` is given, validate it
+ * exists in `available` (fails fast on typos). Otherwise return all.
+ */
+export function resolveNamespaces(
+  available: readonly string[],
+  requested: string | undefined,
+): string[] {
+  if (requested === undefined) {
+    return [...available];
+  }
+  if (!available.includes(requested)) {
+    throw new Error(
+      `unknown namespace: ${requested}. Available: ${available.join(", ")}`,
+    );
+  }
+  return [requested];
+}
+
+function readJsonFile(absPath: string): unknown {
+  const raw = readFileSync(absPath, "utf8");
+  return JSON.parse(raw);
+}
+
+function readJsonFileOrEmpty(absPath: string): unknown {
+  if (!existsSync(absPath)) {
+    return {};
+  }
+  return readJsonFile(absPath);
+}
+
+function readRegisterText(absPath: string, ns: string): string {
+  if (!existsSync(absPath)) {
+    throw new Error(
+      `register file not found for namespace ${ns} at ${absPath} — see PR #8 (voice register authoring)`,
+    );
+  }
+  return readFileSync(absPath, "utf8");
+}
+
+/**
+ * Run the sync pipeline for a single namespace and return the outcome. Never
+ * throws — failures are returned as `{ kind: "failed", message }` so the
+ * caller can accumulate per-namespace errors and surface them together.
+ */
+export async function syncOneNamespace(opts: {
+  ns: string;
+  paths: SyncPaths;
+  modelName: string;
+  dryRun: boolean;
+}): Promise<NamespaceOutcome> {
+  const { ns, paths, modelName, dryRun } = opts;
+  try {
+    const enPath = join(paths.enDir, `${ns}.json`);
+    const targetPath = join(paths.targetDir, `${ns}.json`);
+    const registerPath = join(paths.registerDir, `${ns}.yml`);
+
+    const enTree = readJsonFile(enPath) as JsonTree;
+    const targetTree = readJsonFileOrEmpty(targetPath);
+
+    // Idempotency: bail before touching the register or the LLM if the
+    // target already covers every source leaf. translateNamespace performs
+    // the same check internally, but stopping here keeps `--dry-run` and
+    // the no-op path free of register I/O as well.
+    if (translatableSubtree(enTree, targetTree).pathMap.keys.length === 0) {
+      return { kind: "no-gaps", ns };
+    }
+
+    const registerText = readRegisterText(registerPath, ns);
+    const result = await translateNamespace({
+      enTree,
+      deTree: targetTree,
+      ns,
+      modelName,
+      registerText,
+    });
+
+    if (dryRun) {
+      return { kind: "dry-run", ns };
+    }
+
+    const content = `${JSON.stringify(result, null, 2)}\n`;
+    writeFileSync(targetPath, content, "utf8");
+    return { kind: "wrote", ns, path: targetPath };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { kind: "failed", ns, message };
+  }
+}
+
+export async function runSync(opts: {
+  paths: SyncPaths;
+  namespaces: readonly string[];
+  modelName: string;
+  dryRun: boolean;
+}): Promise<SyncSummary> {
+  const outcomes: NamespaceOutcome[] = [];
+  for (const ns of opts.namespaces) {
+    outcomes.push(
+      await syncOneNamespace({
+        ns,
+        paths: opts.paths,
+        modelName: opts.modelName,
+        dryRun: opts.dryRun,
+      }),
+    );
+  }
+  return {
+    outcomes,
+    hasFailures: outcomes.some((o) => o.kind === "failed"),
+  };
+}
+
+export function formatOutcome(o: NamespaceOutcome): string {
+  switch (o.kind) {
+    case "no-gaps":
+      return `[sync] ${o.ns}: no gaps`;
+    case "wrote":
+      return `[sync] ${o.ns}: wrote ${o.path}`;
+    case "dry-run":
+      return `[sync] ${o.ns}: dry-run (no write)`;
+    case "failed":
+      return `[sync] ${o.ns}: FAILED — ${o.message}`;
+  }
+}

--- a/apps/native-rd/scripts/i18n/syncCore.ts
+++ b/apps/native-rd/scripts/i18n/syncCore.ts
@@ -136,7 +136,7 @@ function readJsonFileOrEmpty(absPath: string): unknown {
 function readRegisterText(absPath: string, ns: string): string {
   if (!existsSync(absPath)) {
     throw new Error(
-      `register file not found for namespace ${ns} at ${absPath} — see PR #8 (voice register authoring)`,
+      `register file not found for namespace ${ns} at ${absPath} — voice register authoring is tracked in apps/native-rd/docs/plans/i18n-llm-sync.md`,
     );
   }
   return readFileSync(absPath, "utf8");


### PR DESCRIPTION
## Summary

- Adds the Bun CLI entry point that wires PR #5's `translateNamespace` into a runnable en→de sync (`bun run i18n:sync`).
- Walks all 15 namespaces by default; flags: `--namespace`, `--dry-run`, `--target` (de allowlist), `--model` (default `claude-haiku-4-5`).
- Gap-only + idempotent: a namespace with zero gaps short-circuits before touching the register or the LLM.

## Changes

- `apps/native-rd/scripts/i18n/syncCore.ts` (new) — pure orchestration: `parseArgs`, `discoverNamespaces` (delegates to `lintSource`), `resolveNamespaces`, `syncOneNamespace`, `runSync`, `formatOutcome`. No `import.meta`, so jest can import it directly.
- `apps/native-rd/scripts/i18n/sync.cli.ts` (new) — thin CLI wrapper: `import.meta.dir` path bootstrap, inline `.env.local` loader (CI uses env directly), exit-code mapping.
- `apps/native-rd/scripts/i18n/__tests__/sync.test.ts` (new) — 17 integration tests with tmpdir fixtures + mocked `llmGateway`, covering: idempotency, idempotency-without-register short-circuit, gap-only, placeholder mismatch, key-order preservation, dry-run, per-namespace failure isolation, `discoverNamespaces` filter.
- `apps/native-rd/package.json` — `"i18n:sync": "bun run scripts/i18n/sync.cli.ts"`.
- `apps/native-rd/docs/plans/dev-plans/issue-161-i18n-sync-cli.md` — dev plan.

## Intent Verification

- [x] Default walk of all 15 namespaces in `src/i18n/resources/en/`, writes to `src/i18n/resources/de/<ns>.json`.
- [x] `--namespace <name>` scopes to one ns; unknown name fails fast.
- [x] `--dry-run` calls `translateNamespace` (LLM still invoked) but skips writes.
- [x] `--target` accepts only `de` for v1; unsupported locale exits 1 with clear error.
- [x] Idempotency: re-running with no `en/` changes is a no-op on the second run (verified by integration test).
- [x] Gap-only: existing `de/` values preserved verbatim (verified by integration test).
- [x] Placeholder mismatch exits non-zero with a clear error naming the offending key; no partial file is written.
- [x] Output JSON preserves source key order (string-position assertion in test, not `toEqual`).
- [x] `bun run type-check` and `bun run lint` pass.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Split `syncCore.ts` + `sync.cli.ts` (overrides plan D1) | Matches the proven `lintSource.ts` / `lintSource.cli.ts` pattern. Keeps `import.meta.dir` out of jest's transform path so tests can import the orchestrator directly. |
| Inline `.env.local` loader in `sync.cli.ts` | CI injects secrets via env; no bash wrapper needed. Existing `process.env` values win (avoids stale `.env.local` clobbering exported secrets). |
| Missing register YAML = per-namespace hard-fail | Authoring real registers is PR #8's scope. The CLI fails per-namespace and accumulates errors, so a single missing register does not abort the batch. Today, only `--namespace common` will succeed end-to-end. |
| `--target` allowlist (`de` only) | Locked decision in `i18n-llm-sync.md`: `de` for v1, `fr` is a near-trivial add later. Hard-fail prevents silent mis-targeting. |
| `--dry-run` still calls the LLM | Exercises the full pipeline (parse + placeholder check), not just the writer. Documented inline. |
| Default model `claude-haiku-4-5` | Cheapest strong-register model in the bakeoff pool; sensible CI default before the bakeoff verdict lands. |

## Test Plan

- [x] `bun run type-check` — passes
- [x] `bun run lint` — passes (0 errors)
- [x] `bun test` — 8401/8401 pass (17 new in `scripts/i18n/__tests__/sync.test.ts`)
- [x] `bun run build` — no-op for native-rd

### Negative space

- The CLI's default "walk all 15 namespaces" run will fail for 14 of 15 today because their register YAMLs do not exist yet — that authoring is PR #8's scope. Smoke test today: `bun run i18n:sync --namespace common --dry-run`.
- `sync.cli.ts` entry path (`import.meta.dir`, `.env.local` parsing, `process.exit` mapping) is intentionally not unit-tested — Q2 resolution in the dev plan keeps `import.meta` out of jest. Worth a manual end-to-end smoke before merging if you have credentials handy.

## Follow-ups (review pass identified, deliberately deferred)

- `loadDotEnvLocal` silently skips malformed lines and shadowed keys — fine for the current single-author flow; revisit if confusion arises.
- Outcomes only print after the full namespace loop completes; on an LLM stall the operator sees nothing. Streaming progress is a small future change.
- `formatOutcome` has no direct test (rating 5).

---

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)