### PR TITLE
feat(native-rd/i18n): voice system prompt + per-namespace registers + sidecar loader (#162)

### DIFF
--- a/apps/native-rd/docs/decisions/ADR-0009-i18n-voice-enforcement.md
+++ b/apps/native-rd/docs/decisions/ADR-0009-i18n-voice-enforcement.md
@@ -1,0 +1,124 @@
+# ADR-0009: i18n voice enforcement shape — three-layer register + intent sidecar + glossary
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Owner:** Joe
+**Relates to:** [ADR-0007](./ADR-0007-i18n-gateway.md), [ADR-0008](./ADR-0008-i18n-bakeoff-model-pool.md)
+
+---
+
+## Context
+
+native-rd is translated en → de via an LLM batch pipeline (`scripts/i18n/`).
+The product has a distinct brand voice documented in
+`landing/docs/BRAND_LANGUAGE.md`: named-maker (Joe by name, solo, bipolar +
+ADHD), identity-first ND vocabulary, refusal-as-feature, parenthetical
+recognition asides (`(noch da? gut.)`), and a hard ban on dismissive
+exit-asides (`oder nicht`, `oder lass es`). A flat German glossary cannot
+capture _stance_ — banning a word list doesn't tell a model how to write like
+this brand. The voice problem is prompt engineering, not translation
+selection (ADR-0008 handled selection).
+
+## Decision
+
+Three-layer voice enforcement, applied per batch in `buildSystemPrompt`:
+
+1. **Per-namespace register YAML** — `apps/native-rd/src/i18n/resources/_register/<ns>.yml`.
+   Default voice for every string in the namespace. Required (hard-fail if
+   missing). Carries `speaker`, `audience`, `formality`, `banned_phrasings`,
+   `notes`. Authored by hand. Schema: `registerSchema` in `translator.ts`.
+
+2. **Per-string intent sidecar JSON** — `apps/native-rd/src/i18n/resources/en/<ns>.intents.json`.
+   Optional overrides for individual keys when a string needs sharper framing
+   than the register default. Loaded by `intentLoader.ts`. Missing-file is
+   graceful (most namespaces have none); present-but-corrupt hard-fails.
+
+3. **Thin glossary string** — passed by `syncCore.ts`. Canonical brand tokens
+   only (e.g. "Rollercoaster.dev → Rollercoaster.dev — do not translate").
+   Not the primary voice mechanism. Authored content deferred to a follow-up
+   (#179).
+
+### Layer ordering rationale
+
+Decreasing strength. Register is always present and frames every string.
+Sidecar overrides for the specific key when present. Glossary is lookup
+material, not instruction.
+
+### Composition with the system preamble
+
+`VOICE_PREAMBLE` in `promptBuilder.ts` carries brand-wide rules sourced
+verbatim from `BRAND_LANGUAGE.md`: identity-first ND vocab, banned
+dismissive exits, parenthetical preservation, placeholder contract.
+Register `banned_phrasings` are deduped against the preamble at assembly
+time so the same phrase never appears twice in the same prompt.
+
+## Alternatives Considered
+
+This is a closed decision. Voice enforcement was the central question for
+the i18n LLM pipeline — relitigating it churns the prompt builder, the
+register format, and the sync pipeline together. The alternatives below are
+recorded so they are not raised again as "have we tried…" without new
+evidence.
+
+### Rejected: ICU MessageFormat
+
+- Runtime parsing complexity for plurals/genders the corpus does not yet
+  use — ICU pays off when message structure is the problem.
+- Would require either swapping out i18next or running a second i18n
+  library alongside it, doubling the surface area.
+- The voice problem is prompt engineering; ICU is a _format_ solution to a
+  _stance_ problem. Wrong layer.
+
+### Rejected: Lingui
+
+- Compile-time message extraction is genuinely useful, but it would
+  require migrating every `t()` call and the source-string format from
+  i18next-shaped JSON to Lingui's catalogues.
+- Requires a Babel/swc transform integrated into the Expo build — adds a
+  build-time dependency to a runtime concern that is already settled.
+- The i18n-llm-sync pipeline is a sync-time tool; Lingui is an extraction
+  tool. They solve different problems.
+
+### Rejected: Fluent (Project Fluent)
+
+- Strong message format for selectors, attributes, and complex
+  pluralization — features the corpus does not need.
+- Adds a runtime parser plus a second string format alongside i18next-style
+  JSON.
+- Same wrong-layer issue as ICU: a format solution to a voice problem.
+
+## Authoring Affordances
+
+- **Registers** are YAML next to locale files (`_register/`). Edited by
+  hand. Schema-validated at sync time.
+- **Sidecars** are JSON next to source-locale files. Authored only when a
+  string needs sharper intent than the register can express. Most
+  namespaces will not have one.
+- **Glossary** is a string passed by the sync CLI. Deferred (#179).
+
+## Composition with promptfoo Assertions
+
+The bake-off (#159, ADR-0008) evaluated inherent model voice quality with a
+minimal prompt — it tested whether a candidate model _can_ follow
+register-style instructions at all. This ADR formalises the _production_
+prompt shape that runs against the chosen model. The two are independent:
+promptfoo answered "is this model trainable to our voice"; ADR-0009 defines
+"what voice instructions does production send".
+
+## Consequences
+
+- `promptBuilder.ts` carries brand-voice copy as a module-level
+  `VOICE_PREAMBLE` constant. Voice copy changes are ADR-0009 amendments,
+  not casual edits.
+- All 15 current namespaces must have a register YAML or sync fails.
+- New namespaces require a new register YAML before they enter the sync
+  pipeline.
+- Sidecars are optional; their absence is normal.
+- Glossary remains plumbed-but-empty until #179 lands.
+
+## Supersession
+
+This ADR is superseded only by a new ADR that names this number and
+explains why the three-layer shape is no longer load-bearing. Voice copy
+edits inside `VOICE_PREAMBLE` are an amendment of this ADR — they require
+a dated revision note here, not a fresh ADR.

--- a/apps/native-rd/docs/decisions/index.md
+++ b/apps/native-rd/docs/decisions/index.md
@@ -12,3 +12,4 @@ Decisions are immutable once accepted. To change a decision, write a new ADR tha
 | [ADR-0006](./ADR-0006-iteration-b-scope-amendment.md) | Iteration B scope amendment — drop three orphans, add step-model enrichment | Accepted | 2026-05-23    |
 | [ADR-0007](./ADR-0007-i18n-gateway.md)                | i18n LLM gateway — OpenRouter + Vercel AI SDK                               | Accepted | 2026-05-24    |
 | [ADR-0008](./ADR-0008-i18n-bakeoff-model-pool.md)     | i18n bake-off model pool - drop reasoning-tuned candidates                  | Accepted | 2026-05-25    |
+| [ADR-0009](./ADR-0009-i18n-voice-enforcement.md)      | i18n voice enforcement — three-layer register + intent sidecar + glossary   | Accepted | 2026-05-25    |

--- a/apps/native-rd/docs/plans/dev-plans/issue-162-voice-prompt-registers.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-162-voice-prompt-registers.md
@@ -1,0 +1,265 @@
+# Development Plan: Issue #162
+
+## Issue Summary
+
+**Title**: i18n sync: voice system prompt + per-namespace registers + sidecar loader + ADR (voice shape)
+**Type**: enhancement
+**Complexity**: MEDIUM
+**Estimated Lines**: ~250 hand-written (2–3 code files + ADR) + ~150 YAML content (15 register files). Tests count toward the hand-written budget.
+
+## Intent Verification
+
+Observable criteria derived from the issue acceptance criteria.
+
+- [ ] `buildSystemPrompt` produces a deterministic, non-empty string containing the full brand voice instructions when given a real register — not just skeleton placeholder text. Re-running with identical inputs returns byte-identical output.
+- [ ] All 15 register YAMLs load without error via `js-yaml` + `registerSchema` (the Zod schema already in `translator.ts`). Every field traces to a specific rule in `landing/docs/BRAND_LANGUAGE.md` — no fabricated voice rules.
+- [ ] When a register YAML exists but is empty (`{}` or `~` or blank), `translator.ts`'s `parseRegister` throws with the namespace name in the error message and does not fall back to a silent default.
+- [ ] When a register YAML is present but structurally invalid (missing required fields, wrong types), same hard-fail behavior as above.
+- [ ] The sidecar intent loader returns an empty record when the `.intents.json` file is absent. It returns a partial record when the file is present but some keys are missing. It hard-fails when the file exists but is not valid JSON.
+- [ ] `syncCore.syncOneNamespace` passes the loaded `intents` (or `undefined`) to `translateNamespace` — the sidecar wiring is live, not just a loader that nothing calls.
+- [ ] The three-layer composition (register → intent override → glossary) is tested end-to-end in a unit test: a namespace register with a banned phrasing, an intent sidecar that overrides audience for one key, and a glossary entry all appear correctly in the assembled system prompt.
+- [ ] ADR-0009 is added to `apps/native-rd/docs/decisions/`, appears in `index.md`, and explicitly names ICU MessageFormat, Lingui, and Fluent as rejected alternatives with rationale.
+- [ ] `bun run type-check` and `bun run lint` pass with no new errors.
+
+## Dependencies
+
+| Issue | Title                                                  | Status                                                   | Type    |
+| ----- | ------------------------------------------------------ | -------------------------------------------------------- | ------- |
+| #160  | i18n sync: translator + promptBuilder — batch pipeline | Closed, merged as commit 8523718 (PR #177) on 2026-05-25 | Blocker |
+
+**Status**: All dependencies met. `translator.ts`, `promptBuilder.ts`, `syncCore.ts`, and `sync.cli.ts` are all on `main`. The `_register/common.yml` stub is already in place at `apps/native-rd/src/i18n/resources/_register/common.yml`.
+
+## Objective
+
+Add the voice-enforcement layer that makes the LLM translate into native-rd's actual voice rather than generic German: (1) replace the skeleton `buildSystemPrompt` with real brand-voice copy sourced from `BRAND_LANGUAGE.md`; (2) author 15 per-namespace register YAMLs; (3) add a sidecar intent loader and wire it into `syncCore.ts`; (4) write ADR-0009 formalising the three-layer design and rejecting ICU/Lingui/Fluent.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                        | Alternatives Considered                             | Rationale                                                                                                                                                                                                                                                                                   |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Expand `promptBuilder.ts` in-place — add the brand-voice static text directly to the `buildSystemPrompt` sections rather than a separate template file.                                                                         | Separate `voiceTemplate.ts` or a `.txt` asset file. | `promptBuilder.ts` is already pure and well-tested. Adding static string constants to the existing sections keeps one import boundary. A separate template file adds indirection with no structural benefit at this scope.                                                                  |
+| D2  | Sidecar loader lives in a new `intentLoader.ts` (not inlined into `syncCore.ts`).                                                                                                                                               | Inline the loader logic in `syncCore.ts`.           | `syncCore.ts` already does path resolution, register loading, and orchestration. Inlining a third loader further bloats a module that should stay thin. `intentLoader.ts` keeps the loading logic independently testable. The pattern mirrors `translator.ts`'s `parseRegister` extraction. |
+| D3  | Sidecar loader hard-fails on a present-but-invalid JSON file; treats missing file as empty record.                                                                                                                              | Treat invalid JSON as empty record (silent).        | The issue explicitly requires: "missing-file: graceful; present-but-empty: graceful; present-but-invalid: hard-fail." Silently ignoring a corrupt sidecar would let a content-authoring mistake produce a wrong prompt with no signal.                                                      |
+| D4  | `syncCore.ts` loads the sidecar via `intentLoader.loadIntentSidecar(enDir, ns)` and passes the result to `translateNamespace` as `intents`. The Zod validation for sidecar shape happens inside `intentLoader.ts` at load time. | Validate sidecar shape inside `translator.ts`.      | `translator.ts`'s comment (line 53–56) explicitly deferred sidecar validation to "PR #8 wires the sidecar loader — add zod schemas + hard-fail at that boundary then." That comment is an implementation instruction for this PR.                                                           |
+| D5  | ADR number is 0009 (next in sequence).                                                                                                                                                                                          | —                                                   | `index.md` currently ends at ADR-0008.                                                                                                                                                                                                                                                      |
+| D6  | `promptBuilder.ts` static brand-voice copy is added as string constants at the module level, not exported — they are implementation details of `buildSystemPrompt`.                                                             | Export them for direct test access.                 | Tests should assert on the assembled output, not on the internal strings. Testing the constants directly would couple tests to exact wording, making future voice copy edits break tests for the wrong reason.                                                                              |
+
+## User Decisions (/start-issue resolution, 2026-05-25)
+
+These are answers Joe gave during the `/start-issue` Q&A pass. Where they conflict with the plan above, these win.
+
+| ID  | Question                                                                    | Decision                                                                                                                                                                                                                                      | Implication                                                                                                                                                                                                                                                                                                                                             |
+| --- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| U1  | Voice preamble wording review point                                         | **Draft → review → commit.** Implementer drafts `VOICE_PREAMBLE`, posts it to chat for Joe's review, waits for sign-off, then commits Step 1.                                                                                                 | Step 1 has a human gate inserted between "draft preamble" and "commit". No autopilot through Step 1.                                                                                                                                                                                                                                                    |
+| U2  | `banned_phrasings` for namespaces with no brand-doc-specific guidance       | **Brand-wide defaults, deduped at prompt-assembly.** Each register carries the full brand-wide banned list. `promptBuilder.ts` dedupes register bans against the system-prompt-level bans so they don't appear twice in the assembled prompt. | (a) Step 2 authoring uses brand-wide defaults for all 15 registers. (b) Step 1 adds a dedup pass — likely a `Set`-based subtract inside `formatRegister` or just before its output. Adds ~10 LOC to Step 1 and a new unit test in `promptBuilder.test.ts` asserting the dedup is in effect.                                                             |
+| U3  | Glossary loader in scope?                                                   | **Defer.** Follow-up filed as **#179** (sub-issue of epic #154, blocked by #162, label `dep:blocked`).                                                                                                                                        | "Not in Scope" table's "German glossary content" row updated to point at #179. No glossary loader in this PR. `syncCore.ts` continues to pass `glossary: undefined`.                                                                                                                                                                                    |
+| U4  | Sidecar wiring smoke-test location                                          | **New `syncCore.intents.test.ts`.** Focused unit test, not extending `sync.test.ts`.                                                                                                                                                          | Testing Strategy entry for "syncCore integration" is replaced by a new test file at `apps/native-rd/scripts/i18n/__tests__/syncCore.intents.test.ts`. Test asserts that when an `.intents.json` exists alongside `<ns>.json` in the fixture enDir, the value reaches `callModel` (mock the LLM call, assert the prompt string contains intent markers). |
+| U5  | ADR-0009 alternative-rejection depth                                        | **Terse bullets + one anchor paragraph.** Open the Alternatives section with a single paragraph framing why this is a closed decision (resist relitigation), then 3–5 terse bullets per rejected alternative.                                 | ADR-0009 target size ~80 LOC (between the original "terse" 60 and "long" 120 estimates). Anchor paragraph names the relitigation risk explicitly.                                                                                                                                                                                                       |
+| U6  | Empty namespaces (`badges`, `badgeDesigner` = `{}`) — author registers now? | **Author now.** Best-effort registers for both. Pipeline never hard-fails on missing register file.                                                                                                                                           | Step 2 authors all 15 registers. Already matched plan default — no change to plan.                                                                                                                                                                                                                                                                      |
+
+## Affected Areas
+
+- `apps/native-rd/scripts/i18n/promptBuilder.ts`: replace skeleton system prompt preamble with full brand-voice instructions sourced from `BRAND_LANGUAGE.md`
+- `apps/native-rd/scripts/i18n/intentLoader.ts`: new file — reads `en/<ns>.intents.json` if present, validates shape, returns `Record<string, IntentEntry>` or throws on corrupt file
+- `apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts`: new test file
+- `apps/native-rd/scripts/i18n/syncCore.ts`: wire `intentLoader.loadIntentSidecar` into `syncOneNamespace` — pass loaded intents to `translateNamespace`
+- `apps/native-rd/src/i18n/resources/_register/common.yml`: fill in real brand-voice content (currently a stub with empty fields)
+- `apps/native-rd/src/i18n/resources/_register/<ns>.yml` (×14 new files): one per remaining namespace — `badgeDesigner`, `badges`, `captureFile`, `captureLink`, `capturePhoto`, `captureText`, `captureVideo`, `captureVoice`, `focusMode`, `goals`, `newGoal`, `permissions`, `settings`, `welcome`
+- `apps/native-rd/docs/decisions/ADR-0009-i18n-voice-enforcement.md`: new ADR
+- `apps/native-rd/docs/decisions/index.md`: add ADR-0009 row
+- `apps/native-rd/docs/plans/i18n-llm-sync.md`: update plan doc to confirm decision #2 final state is reflected (already resolved — verify the module layout table is current)
+
+## Implementation Plan
+
+### Step 1: Fill `promptBuilder.ts` with real brand-voice copy
+
+**Files**: `apps/native-rd/scripts/i18n/promptBuilder.ts`
+
+**Commit**: `feat(native-rd/i18n): promptBuilder — brand-voice system prompt copy`
+
+**Changes**:
+
+- [ ] Replace the minimal inline preamble (`"You translate UI strings from English to German..."`) with a richer static block that captures, from `BRAND_LANGUAGE.md`:
+  - The named-maker stance rule (voice comes from inside the audience; no faceless-we German)
+  - Identity-first ND vocabulary requirements (autistisch, ADHS, bipolar — identity-first, not deficit-first)
+  - Refusal-as-feature / brevity stance (preserve the directness; no corporate filler in German)
+  - Parenthetical-aside preservation (`(noch da? gut.)` pattern — retain register, never expand)
+  - Banned dismissive verbs / exits (the `oder nicht`, `oder lass es` class that the promptfoo banned-phrase list already seeds)
+  - Placeholder preservation instruction (already present — keep it)
+  - Anonymised-dict input/output contract (already present — keep it)
+  - Slot markers for per-batch register + intents + glossary sections (already present via `formatRegister`/`formatIntents`/`formatGlossary`)
+- [ ] The preamble is a module-level `const VOICE_PREAMBLE: string` (unexported). `buildSystemPrompt` prepends it before the `formatRegister` output.
+- [ ] Tests continue to assert section presence (not exact wording) — existing tests remain green. Add one new test asserting the preamble contains the identity-first ND vocab instruction and the placeholder contract.
+- [ ] No new exports. No I/O. Function signature unchanged.
+
+---
+
+### Step 2: 15 register YAMLs — content authoring
+
+**Files**: `apps/native-rd/src/i18n/resources/_register/*.yml` (1 fill + 14 new)
+
+**Commit**: `content(native-rd/i18n): 15 per-namespace voice register YAMLs`
+
+**Changes**:
+
+All content is sourced exclusively from `landing/docs/BRAND_LANGUAGE.md`. Field values are real — no placeholders.
+
+The 15 namespaces and their register character:
+
+| Namespace            | Speaker posture                               | Audience                    | Formality        | Notable banned phrasings                     |
+| -------------------- | --------------------------------------------- | --------------------------- | ---------------- | -------------------------------------------- |
+| `common` (fill stub) | app (system actions, nav labels)              | neurodivergent adults       | informal         | exclamation filler, corporate action verbs   |
+| `welcome`            | app, first-person warmth (named-maker energy) | first-run user, ND adult    | informal         | exit-asides, "special", "unique"             |
+| `goals`              | app                                           | ND adult returning to goals | informal         | streak language, "you haven't yet", pressure |
+| `newGoal`            | app prompting                                 | ND adult creating           | informal         | "amazing", "great job", FOMO pressure        |
+| `badges`             | app                                           | ND adult                    | informal         | achievement-porn filler                      |
+| `badgeDesigner`      | app                                           | ND adult                    | informal         | corporate design filler                      |
+| `focusMode`          | app, quiet                                    | ND adult in focus           | informal         | exclamation, urgency                         |
+| `settings`           | app, neutral                                  | ND adult configuring        | informal-neutral | corporate UI jargon                          |
+| `permissions`        | app, matter-of-fact                           | ND adult                    | informal         | "we need", "please allow", begging register  |
+| `captureText`        | app prompting                                 | ND adult                    | informal         | pressure to elaborate, "amazing note"        |
+| `capturePhoto`       | app                                           | ND adult                    | informal         | exclamation on save                          |
+| `captureVideo`       | app                                           | ND adult                    | informal         | exclamation, pressure                        |
+| `captureVoice`       | app                                           | ND adult                    | informal         | exclamation, corporate                       |
+| `captureLink`        | app                                           | ND adult                    | informal         | exclamation                                  |
+| `captureFile`        | app                                           | ND adult                    | informal         | exclamation                                  |
+
+Each YAML has at minimum: `speaker`, `audience`, `formality`, `banned_phrasings` (drawn from BRAND_LANGUAGE.md anti-patterns), and `notes` (empty list unless namespace-specific guidance applies — e.g. `welcome` gets a note about identity-first ND vocab and named-maker energy).
+
+`badges.json` and `badgeDesigner.json` are currently empty objects (`{}`). Their registers are authored anyway so the sync pipeline has them ready when content is added.
+
+---
+
+### Step 3: `intentLoader.ts` + tests
+
+**Files**:
+
+- `apps/native-rd/scripts/i18n/intentLoader.ts`
+- `apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts`
+
+**Commit**: `feat(native-rd/i18n): intentLoader — sidecar intent file loader`
+
+**Changes**:
+
+`intentLoader.ts`:
+
+- [ ] Export `loadIntentSidecar(enDir: string, ns: string): Record<string, IntentEntry>` — synchronous, no async.
+- [ ] If `<enDir>/<ns>.intents.json` does not exist: return `{}` (no error — most namespaces won't have a sidecar).
+- [ ] If file exists and is empty (`""`) or is `{}`: return `{}`.
+- [ ] If file exists and contains JSON but has non-object root: throw `Error("namespace ${ns}: intent sidecar has unexpected root type")`.
+- [ ] If file exists and is not valid JSON: throw `Error("namespace ${ns}: intent sidecar is not valid JSON — ${detail}")`.
+- [ ] Validate leaf entries against `IntentEntry` shape (import `IntentEntry` from `promptBuilder.ts`). Entries that are strings (wrong shape) throw with a clear message rather than silently dropping. Use a Zod schema mirroring `IntentEntry`: `{ intent: z.string(), audience: z.string().optional(), register: z.string().optional() }`.
+- [ ] No `import.meta`. Pure file I/O via `node:fs`. No Bun-specific APIs. Jest-importable directly.
+
+`intentLoader.test.ts`:
+
+- [ ] Missing file → returns `{}`, no throw.
+- [ ] Present, empty file (`""`) → returns `{}`, no throw.
+- [ ] Present, `{}` content → returns `{}`, no throw.
+- [ ] Present, valid partial content (3 of 10 keys have intent entries) → returns the 3-entry record.
+- [ ] Present, non-JSON content → throws with namespace + "not valid JSON".
+- [ ] Present, non-object root (e.g. `[]`) → throws with namespace + "unexpected root type".
+- [ ] Present, entry with missing `intent` field → throws with Zod validation detail.
+- [ ] Use `test.each` for the graceful-missing and graceful-empty cases.
+- [ ] Tests use `node:fs` + `os.tmpdir()` to write fixture files — no mocking needed for I/O.
+
+---
+
+### Step 4: Wire sidecar loader into `syncCore.ts`
+
+**Files**: `apps/native-rd/scripts/i18n/syncCore.ts`
+
+**Commit**: `feat(native-rd/i18n): syncCore — wire intent sidecar into sync pipeline`
+
+**Changes**:
+
+- [ ] Import `loadIntentSidecar` from `./intentLoader`.
+- [ ] In `syncOneNamespace`, after `readRegisterText` and before `translateNamespace`, call `loadIntentSidecar(paths.enDir, ns)`. Assign result to `intents`.
+- [ ] Pass `intents` to `translateNamespace({ ..., intents })`. When `intents` is `{}` (empty record), `buildSystemPrompt` already handles this correctly (omits the intents section) — no special-casing needed.
+- [ ] If `loadIntentSidecar` throws (corrupt file), let the error propagate to the surrounding `try/catch` in `syncOneNamespace` — it will surface as `{ kind: "failed", message }` with the error text, consistent with how register and LLM failures are reported.
+- [ ] No changes to `SyncPaths`, `CliArgs`, or any exported types — this is internal wiring only.
+
+---
+
+### Step 5: ADR-0009 + index update
+
+**Files**:
+
+- `apps/native-rd/docs/decisions/ADR-0009-i18n-voice-enforcement.md`
+- `apps/native-rd/docs/decisions/index.md`
+
+**Commit**: `docs(native-rd/i18n): ADR-0009 — voice enforcement shape (register + sidecar + glossary)`
+
+**Changes**:
+
+ADR-0009 structure:
+
+- **Context**: native-rd needs LLM translations that preserve its brand voice (named-maker, identity-first ND, refusal-as-feature, parenthetical asides, banned dismissive patterns). Flat glossary alone would not be enough — a German lexicon of banned words cannot capture _stance_.
+- **Alternatives rejected (locked)**:
+  - _ICU MessageFormat_: adds runtime parsing complexity, requires a different i18n library (or dual-library setup), and is overkill for the current string corpus. The voice problem is prompt-engineering, not format parsing.
+  - _Lingui_: compile-time message extraction is a valuable pattern, but requires a full migration of all string literals and a Babel/swc transform in the Expo build. The i18n-llm-sync pipeline is a sync-time tool, not a runtime concern; migrating the source format to Lingui solves a different problem.
+  - _Fluent (Project Fluent)_: expressive for complex pluralization and attribute patterns, but adds a runtime parser and a second string format alongside i18next. The corpus does not yet have the pluralization complexity that would justify it.
+- **Decision**: three-layer voice enforcement as specified in `i18n-llm-sync.md` §Voice enforcement:
+  1. Per-namespace register YAML (default voice for all strings in the namespace)
+  2. Per-string intent sidecar (opt-in override for strings that need sharper framing)
+  3. Thin glossary (canonical brand tokens — not the primary voice mechanism)
+- **Layer ordering rationale**: decreasing strength. Register is always present (fail-fast if missing). Sidecar overrides register for the specific key. Glossary provides lookup, not instruction.
+- **Authoring affordances**: registers are YAML files next to locale files (`_register/`), edited by hand. Sidecars are JSON files next to source locale files, authored only when a string needs sharper intent. Glossary is a plain string passed by the sync CLI.
+- **Composition with promptfoo assertions**: the bake-off (PR #4/issue #159) evaluated inherent model voice quality with a minimal prompt. ADR-0009 formalises the production prompt shape. The two are independent — promptfoo tested whether a model _can_ follow register-style instructions; ADR-0009 defines the production instruction set.
+- **Supersession clause** per ADR-0006 pattern.
+
+`index.md`:
+
+- [ ] Add `ADR-0009` row: "i18n voice enforcement shape — three-layer register + intent sidecar + glossary".
+
+---
+
+### Step 6: Update plan doc
+
+**Files**: `apps/native-rd/docs/plans/i18n-llm-sync.md`
+
+**Commit**: `docs(native-rd/i18n): plan doc — confirm PR #8 decisions, link ADR-0009`
+
+**Changes**:
+
+- [ ] Verify the module layout table already shows the concrete `_register/` path (it does as of PR #177 — confirm no stale text remains).
+- [ ] Add `ADR-0009` reference under the PR #8 row in the PR sequence table.
+- [ ] Add a changelog entry: `2026-05-25 — PR #8 landed: brand-voice prompt copy, 15 register YAMLs, intent sidecar loader wired.`
+
+## Testing Strategy
+
+- [ ] `promptBuilder.test.ts` — extend existing test suite with: (a) preamble contains identity-first ND vocab instruction; (b) preamble contains placeholder-preservation instruction; (c) three-layer composition test (register + sidecar intents + glossary all appear in assembled output). Jest 30, no mocking needed — pure function.
+- [ ] `intentLoader.test.ts` — 8 cases covering all three file-state branches (missing, empty, valid, corrupt). Uses `node:fs` + `os.tmpdir()` for real file I/O. No mocking. `test.each` for the two graceful cases.
+- [ ] `syncCore.intents.test.ts` (new file, per U4) — focused smoke-test for sidecar wiring. Mocks `callModel`, writes a fixture `<ns>.intents.json` alongside `<ns>.json` in a tmpdir, runs `syncOneNamespace`, asserts the prompt string passed to `callModel` contains the `Per-string intents` section with the fixture content. Not in `sync.test.ts` — kept focused.
+- [ ] `promptBuilder.test.ts` also gets a new test for U2's dedup pass: when the register's `banned_phrasings` contains an item already present in the system-prompt-level banned list, the assembled output contains it once, not twice.
+- [ ] Test file locations: `apps/native-rd/scripts/i18n/__tests__/` — matching the established pattern.
+- [ ] Manual: `bun run type-check` + `bun run lint` + `bun run test:ci` before PR.
+
+## Not in Scope
+
+| Item                                                            | Reason                                                                                                                                         | Follow-up                                                                  |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| CI workflow / bot commit-back                                   | PR #9 / issue to be filed                                                                                                                      | #9                                                                         |
+| Authored intent sidecar entries for specific strings            | Sidecars are optional; authoring them is a content task that can happen incrementally as sync output reveals strings that need sharper framing | Post-v1                                                                    |
+| Glossary loader + content                                       | Deferred per U3 — `syncCore.ts` keeps `glossary: undefined`. The slot remains typed in `PromptBuilderInput`.                                   | #179 (filed 2026-05-25, sub-issue of #154, blocked by #162, `dep:blocked`) |
+| `badgeDesigner` and `badges` namespace content (currently `{}`) | These namespaces have no source strings yet — registers are authored but no sidecar needed                                                     | When source strings are added                                              |
+| Concurrent namespace batching                                   | Locked decision #5                                                                                                                             | Post-v1                                                                    |
+| Retry / circuit-breaker on LLM failures                         | Not in scope for this PR series until v1 is working end-to-end                                                                                 | Post-v1                                                                    |
+
+_No items deferred from this PR's core scope — all acceptance criteria are addressed above._
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+
+- [2026-05-25] Blocker #160 (PR #177) is confirmed merged — commit 8523718. `translator.ts`, `promptBuilder.ts`, `syncCore.ts` are all present. The `_register/common.yml` stub exists with empty `banned_phrasings: []` and `notes: []`.
+- [2026-05-25] Decision #2 (register file location) is already resolved in `i18n-llm-sync.md` as of PR #177: `apps/native-rd/src/i18n/resources/_register/`. The `_register/` directory exists on `main`.
+- [2026-05-25] `syncCore.ts` currently calls `translateNamespace` without `intents` or `glossary` (both undefined). Step 4 wires the sidecar — the glossary wire is out of scope here (no authored glossary content yet).
+- [2026-05-25] `translator.ts` lines 53–56 contain an explicit comment: "PR #8 wires the sidecar loader — add zod schemas + hard-fail at that boundary then, mirroring registerSchema." This is an implementation instruction; `intentLoader.ts` in Step 3 fulfills it.
+- [2026-05-25] `badges.json` and `badgeDesigner.json` are currently empty objects (`{}`). Their registers should be authored now (schema must be valid) but `banned_phrasings` can be the same brand-wide defaults. Sidecar files are not needed.
+- [2026-05-25] The promptfoo `promptfooconfig.yaml` already seeds a German banned-phrase list: `oder nicht`, `oder lass es`. These should appear in the `VOICE_PREAMBLE` in `promptBuilder.ts` and/or in relevant register YAMLs — not just in the bake-off config.
+- [2026-05-25] `BRAND_LANGUAGE.md` is at `landing/docs/BRAND_LANGUAGE.md` in the sibling `landing/` repo, not in the `issue-162-started` worktree. Access is via `/Users/joeczarnecki/Code/rollercoaster.dev/landing/docs/BRAND_LANGUAGE.md`. All register content must trace to this file.
+- [2026-05-25] Namespace count confirmed: 15 (badgeDesigner, badges, captureFile, captureLink, capturePhoto, captureText, captureVideo, captureVoice, common, focusMode, goals, newGoal, permissions, settings, welcome).
+- [2026-05-25] ADR sequence: next is 0009. ADR-0008 is the last entry in `index.md`.

--- a/apps/native-rd/docs/plans/i18n-llm-sync.md
+++ b/apps/native-rd/docs/plans/i18n-llm-sync.md
@@ -124,18 +124,18 @@ scripts/i18n/sync.ts (Bun CLI)
 
 Hand-written LOC only. Generated `de/*.json` (PR #10) doesn't count toward the cap.
 
-| #   | PR                                                                                                            | LOC            | Files       | Depends on   |
-| --- | ------------------------------------------------------------------------------------------------------------- | -------------- | ----------- | ------------ |
-| 1   | `jsonTreeUtils.ts` + tests                                                                                    | ~350           | 2           | —            |
-| 2   | `placeholderGuard.ts` + `responseParser.ts` (Zod) + tests                                                     | ~250           | 4           | —            |
-| 3   | `models.ts` registry + Vercel AI SDK + OpenRouter wrapper + tests + **ADR: gateway choice**                   | ~250           | 3 (+ ADR)   | —            |
-| 4   | promptfoo config + ~20 fixture en strings + brand-voice assertions                                            | ~250 yaml/json | 3–5         | #3           |
-| 5   | `translator.ts` + `promptBuilder.ts` + tests                                                                  | ~450           | 4           | #1, #2, #3   |
-| 6   | `sync.ts` CLI + integration test                                                                              | ~300           | 2           | #5           |
-| 7   | `lintSource.ts` warn-only + tests + strict-promotion criterion documented                                     | ~350           | 2           | — (parallel) |
-| 8   | Voice system prompt + per-namespace register YAMLs + sidecar intent loader + **ADR: voice enforcement shape** | ~250 md/yaml   | 2–3 (+ ADR) | #5           |
-| 9   | CI workflow + bot identity                                                                                    | ~100 yaml      | 1–2         | #6, #8       |
-| 10  | First sync output: `resources/de/*.json` × 15 namespaces                                                      | generated      | 15          | #9           |
+| #   | PR                                                                                                                                                  | LOC            | Files       | Depends on   |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------- | ------------ |
+| 1   | `jsonTreeUtils.ts` + tests                                                                                                                          | ~350           | 2           | —            |
+| 2   | `placeholderGuard.ts` + `responseParser.ts` (Zod) + tests                                                                                           | ~250           | 4           | —            |
+| 3   | `models.ts` registry + Vercel AI SDK + OpenRouter wrapper + tests + **ADR: gateway choice**                                                         | ~250           | 3 (+ ADR)   | —            |
+| 4   | promptfoo config + ~20 fixture en strings + brand-voice assertions                                                                                  | ~250 yaml/json | 3–5         | #3           |
+| 5   | `translator.ts` + `promptBuilder.ts` + tests                                                                                                        | ~450           | 4           | #1, #2, #3   |
+| 6   | `sync.ts` CLI + integration test                                                                                                                    | ~300           | 2           | #5           |
+| 7   | `lintSource.ts` warn-only + tests + strict-promotion criterion documented                                                                           | ~350           | 2           | — (parallel) |
+| 8   | Voice system prompt + per-namespace register YAMLs + sidecar intent loader + **ADR-0009: voice enforcement shape** (landed 2026-05-25 — issue #162) | ~250 md/yaml   | 2–3 (+ ADR) | #5           |
+| 9   | CI workflow + bot identity                                                                                                                          | ~100 yaml      | 1–2         | #6, #8       |
+| 10  | First sync output: `resources/de/*.json` × 15 namespaces                                                                                            | generated      | 15          | #9           |
 
 **Total hand-written: ~2,550 LOC across 9 code PRs.**
 
@@ -176,10 +176,11 @@ Strict-mode promotion of `lintSource` is post-v1.
 
 ADRs amending decisions in this plan use **supersession** (write a new ADR that supersedes the old one), not in-place amendment. See ADR-0006 (2026-05-23) for the pattern.
 
-| Date       | Change                                                                                                                   |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| 2026-05-24 | Initial plan. OpenRouter gateway, Vercel AI SDK, sidecar+register voice shape, three-clause linter trip-wire all locked. |
-| 2026-05-25 | ADR-0008 drops reasoning-tuned models from the first bake-off pool after live evals showed reasoning preamble leakage.   |
+| Date       | Change                                                                                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-24 | Initial plan. OpenRouter gateway, Vercel AI SDK, sidecar+register voice shape, three-clause linter trip-wire all locked.                                         |
+| 2026-05-25 | ADR-0008 drops reasoning-tuned models from the first bake-off pool after live evals showed reasoning preamble leakage.                                           |
+| 2026-05-25 | PR #8 (issue #162) landed: brand-voice prompt copy, 15 register YAMLs, intent sidecar loader wired. ADR-0009 formalises the three-layer voice enforcement shape. |
 
 ---
 

--- a/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
@@ -149,12 +149,16 @@ describe("loadIntentSidecar", () => {
     }
   });
 
-  test("throws when `intent` is an empty string", () => {
+  test.each([
+    ["empty string", ""],
+    ["whitespace only (spaces)", "   "],
+    ["whitespace only (tab/newline)", "\t\n"],
+  ])("throws when `intent` is %s", (_label, intent) => {
     const { dir, cleanup } = makeTmpDir();
     try {
       writeFileSync(
         join(dir, "common.intents.json"),
-        JSON.stringify({ "save.confirm": { intent: "" } }),
+        JSON.stringify({ "save.confirm": { intent } }),
         "utf8",
       );
       expect(() => loadIntentSidecar(dir, "common")).toThrow(
@@ -164,6 +168,30 @@ describe("loadIntentSidecar", () => {
       cleanup();
     }
   });
+
+  test.each([
+    ["audience", "audience"],
+    ["register", "register"],
+  ])(
+    "throws when optional `%s` is present but whitespace-only",
+    (_label, field) => {
+      const { dir, cleanup } = makeTmpDir();
+      try {
+        writeFileSync(
+          join(dir, "common.intents.json"),
+          JSON.stringify({
+            "save.confirm": { intent: "matter-of-fact", [field]: "   " },
+          }),
+          "utf8",
+        );
+        expect(() => loadIntentSidecar(dir, "common")).toThrow(
+          new RegExp(`namespace common:.*shape invalid.*${field}`),
+        );
+      } finally {
+        cleanup();
+      }
+    },
+  );
 
   test("throws when an entry value is a string instead of an object", () => {
     const { dir, cleanup } = makeTmpDir();

--- a/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadIntentSidecar } from "../intentLoader";
+
+function makeTmpDir(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "intent-loader-test-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("loadIntentSidecar", () => {
+  test.each([
+    ["missing file", undefined],
+    ["empty string content", ""],
+    ["whitespace-only content", "   \n  "],
+    ["empty JSON object", "{}"],
+  ])("returns {} for %s", (_label, content) => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      if (content !== undefined) {
+        writeFileSync(join(dir, "common.intents.json"), content, "utf8");
+      }
+      expect(loadIntentSidecar(dir, "common")).toEqual({});
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns partial record when only some keys have intent entries", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      const sidecar = {
+        "save.confirm": { intent: "matter-of-fact acknowledgment" },
+        "welcome.title": {
+          intent: "named-maker warmth",
+          audience: "first-run",
+        },
+        "permissions.mic.body": {
+          intent: "plain need",
+          register: "matter-of-fact",
+        },
+      };
+      writeFileSync(
+        join(dir, "common.intents.json"),
+        JSON.stringify(sidecar),
+        "utf8",
+      );
+      expect(loadIntentSidecar(dir, "common")).toEqual(sidecar);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws with namespace and 'not valid JSON' on malformed JSON", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(join(dir, "welcome.intents.json"), "{not valid", "utf8");
+      expect(() => loadIntentSidecar(dir, "welcome")).toThrow(
+        /namespace welcome:.*not valid JSON/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws with namespace and 'unexpected root type' when root is an array", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "goals.intents.json"),
+        JSON.stringify(["a", "b"]),
+        "utf8",
+      );
+      expect(() => loadIntentSidecar(dir, "goals")).toThrow(
+        /namespace goals:.*unexpected root type.*array/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws with namespace and 'unexpected root type' when root is a string", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "goals.intents.json"),
+        JSON.stringify("hello"),
+        "utf8",
+      );
+      expect(() => loadIntentSidecar(dir, "goals")).toThrow(
+        /namespace goals:.*unexpected root type.*string/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws when an entry is missing the required 'intent' field", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "permissions.intents.json"),
+        JSON.stringify({
+          "mic.body": { audience: "first-run" },
+        }),
+        "utf8",
+      );
+      expect(() => loadIntentSidecar(dir, "permissions")).toThrow(
+        /namespace permissions:.*shape invalid.*intent/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws when an entry value is a string instead of an object", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "common.intents.json"),
+        JSON.stringify({ "save.confirm": "matter-of-fact" }),
+        "utf8",
+      );
+      expect(() => loadIntentSidecar(dir, "common")).toThrow(
+        /namespace common:.*shape invalid/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
@@ -128,6 +128,43 @@ describe("loadIntentSidecar", () => {
     }
   });
 
+  test("throws on an unknown leaf key (e.g. an `audiance` typo)", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "welcome.intents.json"),
+        JSON.stringify({
+          "welcome.title": {
+            intent: "named-maker warmth",
+            audiance: "first-run",
+          },
+        }),
+        "utf8",
+      );
+      expect(() => loadIntentSidecar(dir, "welcome")).toThrow(
+        /namespace welcome:.*shape invalid.*audiance/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws when `intent` is an empty string", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "common.intents.json"),
+        JSON.stringify({ "save.confirm": { intent: "" } }),
+        "utf8",
+      );
+      expect(() => loadIntentSidecar(dir, "common")).toThrow(
+        /namespace common:.*shape invalid.*intent/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
   test("throws when an entry value is a string instead of an object", () => {
     const { dir, cleanup } = makeTmpDir();
     try {

--- a/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/intentLoader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -108,6 +108,20 @@ describe("loadIntentSidecar", () => {
       );
       expect(() => loadIntentSidecar(dir, "permissions")).toThrow(
         /namespace permissions:.*shape invalid.*intent/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("wraps non-ENOENT read errors with the namespace name", () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      // A directory at the sidecar path triggers EISDIR on readFileSync —
+      // any non-ENOENT errno that surfaces must carry the namespace.
+      mkdirSync(join(dir, "goals.intents.json"));
+      expect(() => loadIntentSidecar(dir, "goals")).toThrow(
+        /namespace goals:.*intent sidecar read failed/,
       );
     } finally {
       cleanup();

--- a/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
@@ -157,6 +157,23 @@ describe("buildSystemPrompt", () => {
     expect(out).toContain("oder lass es");
   });
 
+  test("preamble states the translate-from-English-to-German task explicitly", () => {
+    // Defense-in-depth: don't rely on "Identity-first ND vocab in German"
+    // to imply translation. Make the verb explicit so the model can't
+    // drift into rewriting in English or doing non-translation transforms.
+    const out = buildSystemPrompt({ register: BASE_REGISTER });
+    expect(out).toMatch(/translate[\s\S]*English[\s\S]*German/i);
+  });
+
+  test("preamble describes input keys as opaque/anonymized, not as paths", () => {
+    // The pipeline anonymizes dotted paths to `k0`, `k1`, …
+    // (jsonTreeUtils.collectMissing). The prompt must match what the
+    // model actually receives, not the pre-anonymization shape.
+    const out = buildSystemPrompt({ register: BASE_REGISTER });
+    expect(out).toMatch(/k0/);
+    expect(out).not.toMatch(/path\s*→\s*English string/);
+  });
+
   test("register banned_phrasings are deduped against preamble exits", () => {
     const out = buildSystemPrompt({
       register: {

--- a/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
@@ -115,6 +115,52 @@ describe("buildSystemPrompt", () => {
     expect(buildSystemPrompt(input)).toBe(buildSystemPrompt(input));
   });
 
+  test("preamble contains identity-first ND vocab instruction", () => {
+    const out = buildSystemPrompt({ register: BASE_REGISTER });
+    expect(out).toContain("autistisch");
+    expect(out).toContain("ADHS");
+    expect(out).toContain("identity-first");
+  });
+
+  test("preamble contains the placeholder-preservation contract", () => {
+    const out = buildSystemPrompt({ register: BASE_REGISTER });
+    expect(out).toMatch(/\{\{placeholder\}\}/);
+    expect(out).toContain("EXACTLY");
+  });
+
+  test("preamble names the banned dismissive exits", () => {
+    const out = buildSystemPrompt({ register: BASE_REGISTER });
+    expect(out).toContain("oder nicht");
+    expect(out).toContain("oder lass es");
+  });
+
+  test("register banned_phrasings are deduped against preamble exits", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: [
+          "oder nicht",
+          "exclamation filler",
+          "oder lass es",
+          "exclamation filler",
+        ],
+      },
+    });
+    expect(out.match(/oder nicht/g)?.length).toBe(1);
+    expect(out.match(/oder lass es/g)?.length).toBe(1);
+    expect(out.match(/- exclamation filler/g)?.length).toBe(1);
+  });
+
+  test("register section falls back to '(none beyond preamble defaults)' when only preamble dups are listed", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: ["oder nicht", "oder lass es"],
+      },
+    });
+    expect(out).toContain("(none beyond preamble defaults)");
+  });
+
   test("intent ordering is independent of object insertion order", () => {
     const a = buildSystemPrompt({
       register: BASE_REGISTER,

--- a/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
@@ -106,6 +106,29 @@ describe("buildSystemPrompt", () => {
     expect(out).toContain("Notes:");
   });
 
+  test("three-layer composition surfaces register ban + intent metadata + glossary content", () => {
+    // Headers-only assertions would pass even if section content were dropped;
+    // this test guards the contract named in the dev plan Intent Verification.
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: ["exclamation filler"],
+      },
+      intents: {
+        "save.confirm": {
+          intent: "matter-of-fact ack",
+          audience: "returning-nd-adult",
+        },
+      },
+      glossary: "Streak → (do not use)",
+    });
+    expect(out).toContain("- exclamation filler");
+    expect(out).toContain("save.confirm");
+    expect(out).toContain('intent="matter-of-fact ack"');
+    expect(out).toContain('audience="returning-nd-adult"');
+    expect(out).toContain("Streak → (do not use)");
+  });
+
   test("is deterministic — same input produces identical output", () => {
     const input = {
       register: { ...BASE_REGISTER, notes: ["a", "b"] },

--- a/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
@@ -151,6 +151,40 @@ describe("buildSystemPrompt", () => {
     expect(out.match(/- exclamation filler/g)?.length).toBe(1);
   });
 
+  test("dedup is case- and whitespace-insensitive against preamble exits", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: [
+          "  Oder Nicht  ",
+          "ODER LASS ES",
+          "exclamation filler",
+        ],
+      },
+    });
+    // Preamble dups appear once each in the preamble; no register-bullet copy.
+    expect(out.match(/oder nicht/gi)?.length).toBe(1);
+    expect(out.match(/oder lass es/gi)?.length).toBe(1);
+    // Non-preamble phrase still surfaces in the register bullet list.
+    expect(out).toContain("- exclamation filler");
+  });
+
+  test("dedup is case- and whitespace-insensitive across register entries", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: [
+          "exclamation filler",
+          "Exclamation Filler",
+          "  exclamation filler  ",
+        ],
+      },
+    });
+    // The first author-written form is preserved; the dup variants are dropped.
+    expect(out.match(/- exclamation filler/g)?.length).toBe(1);
+    expect(out).not.toContain("- Exclamation Filler");
+  });
+
   test("register section falls back to '(none beyond preamble defaults)' when only preamble dups are listed", () => {
     const out = buildSystemPrompt({
       register: {

--- a/apps/native-rd/scripts/i18n/__tests__/syncCore.intents.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/syncCore.intents.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Focused smoke test for sidecar-intent wiring in `syncOneNamespace`.
+ *
+ * Kept separate from `sync.test.ts` so the intent-wiring expectation is easy
+ * to find and won't be obscured by the broader sync test suite (decision U4
+ * in the dev plan for #162).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { callModel } from "../llmGateway";
+import { syncOneNamespace, type SyncPaths } from "../syncCore";
+
+jest.mock("../llmGateway", () => ({
+  callModel: jest.fn(),
+}));
+
+const mockCallModel = callModel as jest.MockedFunction<typeof callModel>;
+
+const STUB_REGISTER = `
+speaker: app
+audience: neurodivergent-adults
+formality: informal
+banned_phrasings: []
+`.trim();
+
+type Fixture = {
+  paths: SyncPaths;
+  enDir: string;
+  cleanup: () => void;
+};
+
+function makeFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "synccore-intents-"));
+  const enDir = join(root, "en");
+  const targetDir = join(root, "de");
+  const registerDir = join(root, "_register");
+  mkdirSync(enDir);
+  mkdirSync(targetDir);
+  mkdirSync(registerDir);
+  return {
+    paths: { enDir, targetDir, registerDir },
+    enDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("syncOneNamespace — sidecar intent wiring", () => {
+  let fixture: Fixture;
+
+  beforeEach(() => {
+    fixture = makeFixture();
+    mockCallModel.mockReset();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test("passes loaded intents into the LLM system prompt when sidecar exists", async () => {
+    writeFileSync(
+      join(fixture.enDir, "welcome.json"),
+      JSON.stringify({ title: "still here?" }),
+      "utf8",
+    );
+    writeFileSync(
+      join(fixture.enDir, "welcome.intents.json"),
+      JSON.stringify({
+        title: {
+          intent: "warm recognition, never expansive",
+          audience: "first-run-nd-adult",
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(fixture.paths.registerDir, "welcome.yml"),
+      STUB_REGISTER,
+    );
+
+    mockCallModel.mockResolvedValueOnce(JSON.stringify({ k0: "noch da?" }));
+
+    const outcome = await syncOneNamespace({
+      ns: "welcome",
+      paths: fixture.paths,
+      modelName: "claude-haiku-4-5",
+      dryRun: true,
+    });
+
+    if (outcome.kind === "failed") throw new Error(outcome.message);
+    expect(outcome.kind).toBe("dry-run");
+    expect(mockCallModel).toHaveBeenCalledTimes(1);
+    const systemPrompt = mockCallModel.mock.calls[0]![1];
+    expect(systemPrompt).toContain("Per-string intents");
+    expect(systemPrompt).toContain("title");
+    expect(systemPrompt).toContain("warm recognition, never expansive");
+    expect(systemPrompt).toContain('audience="first-run-nd-adult"');
+  });
+
+  test("omits the intents section when no sidecar file is present", async () => {
+    writeFileSync(
+      join(fixture.enDir, "welcome.json"),
+      JSON.stringify({ title: "still here?" }),
+      "utf8",
+    );
+    writeFileSync(
+      join(fixture.paths.registerDir, "welcome.yml"),
+      STUB_REGISTER,
+    );
+
+    mockCallModel.mockResolvedValueOnce(JSON.stringify({ k0: "noch da?" }));
+
+    const outcome = await syncOneNamespace({
+      ns: "welcome",
+      paths: fixture.paths,
+      modelName: "claude-haiku-4-5",
+      dryRun: true,
+    });
+
+    expect(outcome.kind).toBe("dry-run");
+    const systemPrompt = mockCallModel.mock.calls[0]![1];
+    expect(systemPrompt).not.toContain("Per-string intents");
+  });
+
+  test("surfaces a corrupt sidecar as a failed outcome with the namespace name", async () => {
+    writeFileSync(
+      join(fixture.enDir, "welcome.json"),
+      JSON.stringify({ title: "still here?" }),
+      "utf8",
+    );
+    writeFileSync(
+      join(fixture.enDir, "welcome.intents.json"),
+      "{not valid json",
+      "utf8",
+    );
+    writeFileSync(
+      join(fixture.paths.registerDir, "welcome.yml"),
+      STUB_REGISTER,
+    );
+
+    const outcome = await syncOneNamespace({
+      ns: "welcome",
+      paths: fixture.paths,
+      modelName: "claude-haiku-4-5",
+      dryRun: true,
+    });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind === "failed") {
+      expect(outcome.message).toMatch(/welcome/);
+      expect(outcome.message).toMatch(/not valid JSON/);
+    }
+    expect(mockCallModel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/native-rd/scripts/i18n/__tests__/translator.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/translator.test.ts
@@ -272,6 +272,25 @@ describe("translateNamespace — register/intent/glossary plumbing", () => {
     expect(mockCallModel).not.toHaveBeenCalled();
   });
 
+  test("throws on an unknown register key (e.g. a `banned_phrasing` typo)", async () => {
+    const enTree = { greeting: "Hello" };
+    const deTree = {};
+
+    await expect(
+      translateNamespace({
+        enTree,
+        deTree,
+        ns: "common",
+        modelName: "gpt-4o-mini",
+        registerText:
+          "speaker: app\naudience: nd-adults\nformality: informal\nbanned_phrasings: []\nbanned_phrasing: []\n",
+      }),
+    ).rejects.toThrow(
+      /namespace common.*register YAML schema invalid.*banned_phrasing/,
+    );
+    expect(mockCallModel).not.toHaveBeenCalled();
+  });
+
   test("preserves YAML parse error cause for debugging", async () => {
     const enTree = { greeting: "Hello" };
     const deTree = {};

--- a/apps/native-rd/scripts/i18n/intentLoader.ts
+++ b/apps/native-rd/scripts/i18n/intentLoader.ts
@@ -25,11 +25,13 @@ import { z } from "zod";
 
 import type { IntentEntry } from "./promptBuilder";
 
-const intentEntrySchema: z.ZodType<IntentEntry> = z.object({
-  intent: z.string(),
-  audience: z.string().optional(),
-  register: z.string().optional(),
-});
+const intentEntrySchema: z.ZodType<IntentEntry> = z
+  .object({
+    intent: z.string().min(1),
+    audience: z.string().optional(),
+    register: z.string().optional(),
+  })
+  .strict();
 
 const intentRecordSchema = z.record(z.string(), intentEntrySchema);
 

--- a/apps/native-rd/scripts/i18n/intentLoader.ts
+++ b/apps/native-rd/scripts/i18n/intentLoader.ts
@@ -1,0 +1,83 @@
+/**
+ * Sidecar intent loader for the i18n batch translator.
+ *
+ * Mirrors `translator.ts`'s `parseRegister` discipline: namespace name is
+ * embedded in every error so callers don't need to wrap. The asymmetry
+ * matters — missing file is the common case (most namespaces have no
+ * sidecar), but a present-but-corrupt file is a content-authoring mistake
+ * that must surface, not silently degrade the prompt.
+ *
+ *   - missing file        → `{}` (no throw)
+ *   - present but empty   → `{}` (no throw)
+ *   - present, `{}`       → `{}` (no throw)
+ *   - present, not JSON   → throws
+ *   - present, non-object → throws
+ *   - present, bad shape  → throws (zod validation)
+ *
+ * Pure sync `node:fs` I/O — no Bun-specific APIs, no `import.meta`. Jest can
+ * import this module directly.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import type { IntentEntry } from "./promptBuilder";
+
+const intentEntrySchema: z.ZodType<IntentEntry> = z.object({
+  intent: z.string(),
+  audience: z.string().optional(),
+  register: z.string().optional(),
+});
+
+const intentRecordSchema = z.record(z.string(), intentEntrySchema);
+
+export function loadIntentSidecar(
+  enDir: string,
+  ns: string,
+): Record<string, IntentEntry> {
+  const path = join(enDir, `${ns}.intents.json`);
+  if (!existsSync(path)) {
+    return {};
+  }
+
+  const raw = readFileSync(path, "utf8");
+  if (raw.trim().length === 0) {
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `namespace ${ns}: intent sidecar is not valid JSON — ${detail}`,
+      { cause: e },
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `namespace ${ns}: intent sidecar has unexpected root type — expected JSON object, got ${
+        Array.isArray(parsed)
+          ? "array"
+          : parsed === null
+            ? "null"
+            : typeof parsed
+      }`,
+    );
+  }
+
+  const result = intentRecordSchema.safeParse(parsed);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    throw new Error(
+      `namespace ${ns}: intent sidecar shape invalid — ${details}`,
+    );
+  }
+  return result.data;
+}

--- a/apps/native-rd/scripts/i18n/intentLoader.ts
+++ b/apps/native-rd/scripts/i18n/intentLoader.ts
@@ -27,9 +27,9 @@ import type { IntentEntry } from "./promptBuilder";
 
 const intentEntrySchema: z.ZodType<IntentEntry> = z
   .object({
-    intent: z.string().min(1),
-    audience: z.string().optional(),
-    register: z.string().optional(),
+    intent: z.string().trim().min(1),
+    audience: z.string().trim().min(1).optional(),
+    register: z.string().trim().min(1).optional(),
   })
   .strict();
 

--- a/apps/native-rd/scripts/i18n/intentLoader.ts
+++ b/apps/native-rd/scripts/i18n/intentLoader.ts
@@ -45,7 +45,10 @@ export function loadIntentSidecar(
     if ((e as NodeJS.ErrnoException)?.code === "ENOENT") {
       return {};
     }
-    throw e;
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new Error(`namespace ${ns}: intent sidecar read failed — ${detail}`, {
+      cause: e,
+    });
   }
   if (raw.trim().length === 0) {
     return {};

--- a/apps/native-rd/scripts/i18n/intentLoader.ts
+++ b/apps/native-rd/scripts/i18n/intentLoader.ts
@@ -18,7 +18,7 @@
  * import this module directly.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { z } from "zod";
@@ -38,11 +38,15 @@ export function loadIntentSidecar(
   ns: string,
 ): Record<string, IntentEntry> {
   const path = join(enDir, `${ns}.intents.json`);
-  if (!existsSync(path)) {
-    return {};
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return {};
+    }
+    throw e;
   }
-
-  const raw = readFileSync(path, "utf8");
   if (raw.trim().length === 0) {
     return {};
   }

--- a/apps/native-rd/scripts/i18n/promptBuilder.ts
+++ b/apps/native-rd/scripts/i18n/promptBuilder.ts
@@ -49,8 +49,17 @@ const PREAMBLE_BANNED_EXITS: readonly string[] = [
   "wir sind hier wenn du zurückkommst",
 ];
 
+// Compare deduplication on a normalized form so 15 hand-authored YAML
+// register files can't slip past the filter with trailing whitespace or
+// stray capitalization (e.g. "  Oder Nicht  " vs "oder nicht"). The
+// preamble's canonical form is what ships — we only normalize for the
+// membership test.
+function normalizeBan(phrase: string): string {
+  return phrase.trim().toLowerCase();
+}
+
 const PREAMBLE_BANNED_EXIT_SET: ReadonlySet<string> = new Set(
-  PREAMBLE_BANNED_EXITS,
+  PREAMBLE_BANNED_EXITS.map(normalizeBan),
 );
 
 const PREAMBLE_BANNED_EXITS_INLINE = PREAMBLE_BANNED_EXITS.map(
@@ -96,8 +105,9 @@ function dedupedRegisterBans(bans: readonly string[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const phrase of bans) {
-    if (PREAMBLE_BANNED_EXIT_SET.has(phrase) || seen.has(phrase)) continue;
-    seen.add(phrase);
+    const norm = normalizeBan(phrase);
+    if (PREAMBLE_BANNED_EXIT_SET.has(norm) || seen.has(norm)) continue;
+    seen.add(norm);
     out.push(phrase);
   }
   return out;

--- a/apps/native-rd/scripts/i18n/promptBuilder.ts
+++ b/apps/native-rd/scripts/i18n/promptBuilder.ts
@@ -37,9 +37,10 @@ export type PromptBuilderInput = {
   glossary?: string;
 };
 
-// Banned dismissive exits already enumerated in the preamble. Register
-// `banned_phrasings` get subtracted against this set before rendering so an
-// exit phrase named in both layers doesn't appear twice in the prompt.
+// Single source of truth for banned dismissive exits. The list is rendered
+// into the preamble below AND used to dedup register `banned_phrasings` at
+// assembly time — keeping these in one constant avoids the two layers
+// drifting out of sync.
 const PREAMBLE_BANNED_EXITS: readonly string[] = [
   "oder nicht",
   "oder lass es",
@@ -47,6 +48,14 @@ const PREAMBLE_BANNED_EXITS: readonly string[] = [
   "schließ den Tab",
   "wir sind hier wenn du zurückkommst",
 ];
+
+const PREAMBLE_BANNED_EXIT_SET: ReadonlySet<string> = new Set(
+  PREAMBLE_BANNED_EXITS,
+);
+
+const PREAMBLE_BANNED_EXITS_INLINE = PREAMBLE_BANNED_EXITS.map(
+  (p) => `"${p}"`,
+).join(", ");
 
 const VOICE_PREAMBLE = `This is the rollercoaster.dev brand voice. The audience is neurodivergent adults (ADHD, autism, bipolar). The product is a personal goal tracker built by one person (Joe, bipolar + ADHD). Voice comes from inside the audience — not from outside it.
 
@@ -65,7 +74,7 @@ Parenthetical asides (recognition pattern):
 - Recognition asides only. NEVER dismissive / exit-asides.
 
 Banned dismissive exits in German (never emit these, even if the source seems to invite them):
-- "oder nicht", "oder lass es", "oder mach's halt nicht", "schließ den Tab", "wir sind hier wenn du zurückkommst" — these waved-off patterns contradict the founder energy of this project.
+- ${PREAMBLE_BANNED_EXITS_INLINE} — these waved-off patterns contradict the founder energy of this project.
 
 Punctuation:
 - No default exclamation points. Reserve for genuine celebration moments only.
@@ -84,11 +93,10 @@ function formatList(items: readonly string[]): string {
 }
 
 function dedupedRegisterBans(bans: readonly string[]): string[] {
-  const preambleSet = new Set(PREAMBLE_BANNED_EXITS);
   const seen = new Set<string>();
   const out: string[] = [];
   for (const phrase of bans) {
-    if (preambleSet.has(phrase) || seen.has(phrase)) continue;
+    if (PREAMBLE_BANNED_EXIT_SET.has(phrase) || seen.has(phrase)) continue;
     seen.add(phrase);
     out.push(phrase);
   }

--- a/apps/native-rd/scripts/i18n/promptBuilder.ts
+++ b/apps/native-rd/scripts/i18n/promptBuilder.ts
@@ -66,7 +66,9 @@ const PREAMBLE_BANNED_EXITS_INLINE = PREAMBLE_BANNED_EXITS.map(
   (p) => `"${p}"`,
 ).join(", ");
 
-const VOICE_PREAMBLE = `This is the rollercoaster.dev brand voice. The audience is neurodivergent adults (ADHD, autism, bipolar). The product is a personal goal tracker built by one person (Joe, bipolar + ADHD). Voice comes from inside the audience — not from outside it.
+const VOICE_PREAMBLE = `Task: translate each input value from English to German, applying the voice rules below. Keys are opaque identifiers — return them verbatim, do NOT interpret meaning from them.
+
+This is the rollercoaster.dev brand voice. The audience is neurodivergent adults (ADHD, autism, bipolar). The product is a personal goal tracker built by one person (Joe, bipolar + ADHD). Voice comes from inside the audience — not from outside it.
 
 Identity-first ND vocabulary in German:
 - "autistisch", "ADHS", "bipolar" — identity-first, not deficit-first.
@@ -93,8 +95,8 @@ Placeholders:
 - Preserve every \`{{placeholder}}\` token EXACTLY. Same name, same braces, same count. Do not translate placeholder names.
 
 Output contract:
-- Input is a flat JSON dictionary of \`path → English string\`.
-- Output is raw JSON with the IDENTICAL key set — no added keys, no dropped keys, no wrapper object.
+- Input is a flat JSON dictionary with anonymized string keys (e.g. \`k0\`, \`k1\`) mapping to English source values. The keys carry no semantic meaning — they are NOT paths or labels; do not translate, expand, or annotate them.
+- Output is raw JSON with the IDENTICAL key set — no added keys, no dropped keys, no wrapper object. Only the values change (English → German).
 - No markdown code fences. No prose before or after. JSON only.`;
 
 function formatList(items: readonly string[]): string {

--- a/apps/native-rd/scripts/i18n/promptBuilder.ts
+++ b/apps/native-rd/scripts/i18n/promptBuilder.ts
@@ -5,11 +5,14 @@
  * record and calls `buildSystemPrompt` to produce the `system` string that
  * goes into `callModel`. Three inputs:
  *   - register: required, the per-namespace voice register
- *   - intents:  optional, per-string overrides (sidecar from PR #8)
+ *   - intents:  optional, per-string overrides (sidecar loader in #162)
  *   - glossary: optional, thin reference for canonical wordings
  *
- * Skeleton template only (Resolved Decision #3 in dev-plan for #160). PR #8
- * owns the polished voice copy. Tests assert section presence, not wording.
+ * `VOICE_PREAMBLE` carries the brand-wide voice instructions sourced from
+ * `landing/docs/BRAND_LANGUAGE.md`. Register `banned_phrasings` are deduped
+ * against `PREAMBLE_BANNED_EXITS` at assembly time so the same phrase never
+ * appears twice in the assembled prompt.
+ *
  * Pure: no I/O, no `import.meta`, no clock/random — same inputs in, same
  * string out.
  */
@@ -34,8 +37,62 @@ export type PromptBuilderInput = {
   glossary?: string;
 };
 
+// Banned dismissive exits already enumerated in the preamble. Register
+// `banned_phrasings` get subtracted against this set before rendering so an
+// exit phrase named in both layers doesn't appear twice in the prompt.
+const PREAMBLE_BANNED_EXITS: readonly string[] = [
+  "oder nicht",
+  "oder lass es",
+  "oder mach's halt nicht",
+  "schließ den Tab",
+  "wir sind hier wenn du zurückkommst",
+];
+
+const VOICE_PREAMBLE = `This is the rollercoaster.dev brand voice. The audience is neurodivergent adults (ADHD, autism, bipolar). The product is a personal goal tracker built by one person (Joe, bipolar + ADHD). Voice comes from inside the audience — not from outside it.
+
+Identity-first ND vocabulary in German:
+- "autistisch", "ADHS", "bipolar" — identity-first, not deficit-first.
+- Never "leidet an" (suffers from), "Störung" emphasis, "anders begabt", or "besondere Bedürfnisse". Treat ND as difference, not deficit.
+
+Stance:
+- Direct. One idea per sentence. Short sentences (~12 words avg). Concrete verbs, not abstract ones.
+- Refusal-as-feature is preserved: "Keine Streaks. Keine Werbung." reads as confident, not apologetic — keep the bare-list shape.
+- Limits-first: when the source admits a limit, the German must admit the same limit. Do not soften.
+- Never corporate. Never patronising ("besonders", "einzigartig"). Never toxic-positive ("Du schaffst das!", "Großartig!").
+
+Parenthetical asides (recognition pattern):
+- Preserve them. \`(still here? good.)\` → \`(noch da? gut.)\`. Same shape, same warmth, never expanded into a sentence.
+- Recognition asides only. NEVER dismissive / exit-asides.
+
+Banned dismissive exits in German (never emit these, even if the source seems to invite them):
+- "oder nicht", "oder lass es", "oder mach's halt nicht", "schließ den Tab", "wir sind hier wenn du zurückkommst" — these waved-off patterns contradict the founder energy of this project.
+
+Punctuation:
+- No default exclamation points. Reserve for genuine celebration moments only.
+- No emoji unless the source already has one.
+
+Placeholders:
+- Preserve every \`{{placeholder}}\` token EXACTLY. Same name, same braces, same count. Do not translate placeholder names.
+
+Output contract:
+- Input is a flat JSON dictionary of \`path → English string\`.
+- Output is raw JSON with the IDENTICAL key set — no added keys, no dropped keys, no wrapper object.
+- No markdown code fences. No prose before or after. JSON only.`;
+
 function formatList(items: readonly string[]): string {
   return items.map((item) => `- ${item}`).join("\n");
+}
+
+function dedupedRegisterBans(bans: readonly string[]): string[] {
+  const preambleSet = new Set(PREAMBLE_BANNED_EXITS);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const phrase of bans) {
+    if (preambleSet.has(phrase) || seen.has(phrase)) continue;
+    seen.add(phrase);
+    out.push(phrase);
+  }
+  return out;
 }
 
 function formatRegister(register: RegisterData): string {
@@ -46,10 +103,11 @@ function formatRegister(register: RegisterData): string {
     `Formality: ${register.formality}`,
   ];
 
-  if (register.banned_phrasings.length > 0) {
-    lines.push("Banned phrasings:", formatList(register.banned_phrasings));
+  const bans = dedupedRegisterBans(register.banned_phrasings);
+  if (bans.length > 0) {
+    lines.push("Banned phrasings:", formatList(bans));
   } else {
-    lines.push("Banned phrasings: (none)");
+    lines.push("Banned phrasings: (none beyond preamble defaults)");
   }
 
   if (register.notes && register.notes.length > 0) {
@@ -92,10 +150,7 @@ function formatGlossary(glossary: string): string {
  * returns only the system content.
  */
 export function buildSystemPrompt(input: PromptBuilderInput): string {
-  const sections: string[] = [
-    "You translate UI strings from English to German. Preserve every `{{placeholder}}` token exactly. Return JSON with the same key set as the input. Output raw JSON only — do not wrap the response in markdown code fences (no ```json, no ```).",
-    formatRegister(input.register),
-  ];
+  const sections: string[] = [VOICE_PREAMBLE, formatRegister(input.register)];
 
   if (input.intents && Object.keys(input.intents).length > 0) {
     sections.push(formatIntents(input.intents));

--- a/apps/native-rd/scripts/i18n/syncCore.ts
+++ b/apps/native-rd/scripts/i18n/syncCore.ts
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { loadIntentSidecar } from "./intentLoader";
 import { translatableSubtree, type JsonTree } from "./jsonTreeUtils";
 import { discoverNamespaces as discoverNamespaceFiles } from "./lintSource";
 import { translateNamespace } from "./translator";
@@ -171,12 +172,14 @@ export async function syncOneNamespace(opts: {
     }
 
     const registerText = readRegisterText(registerPath, ns);
+    const intents = loadIntentSidecar(paths.enDir, ns);
     const result = await translateNamespace({
       enTree,
       deTree: targetTree,
       ns,
       modelName,
       registerText,
+      intents,
     });
 
     if (dryRun) {

--- a/apps/native-rd/scripts/i18n/translator.ts
+++ b/apps/native-rd/scripts/i18n/translator.ts
@@ -33,13 +33,15 @@ import {
 } from "./promptBuilder";
 import { parseAndValidate, type ParseError } from "./responseParser";
 
-const registerSchema: z.ZodType<RegisterData> = z.object({
-  speaker: z.string(),
-  audience: z.string(),
-  formality: z.string(),
-  banned_phrasings: z.array(z.string()),
-  notes: z.array(z.string()).optional(),
-});
+const registerSchema: z.ZodType<RegisterData> = z
+  .object({
+    speaker: z.string(),
+    audience: z.string(),
+    formality: z.string(),
+    banned_phrasings: z.array(z.string()),
+    notes: z.array(z.string()).optional(),
+  })
+  .strict();
 
 export type TranslateNamespaceOptions = {
   enTree: JsonTree;

--- a/apps/native-rd/scripts/i18n/translator.ts
+++ b/apps/native-rd/scripts/i18n/translator.ts
@@ -121,6 +121,14 @@ export async function translateNamespace(
   }
 
   const register = parseRegister(registerText, ns);
+  // Known limitation (see #180): `intents` is keyed by source paths
+  // (e.g. "save.confirm"), but `dict` goes to the LLM keyed by synthetic
+  // `k{n}` keys synthesized in `collectMissing` (jsonTreeUtils.ts:174-188).
+  // The per-string intent override is therefore visible in the prompt but
+  // cannot bind to specific user-content strings until the keys are reconciled
+  // (either re-key intents through `pathMap.paths` before assembly, or drop
+  // the synthetic-key scheme entirely). The brand-voice preamble and per-
+  // namespace register are unaffected.
   const systemPrompt = buildSystemPrompt({ register, intents, glossary });
   const userContent = JSON.stringify(dict);
 

--- a/apps/native-rd/src/i18n/resources/_register/badgeDesigner.yml
+++ b/apps/native-rd/src/i18n/resources/_register/badgeDesigner.yml
@@ -1,0 +1,19 @@
+# badgeDesigner — ND adult designing a badge.
+# Source JSON is currently {}; register authored ahead of content.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - dein wunderschönes Design
+  - kreativ sein
+  - Design-Suite
+  - leverage
+  - Großartig!
+  - Super!
+  - besonders
+  - einzigartig
+  - leidet an
+notes:
+  - Plain design language. "Farbe wählen" beats "Wähle eine Farbe, die zu dir passt".
+  - No corporate design jargon (no "Brand-Identität", no "Asset").

--- a/apps/native-rd/src/i18n/resources/_register/badges.yml
+++ b/apps/native-rd/src/i18n/resources/_register/badges.yml
@@ -1,0 +1,20 @@
+# badges — ND adult, badge collection view.
+# Source JSON is currently {}; register is authored ahead of content so the
+# sync pipeline has it ready.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Glückwunsch!
+  - Großartig!
+  - du hast es geschafft!
+  - dein Erfolg
+  - Achievement
+  - sammle sie alle
+  - besonders
+  - einzigartig
+  - leidet an
+notes:
+  - Badges are self-validation, not external approval — no achievement-porn.
+  - 'Matter-of-fact brevity. "verliehen." beats "Du hast erfolgreich einen Badge erhalten!".'

--- a/apps/native-rd/src/i18n/resources/_register/captureFile.yml
+++ b/apps/native-rd/src/i18n/resources/_register/captureFile.yml
@@ -1,0 +1,16 @@
+# captureFile — ND adult attaching a file.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - tolle Datei!
+  - leverage
+  - Du schaffst das!
+  - besonders
+  - leidet an
+notes:
+  - Plain file labels. "Datei gespeichert." beats celebratory copy.
+  - File size / format errors stay matter-of-fact ("zu groß. Maximum 25 MB.").

--- a/apps/native-rd/src/i18n/resources/_register/captureLink.yml
+++ b/apps/native-rd/src/i18n/resources/_register/captureLink.yml
@@ -1,0 +1,16 @@
+# captureLink — ND adult capturing a URL.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - toller Link!
+  - leverage
+  - Du schaffst das!
+  - besonders
+  - leidet an
+notes:
+  - Plain URL handling. "Link gespeichert." beats "Dein Link wurde
+    erfolgreich hinzugefügt!".

--- a/apps/native-rd/src/i18n/resources/_register/capturePhoto.yml
+++ b/apps/native-rd/src/i18n/resources/_register/capturePhoto.yml
@@ -1,0 +1,17 @@
+# capturePhoto — ND adult capturing a photo.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - tolles Foto!
+  - perfektes Bild
+  - lächeln!
+  - Du schaffst das!
+  - besonders
+  - leidet an
+notes:
+  - Matter-of-fact save confirmations. "gespeichert." beats "Dein Foto wurde
+    erfolgreich gespeichert!".

--- a/apps/native-rd/src/i18n/resources/_register/captureText.yml
+++ b/apps/native-rd/src/i18n/resources/_register/captureText.yml
@@ -1,0 +1,18 @@
+# captureText — ND adult capturing a text note.
+
+speaker: app prompting
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - tolle Notiz!
+  - schreib mehr!
+  - sei ausführlich
+  - erzähl uns alles
+  - Du schaffst das!
+  - besonders
+  - leidet an
+notes:
+  - Short answers are valid. "notiert." beats "Wir haben deine Notiz erfolgreich gespeichert!".
+  - Placeholder text stays low-pressure ("hier tippen…").

--- a/apps/native-rd/src/i18n/resources/_register/captureVideo.yml
+++ b/apps/native-rd/src/i18n/resources/_register/captureVideo.yml
@@ -1,0 +1,17 @@
+# captureVideo — ND adult capturing a video.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - tolles Video!
+  - Action!
+  - Du schaffst das!
+  - jetzt aufnehmen!
+  - besonders
+  - leidet an
+notes:
+  - No urgency on the record button. "aufnehmen" beats "Jetzt aufnehmen!".
+  - Plain status. "gespeichert." beats celebratory wrap-up copy.

--- a/apps/native-rd/src/i18n/resources/_register/captureVoice.yml
+++ b/apps/native-rd/src/i18n/resources/_register/captureVoice.yml
@@ -1,0 +1,16 @@
+# captureVoice — ND adult capturing a voice memo.
+
+speaker: app
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - tolle Aufnahme!
+  - sprich laut und deutlich
+  - Du schaffst das!
+  - besonders
+  - leidet an
+notes:
+  - 'Quiet labels. "aufnehmen" / "stoppen" — no celebratory wrap-up.'
+  - 'Matter-of-fact confirmations: "notiert." on save, never "Aufnahme erfolgreich gespeichert!".'

--- a/apps/native-rd/src/i18n/resources/_register/common.yml
+++ b/apps/native-rd/src/i18n/resources/_register/common.yml
@@ -2,10 +2,27 @@
 #
 # Loaded by scripts/i18n/translator.ts and passed to promptBuilder. The runtime
 # (i18next) never reads this file — only the sync tooling does. Schema must
-# match RegisterData in promptBuilder.ts. PR #8 fills in the real content.
+# match RegisterData in promptBuilder.ts. Brand-voice defaults sourced from
+# landing/docs/BRAND_LANGUAGE.md. Banned exits already in the system preamble
+# are deduped at prompt assembly — no need to repeat "oder nicht" etc. here.
 
 speaker: app
 audience: neurodivergent-adults
 formality: informal
-banned_phrasings: []
-notes: []
+banned_phrasings:
+  - besonders
+  - einzigartig
+  - anders begabt
+  - besondere Bedürfnisse
+  - leidet an
+  - Großartig!
+  - Super!
+  - Du schaffst das!
+  - Fantastisch!
+  - Streak
+  - Tage ohne
+  - leverage
+  - Synergien
+notes:
+  - Identity-first ND vocab (autistisch, ADHS, bipolar — never deficit-first).
+  - Short sentences. Concrete verbs. No corporate filler.

--- a/apps/native-rd/src/i18n/resources/_register/focusMode.yml
+++ b/apps/native-rd/src/i18n/resources/_register/focusMode.yml
@@ -1,0 +1,18 @@
+# focusMode — ND adult in focus session. Quiet, no urgency.
+
+speaker: app, quiet
+audience: ND adult in focus
+formality: informal
+banned_phrasings:
+  - Achtung!
+  - dringend
+  - jetzt sofort
+  - bleib dran!
+  - Konzentrier dich!
+  - Du schaffst das!
+  - Großartig!
+  - besonders
+  - leidet an
+notes:
+  - Quiet register. No exclamations, no urgency cues.
+  - 'Plain labels: "Pause" beats "Mach jetzt eine Pause!".'

--- a/apps/native-rd/src/i18n/resources/_register/goals.yml
+++ b/apps/native-rd/src/i18n/resources/_register/goals.yml
@@ -1,0 +1,21 @@
+# goals — ND adult returning to goal tracking.
+# No streak language, no "you haven't yet" pressure. BRAND_LANGUAGE.md
+# Anti-Patterns → Gamification Punishments.
+
+speaker: app
+audience: ND adult returning to goals
+formality: informal
+banned_phrasings:
+  - Streak
+  - Tage ohne
+  - du hast noch nicht
+  - schon wieder verpasst
+  - dranbleiben!
+  - Großartig!
+  - Super!
+  - Du schaffst das!
+  - besonders
+  - leidet an
+notes:
+  - Non-linear progress is the point — never frame a gap as failure.
+  - 'Resume phrasing: "Pick up where you left off" → "Mach da weiter, wo du aufgehört hast." — no urgency, no streak math.'

--- a/apps/native-rd/src/i18n/resources/_register/newGoal.yml
+++ b/apps/native-rd/src/i18n/resources/_register/newGoal.yml
@@ -1,0 +1,21 @@
+# newGoal — ND adult creating a new goal.
+# No FOMO, no "amazing" prompts.
+
+speaker: app prompting
+audience: ND adult creating a goal
+formality: informal
+banned_phrasings:
+  - Großartig!
+  - Super!
+  - Fantastisch!
+  - Toll!
+  - Du schaffst das!
+  - amazing goal
+  - dein bestes Selbst
+  - was möchtest du erreichen?
+  - besonders
+  - einzigartig
+  - leidet an
+notes:
+  - Plain prompts. "Was willst du tun?" beats "Was ist dein wunderbares Ziel?".
+  - No pressure to elaborate — short answers are valid.

--- a/apps/native-rd/src/i18n/resources/_register/permissions.yml
+++ b/apps/native-rd/src/i18n/resources/_register/permissions.yml
@@ -1,0 +1,18 @@
+# permissions — ND adult, OS permission prompts. Matter-of-fact, not begging.
+
+speaker: app, matter-of-fact
+audience: ND adult
+formality: informal
+banned_phrasings:
+  - wir brauchen
+  - bitte erlaube
+  - bitte gewähre
+  - nur dieses eine Mal
+  - hilf uns
+  - wir möchten dich besser kennenlernen
+  - Großartig!
+  - besonders
+  - leidet an
+notes:
+  - State why the permission is needed in plain terms. No begging register.
+  - 'Plain phrasing: "Mikrofonzugriff für Sprachaufnahmen" beats "Bitte erlaube uns Zugriff auf dein Mikrofon, damit wir dir helfen können".'

--- a/apps/native-rd/src/i18n/resources/_register/settings.yml
+++ b/apps/native-rd/src/i18n/resources/_register/settings.yml
@@ -1,0 +1,18 @@
+# settings — ND adult configuring the app. Matter-of-fact.
+
+speaker: app, neutral
+audience: ND adult configuring
+formality: informal-neutral
+banned_phrasings:
+  - Konfiguration
+  - Präferenzen verwalten
+  - personalisiere dein Erlebnis
+  - leverage
+  - Synergien
+  - optimieren Sie Ihre Erfahrung
+  - Großartig!
+  - besonders
+  - leidet an
+notes:
+  - Plain UI labels. "Einstellungen" not "Konfigurationsoberfläche".
+  - Concrete verbs ("ändern", "speichern") over abstract ("verwalten", "konfigurieren").

--- a/apps/native-rd/src/i18n/resources/_register/welcome.yml
+++ b/apps/native-rd/src/i18n/resources/_register/welcome.yml
@@ -1,0 +1,26 @@
+# welcome — first-run user, named-maker warmth.
+# Sourced from landing/docs/BRAND_LANGUAGE.md Voice Pattern #8 (Named-Maker
+# Voice) and the recognition-aside pattern.
+
+speaker: app, first-person warmth (named-maker energy — Joe builds this solo)
+audience: first-run neurodivergent adult
+formality: informal
+banned_phrasings:
+  - besonders
+  - einzigartig
+  - Willkommen in unserer Familie
+  - Großartig!
+  - Super!
+  - Fantastisch!
+  - Du schaffst das!
+  - unser Team
+  - wir sind ein Unternehmen
+  - leidet an
+  - anders begabt
+notes:
+  - Named-maker stance — if the source uses first-person ("I built this"),
+    keep that in German ("Ich habe das gebaut, weil ich es selbst brauchte.").
+    Never collapse into faceless "wir".
+  - Identity-first ND vocab (autistisch, ADHS, bipolar).
+  - Recognition asides like "(noch da? gut.)" are preserved verbatim,
+    never expanded.


### PR DESCRIPTION
## Summary

- Replaces the skeleton `buildSystemPrompt` with full brand-voice copy sourced from `landing/docs/BRAND_LANGUAGE.md` (named-maker stance, identity-first ND vocab, refusal-as-feature, parenthetical-aside preservation, banned dismissive verbs).
- Authors 15 per-namespace voice register YAMLs and wires a new `intentLoader.ts` sidecar into `syncCore.syncOneNamespace`.
- Adds **ADR-0009** formalising the three-layer voice enforcement shape (register → intent override → glossary) and explicitly rejecting ICU MessageFormat, Lingui, and Fluent.

## Changes

- `scripts/i18n/promptBuilder.ts` — `VOICE_PREAMBLE` + case/whitespace-insensitive dedup against register `banned_phrasings`.
- `scripts/i18n/intentLoader.ts` — new sidecar loader; strict schema, namespace-tagged errors, `.trim().min(1)` on `intent`/`audience`/`register`.
- `scripts/i18n/translator.ts` — `registerSchema` is now `.strict()`; mismatch comment for #180.
- `scripts/i18n/syncCore.ts` — wires `loadIntentSidecar` into the pipeline.
- `src/i18n/resources/_register/*.yml` — 14 new + 1 filled register YAMLs.
- `docs/decisions/ADR-0009-i18n-voice-enforcement.md` + `index.md` row.
- `docs/plans/i18n-llm-sync.md` — PR #8 landed entry + ADR-0009 link.

## Intent Verification

- [x] `buildSystemPrompt` produces a deterministic, non-empty string containing the full brand voice instructions when given a real register — not just skeleton placeholder text. Re-running with identical inputs returns byte-identical output.
- [x] All 15 register YAMLs load without error via `js-yaml` + `registerSchema` (the Zod schema already in `translator.ts`). Every field traces to a specific rule in `landing/docs/BRAND_LANGUAGE.md` — no fabricated voice rules.
- [x] When a register YAML exists but is empty (`{}` or `~` or blank), `translator.ts`'s `parseRegister` throws with the namespace name in the error message and does not fall back to a silent default.
- [x] When a register YAML is present but structurally invalid (missing required fields, wrong types), same hard-fail behavior as above.
- [x] The sidecar intent loader returns an empty record when the `.intents.json` file is absent. It returns a partial record when the file is present but some keys are missing. It hard-fails when the file exists but is not valid JSON.
- [x] `syncCore.syncOneNamespace` passes the loaded `intents` (or `undefined`) to `translateNamespace` — the sidecar wiring is live, not just a loader that nothing calls.
- [x] The three-layer composition (register → intent override → glossary) is tested end-to-end in a unit test: a namespace register with a banned phrasing, an intent sidecar that overrides audience for one key, and a glossary entry all appear correctly in the assembled system prompt.
- [x] ADR-0009 is added to `apps/native-rd/docs/decisions/`, appears in `index.md`, and explicitly names ICU MessageFormat, Lingui, and Fluent as rejected alternatives with rationale.
- [x] `bun run type-check` and `bun run lint` pass with no new errors.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| D1: Expand `promptBuilder.ts` in-place rather than a separate template file | `promptBuilder.ts` is already pure and well-tested; static string constants in existing sections keep one import boundary. |
| D2: Sidecar loader lives in a new `intentLoader.ts`, not inlined into `syncCore.ts` | Keeps loading logic independently testable; mirrors `translator.ts`'s `parseRegister` extraction. |
| D3: Sidecar loader hard-fails on present-but-invalid JSON; treats missing file as empty record | Issue contract: "missing-file graceful; present-but-empty graceful; present-but-invalid hard-fail." |
| D4: Zod validation for sidecar shape happens inside `intentLoader.ts` at load time | Implements `translator.ts`'s line-53-56 comment ("PR #8 wires the sidecar loader — add zod schemas + hard-fail at that boundary"). |
| D5: ADR number is 0009 (next in sequence) | `index.md` ends at ADR-0008. |
| D6: Static brand-voice copy is module-level non-exported string constants | Tests should assert on assembled output, not internal strings — keeps voice copy edits from breaking tests for the wrong reason. |
| U1: Voice preamble — draft → review → commit gate | Joe reviewed `VOICE_PREAMBLE` text before commit landed. |
| U2: `banned_phrasings` use brand-wide defaults, deduped at prompt-assembly | Each register carries the full brand-wide banned list; `promptBuilder` dedupes against system-prompt-level bans. Case+whitespace-insensitive dedup added in commit `510cff2`. |
| U3: Glossary loader deferred | Filed as #179 (sub-issue of #154, blocked by #162). `syncCore` continues to pass `glossary: undefined`. |
| U4: Sidecar wiring smoke-test in new `syncCore.intents.test.ts` | Focused unit test, not extending `sync.test.ts`. |
| U5: ADR-0009 alternative-rejection — terse bullets + one anchor paragraph | Names the relitigation risk explicitly; target ~80 LOC. |
| U6: Author registers for empty `badges`/`badgeDesigner` namespaces now | Pipeline never hard-fails on missing register file; ready when content is added. |

## Discovery Log

- [2026-05-25] Blocker #160 (PR #177) is confirmed merged — commit 8523718. `translator.ts`, `promptBuilder.ts`, `syncCore.ts` are all present. The `_register/common.yml` stub exists with empty `banned_phrasings: []` and `notes: []`.
- [2026-05-25] Decision #2 (register file location) is already resolved in `i18n-llm-sync.md` as of PR #177: `apps/native-rd/src/i18n/resources/_register/`. The `_register/` directory exists on `main`.
- [2026-05-25] `syncCore.ts` currently calls `translateNamespace` without `intents` or `glossary` (both undefined). Step 4 wires the sidecar — the glossary wire is out of scope here (no authored glossary content yet).
- [2026-05-25] `translator.ts` lines 53–56 contain an explicit comment: "PR #8 wires the sidecar loader — add zod schemas + hard-fail at that boundary then, mirroring registerSchema." This is an implementation instruction; `intentLoader.ts` in Step 3 fulfills it.
- [2026-05-25] `badges.json` and `badgeDesigner.json` are currently empty objects (`{}`). Their registers should be authored now (schema must be valid) but `banned_phrasings` can be the same brand-wide defaults. Sidecar files are not needed.
- [2026-05-25] The promptfoo `promptfooconfig.yaml` already seeds a German banned-phrase list: `oder nicht`, `oder lass es`. These should appear in the `VOICE_PREAMBLE` in `promptBuilder.ts` and/or in relevant register YAMLs — not just in the bake-off config.
- [2026-05-25] `BRAND_LANGUAGE.md` is at `landing/docs/BRAND_LANGUAGE.md` in the sibling `landing/` repo, not in the `issue-162-started` worktree. Access is via `/Users/joeczarnecki/Code/rollercoaster.dev/landing/docs/BRAND_LANGUAGE.md`. All register content must trace to this file.
- [2026-05-25] Namespace count confirmed: 15 (badgeDesigner, badges, captureFile, captureLink, capturePhoto, captureText, captureVideo, captureVoice, common, focusMode, goals, newGoal, permissions, settings, welcome).
- [2026-05-25] ADR sequence: next is 0009. ADR-0008 is the last entry in `index.md`.
- [2026-05-25] Post-review: silent-failure-hunter pass surfaced 4 findings. F1 (`registerSchema` non-strict), F2 (whitespace-only `intent` bypasses `min(1)`), F3 (empty `audience`/`register` silently elided) landed in this PR as commits `9e9ad11` and `432ed2a`. F4 (sidecar inert at runtime, no operator warning) filed as **#181** for inclusion alongside #180's fix. Pre-existing `lintSource.ts` nested-walker vs `intentLoader.ts` flat-key disagreement noted as a comment on **#180** for resolution in that fix.

## Test Plan

- [x] Type-check passes (`bun run type-check`)
- [x] Lint passes (`bun run lint` — 0 errors, 161 pre-existing warnings none in touched files)
- [x] Tests pass (`bun run test:ci` — 163 suites / 8441 tests)
- [x] Build script (no-op for native-rd) returns successfully

## Follow-ups filed

- **#179** — glossary loader (U3 deferral, blocked by #162)
- **#180** — re-key intent sidecar onto dict keys (code-reviewer F1 from review pass)
- **#181** — operator warning when sidecar entries are inert until #180 (silent-failure-hunter F4)

---

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)