### PR TITLE
fix(native-rd/i18n): expand preamble dedup to all banned phrases in VOICE_PREAMBLE (#183)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-183-promptbuilder-preamble-dedup.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-183-promptbuilder-preamble-dedup.md
@@ -1,0 +1,125 @@
+# Development Plan: Issue #183
+
+## Issue Summary
+
+**Title**: i18n/promptBuilder — dedup only covers banned exits, not every banned phrase named in VOICE_PREAMBLE
+**Type**: tech-debt / bug
+**Complexity**: TRIVIAL
+**Estimated Lines**: ~60 LOC (2 files: promptBuilder.ts + promptBuilder.test.ts)
+
+## Intent Verification
+
+Observable criteria a reviewer can verify by running the code or reading the diff.
+
+- [ ] When a register YAML lists `"leidet an"`, `"anders begabt"`, or `"besondere Bedürfnisse"` in `banned_phrasings`, those phrases do NOT appear as register bullet points in the assembled prompt — they are deduplicated away as preamble defaults.
+- [ ] When a register YAML lists `"besonders"`, `"einzigartig"`, `"Du schaffst das!"`, or `"Großartig!"` in `banned_phrasings`, those phrases do NOT appear as register bullet points — deduplicated away.
+- [ ] When a register's `banned_phrasings` contains only phrases already covered by `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive), the register section renders `(none beyond preamble defaults)`.
+- [ ] Dedup is case- and whitespace-insensitive for all three phrase groups (same normalization as the existing exit dedup).
+- [ ] The module docstring correctly says dedup is against `PREAMBLE_BANNED_ALL` (or equivalent), not just `PREAMBLE_BANNED_EXITS`.
+- [ ] `bun run type-check` and `bun run lint` pass clean.
+- [ ] All existing `promptBuilder.test.ts` tests continue to pass without modification.
+
+## Dependencies
+
+No blockers. Issue #182 (PR closed, deferred this fix) and PR #189 (re-key sidecar, now merged) are the prior-art commits — both are on `main`.
+
+| Issue | Title                                                          | Status           | Type      |
+| ----- | -------------------------------------------------------------- | ---------------- | --------- |
+| #182  | voice system prompt + per-namespace registers + sidecar loader | Merged (PR #182) | Prior-art |
+| #189  | re-key intent sidecar onto synthetic dict keys                 | Merged (PR #189) | Prior-art |
+
+**Status**: All dependencies met.
+
+## Objective
+
+Expand the preamble dedup set from 5 dismissive-exit phrases to all banned phrases named inline in `VOICE_PREAMBLE`. Concretely: add `PREAMBLE_BANNED_ND_VOCAB` and `PREAMBLE_BANNED_TOXIC_POSITIVE` constant arrays, build a combined `PREAMBLE_BANNED_ALL` set from all three, and dedup `register.banned_phrasings` against the combined set. The preamble prose itself is unchanged — only the dedup set widens.
+
+This closes the drift between the module docstring claim ("same phrase never appears twice") and runtime behaviour on all 15 current register YAMLs (every one lists at least one overlap phrase).
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                     | Alternatives Considered                                                    | Rationale                                                                                                                                                                                                                                          |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Option A: grouped constants + combined set, preamble prose unchanged                                                                                                                                                         | Option B: collapse to single source-of-truth and render preamble from data | Option B restructures the U1-gated voice preamble shape and requires Joe review. Option A is a pure expansion of the dedup set — zero change to the rendered preamble string, zero risk to the voice content, self-contained in ~20 LOC.           |
+| D2  | Export the three phrase arrays (`PREAMBLE_BANNED_ND_VOCAB`, `PREAMBLE_BANNED_TOXIC_POSITIVE`, `PREAMBLE_BANNED_EXITS`) as named exports so tests can assert against the canonical lists without hardcoding the phrases twice | Keep them module-private                                                   | The test for "falls back to '(none beyond preamble defaults)'" needs to supply the exact preamble phrases as input. Exporting avoids duplicating the lists in tests and makes future additions to a group automatically covered by existing tests. |
+
+## Affected Areas
+
+- `apps/native-rd/scripts/i18n/promptBuilder.ts`: add two phrase-group constants and their inline set; combine into `PREAMBLE_BANNED_ALL`; update `dedupedRegisterBans` to reference `PREAMBLE_BANNED_ALL`; update the module docstring one-liner; export all three phrase arrays.
+- `apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts`: add three new test cases covering ND-vocab dedup, toxic-positive dedup, and the `(none beyond preamble defaults)` fallback when only preamble-covered phrases are listed.
+
+## Implementation Plan
+
+### Step 1: Expand dedup constants and wire into `dedupedRegisterBans`
+
+**Files**: `apps/native-rd/scripts/i18n/promptBuilder.ts`
+
+**Commit**: `fix(i18n/promptBuilder): expand preamble dedup set to ND vocab and toxic-positive phrases`
+
+**Changes**:
+
+- [ ] After the existing `PREAMBLE_BANNED_EXITS` block (line 44–50), add:
+
+  ```ts
+  export const PREAMBLE_BANNED_ND_VOCAB: readonly string[] = [
+    "leidet an",
+    "anders begabt",
+    "besondere Bedürfnisse",
+  ];
+
+  export const PREAMBLE_BANNED_TOXIC_POSITIVE: readonly string[] = [
+    "besonders",
+    "einzigartig",
+    "Du schaffst das!",
+    "Großartig!",
+  ];
+  ```
+
+- [ ] Change `PREAMBLE_BANNED_EXITS` to `export const PREAMBLE_BANNED_EXITS` (so tests can reference it without hardcoding).
+- [ ] Replace the `PREAMBLE_BANNED_EXIT_SET` const with a combined set:
+  ```ts
+  const PREAMBLE_BANNED_ALL: ReadonlySet<string> = new Set(
+    [
+      ...PREAMBLE_BANNED_EXITS,
+      ...PREAMBLE_BANNED_ND_VOCAB,
+      ...PREAMBLE_BANNED_TOXIC_POSITIVE,
+    ].map(normalizeBan),
+  );
+  ```
+- [ ] In `dedupedRegisterBans`, replace `PREAMBLE_BANNED_EXIT_SET` with `PREAMBLE_BANNED_ALL`.
+- [ ] Update the module docstring (line 13) from "deduped against `PREAMBLE_BANNED_EXITS`" to "deduped against `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive phrases)".
+- [ ] Remove the now-unused `PREAMBLE_BANNED_EXIT_SET` const declaration (the combined set replaces it).
+
+### Step 2: Add tests covering the widened dedup set
+
+**Files**: `apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts`
+
+**Commit**: `test(i18n/promptBuilder): cover ND-vocab and toxic-positive preamble dedup`
+
+**Changes**:
+
+- [ ] Import `PREAMBLE_BANNED_ND_VOCAB`, `PREAMBLE_BANNED_TOXIC_POSITIVE`, `PREAMBLE_BANNED_EXITS` from `../promptBuilder`.
+- [ ] Add test: `"register banned_phrasings are deduped against preamble ND vocab phrases"` — supply each phrase from `PREAMBLE_BANNED_ND_VOCAB` plus one novel phrase; assert the ND-vocab items do not appear as register bullets, the novel phrase does.
+- [ ] Add test: `"register banned_phrasings are deduped against preamble toxic-positive phrases"` — same pattern for `PREAMBLE_BANNED_TOXIC_POSITIVE`.
+- [ ] Add test: `"register section falls back to '(none beyond preamble defaults)' when all listed phrasings are preamble-covered (exits + ND + toxic)"` — supply a mix of one exit, one ND vocab, one toxic-positive; assert the fallback string is rendered.
+
+## Testing Strategy
+
+- [ ] Run `bun test --testPathPatterns promptBuilder` after Step 1 (all existing tests must pass before Step 2 adds new ones).
+- [ ] Run `bun test --testPathPatterns promptBuilder` after Step 2 (all tests including new ones must pass).
+- [ ] Run `bun run type-check` and `bun run lint` after Step 1.
+- [ ] No manual testing required — `promptBuilder` is a pure function with full unit coverage.
+
+## Not in Scope
+
+| Item                                                        | Reason                                                                                                                                                                     | Follow-up                                                                              |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Option B (render VOICE_PREAMBLE from data)                  | Restructures the U1-gated preamble shape; requires Joe review before touching                                                                                              | none filed yet — can be raised as a follow-up if Joe wants full single-source-of-truth |
+| Removing the overlapping phrases from the 15 register YAMLs | The YAMLs are YAML source of truth for register-level voice intent; dedup in promptBuilder is the right fix layer. The redundant YAML entries are now harmlessly filtered. | none needed — filtering at assembly time is the contract                               |
+| Updating ADR-0009                                           | ADR-0009 §Composition already says "deduped against the preamble" without naming the specific constant. The fix is consistent with that language — no amendment needed.    | none                                                                                   |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/docs/plans/dev-plans/issue-183-promptbuilder-preamble-dedup.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-183-promptbuilder-preamble-dedup.md
@@ -11,13 +11,13 @@
 
 Observable criteria a reviewer can verify by running the code or reading the diff.
 
-- [ ] When a register YAML lists `"leidet an"`, `"anders begabt"`, or `"besondere Bedürfnisse"` in `banned_phrasings`, those phrases do NOT appear as register bullet points in the assembled prompt — they are deduplicated away as preamble defaults.
-- [ ] When a register YAML lists `"besonders"`, `"einzigartig"`, `"Du schaffst das!"`, or `"Großartig!"` in `banned_phrasings`, those phrases do NOT appear as register bullet points — deduplicated away.
-- [ ] When a register's `banned_phrasings` contains only phrases already covered by `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive), the register section renders `(none beyond preamble defaults)`.
-- [ ] Dedup is case- and whitespace-insensitive for all three phrase groups (same normalization as the existing exit dedup).
-- [ ] The module docstring correctly says dedup is against `PREAMBLE_BANNED_ALL` (or equivalent), not just `PREAMBLE_BANNED_EXITS`.
-- [ ] `bun run type-check` and `bun run lint` pass clean.
-- [ ] All existing `promptBuilder.test.ts` tests continue to pass without modification.
+- [x] When a register YAML lists `"leidet an"`, `"anders begabt"`, or `"besondere Bedürfnisse"` in `banned_phrasings`, those phrases do NOT appear as register bullet points in the assembled prompt — they are deduplicated away as preamble defaults.
+- [x] When a register YAML lists `"besonders"`, `"einzigartig"`, `"Du schaffst das!"`, or `"Großartig!"` in `banned_phrasings`, those phrases do NOT appear as register bullet points — deduplicated away.
+- [x] When a register's `banned_phrasings` contains only phrases already covered by `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive), the register section renders `(none beyond preamble defaults)`.
+- [x] Dedup is case- and whitespace-insensitive for all three phrase groups (same normalization as the existing exit dedup).
+- [x] The module docstring correctly says dedup is against `PREAMBLE_BANNED_ALL` (or equivalent), not just `PREAMBLE_BANNED_EXITS`.
+- [x] `bun run type-check` and `bun run lint` pass clean.
+- [x] All existing `promptBuilder.test.ts` tests continue to pass without modification.
 
 ## Dependencies
 
@@ -58,7 +58,7 @@ This closes the drift between the module docstring claim ("same phrase never app
 
 **Changes**:
 
-- [ ] After the existing `PREAMBLE_BANNED_EXITS` block (line 44–50), add:
+- [x] After the existing `PREAMBLE_BANNED_EXITS` block (line 44–50), add:
 
   ```ts
   export const PREAMBLE_BANNED_ND_VOCAB: readonly string[] = [
@@ -75,8 +75,8 @@ This closes the drift between the module docstring claim ("same phrase never app
   ];
   ```
 
-- [ ] Change `PREAMBLE_BANNED_EXITS` to `export const PREAMBLE_BANNED_EXITS` (so tests can reference it without hardcoding).
-- [ ] Replace the `PREAMBLE_BANNED_EXIT_SET` const with a combined set:
+- [x] Change `PREAMBLE_BANNED_EXITS` to `export const PREAMBLE_BANNED_EXITS` (so tests can reference it without hardcoding).
+- [x] Replace the `PREAMBLE_BANNED_EXIT_SET` const with a combined set:
   ```ts
   const PREAMBLE_BANNED_ALL: ReadonlySet<string> = new Set(
     [
@@ -86,9 +86,9 @@ This closes the drift between the module docstring claim ("same phrase never app
     ].map(normalizeBan),
   );
   ```
-- [ ] In `dedupedRegisterBans`, replace `PREAMBLE_BANNED_EXIT_SET` with `PREAMBLE_BANNED_ALL`.
-- [ ] Update the module docstring (line 13) from "deduped against `PREAMBLE_BANNED_EXITS`" to "deduped against `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive phrases)".
-- [ ] Remove the now-unused `PREAMBLE_BANNED_EXIT_SET` const declaration (the combined set replaces it).
+- [x] In `dedupedRegisterBans`, replace `PREAMBLE_BANNED_EXIT_SET` with `PREAMBLE_BANNED_ALL`.
+- [x] Update the module docstring (line 13) from "deduped against `PREAMBLE_BANNED_EXITS`" to "deduped against `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive phrases)".
+- [x] Remove the now-unused `PREAMBLE_BANNED_EXIT_SET` const declaration (the combined set replaces it).
 
 ### Step 2: Add tests covering the widened dedup set
 
@@ -98,17 +98,17 @@ This closes the drift between the module docstring claim ("same phrase never app
 
 **Changes**:
 
-- [ ] Import `PREAMBLE_BANNED_ND_VOCAB`, `PREAMBLE_BANNED_TOXIC_POSITIVE`, `PREAMBLE_BANNED_EXITS` from `../promptBuilder`.
-- [ ] Add test: `"register banned_phrasings are deduped against preamble ND vocab phrases"` — supply each phrase from `PREAMBLE_BANNED_ND_VOCAB` plus one novel phrase; assert the ND-vocab items do not appear as register bullets, the novel phrase does.
-- [ ] Add test: `"register banned_phrasings are deduped against preamble toxic-positive phrases"` — same pattern for `PREAMBLE_BANNED_TOXIC_POSITIVE`.
-- [ ] Add test: `"register section falls back to '(none beyond preamble defaults)' when all listed phrasings are preamble-covered (exits + ND + toxic)"` — supply a mix of one exit, one ND vocab, one toxic-positive; assert the fallback string is rendered.
+- [x] Import `PREAMBLE_BANNED_ND_VOCAB`, `PREAMBLE_BANNED_TOXIC_POSITIVE`, `PREAMBLE_BANNED_EXITS` from `../promptBuilder`.
+- [x] Add test: `"register banned_phrasings are deduped against preamble ND vocab phrases"` — supply each phrase from `PREAMBLE_BANNED_ND_VOCAB` plus one novel phrase; assert the ND-vocab items do not appear as register bullets, the novel phrase does.
+- [x] Add test: `"register banned_phrasings are deduped against preamble toxic-positive phrases"` — same pattern for `PREAMBLE_BANNED_TOXIC_POSITIVE`.
+- [x] Add test: `"register section falls back to '(none beyond preamble defaults)' when all listed phrasings are preamble-covered (exits + ND + toxic)"` — supply a mix of one exit, one ND vocab, one toxic-positive; assert the fallback string is rendered.
 
 ## Testing Strategy
 
-- [ ] Run `bun test --testPathPatterns promptBuilder` after Step 1 (all existing tests must pass before Step 2 adds new ones).
-- [ ] Run `bun test --testPathPatterns promptBuilder` after Step 2 (all tests including new ones must pass).
-- [ ] Run `bun run type-check` and `bun run lint` after Step 1.
-- [ ] No manual testing required — `promptBuilder` is a pure function with full unit coverage.
+- [x] Run `bun test --testPathPatterns promptBuilder` after Step 1 (all existing tests must pass before Step 2 adds new ones).
+- [x] Run `bun test --testPathPatterns promptBuilder` after Step 2 (all tests including new ones must pass).
+- [x] Run `bun run type-check` and `bun run lint` after Step 1.
+- [x] No manual testing required — `promptBuilder` is a pure function with full unit coverage.
 
 ## Not in Scope
 

--- a/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
+++ b/apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts
@@ -1,5 +1,8 @@
 import {
   buildSystemPrompt,
+  PREAMBLE_BANNED_EXITS,
+  PREAMBLE_BANNED_ND_VOCAB,
+  PREAMBLE_BANNED_TOXIC_POSITIVE,
   type IntentEntry,
   type RegisterData,
 } from "../promptBuilder";
@@ -230,6 +233,52 @@ describe("buildSystemPrompt", () => {
       register: {
         ...BASE_REGISTER,
         banned_phrasings: ["oder nicht", "oder lass es"],
+      },
+    });
+    expect(out).toContain("(none beyond preamble defaults)");
+  });
+
+  test("register banned_phrasings are deduped against preamble ND deficit-framing vocab", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: [...PREAMBLE_BANNED_ND_VOCAB, "novel ND filler"],
+      },
+    });
+    // Each ND-vocab phrase appears only in the preamble prose, not as a
+    // register bullet. The preamble lists them in prose context like
+    // "Never `leidet an` …", so a bullet-prefixed copy would be a dup.
+    for (const phrase of PREAMBLE_BANNED_ND_VOCAB) {
+      expect(out).not.toContain(`- ${phrase}`);
+    }
+    expect(out).toContain("- novel ND filler");
+  });
+
+  test("register banned_phrasings are deduped against preamble toxic-positive phrases", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: [
+          ...PREAMBLE_BANNED_TOXIC_POSITIVE,
+          "novel positive filler",
+        ],
+      },
+    });
+    for (const phrase of PREAMBLE_BANNED_TOXIC_POSITIVE) {
+      expect(out).not.toContain(`- ${phrase}`);
+    }
+    expect(out).toContain("- novel positive filler");
+  });
+
+  test("register section falls back to '(none beyond preamble defaults)' across all three preamble phrase groups", () => {
+    const out = buildSystemPrompt({
+      register: {
+        ...BASE_REGISTER,
+        banned_phrasings: [
+          PREAMBLE_BANNED_EXITS[0],
+          PREAMBLE_BANNED_ND_VOCAB[0],
+          PREAMBLE_BANNED_TOXIC_POSITIVE[0],
+        ],
       },
     });
     expect(out).toContain("(none beyond preamble defaults)");

--- a/apps/native-rd/scripts/i18n/promptBuilder.ts
+++ b/apps/native-rd/scripts/i18n/promptBuilder.ts
@@ -10,7 +10,8 @@
  *
  * `VOICE_PREAMBLE` carries the brand-wide voice instructions sourced from
  * `landing/docs/BRAND_LANGUAGE.md`. Register `banned_phrasings` are deduped
- * against `PREAMBLE_BANNED_EXITS` at assembly time so the same phrase never
+ * against `PREAMBLE_BANNED_ALL` (dismissive exits + ND deficit-framing vocab
+ * + toxic-positive phrases) at assembly time so the same phrase never
  * appears twice in the assembled prompt.
  *
  * Pure: no I/O, no `import.meta`, no clock/random — same inputs in, same
@@ -41,12 +42,32 @@ export type PromptBuilderInput = {
 // into the preamble below AND used to dedup register `banned_phrasings` at
 // assembly time — keeping these in one constant avoids the two layers
 // drifting out of sync.
-const PREAMBLE_BANNED_EXITS: readonly string[] = [
+export const PREAMBLE_BANNED_EXITS: readonly string[] = [
   "oder nicht",
   "oder lass es",
   "oder mach's halt nicht",
   "schließ den Tab",
   "wir sind hier wenn du zurückkommst",
+];
+
+// ND deficit-framing phrases named inline in the preamble below. Not
+// rendered from this constant — the preamble lists them in prose. Used
+// only as dedup input so register YAMLs that repeat these don't surface
+// the same phrase twice in the assembled prompt.
+export const PREAMBLE_BANNED_ND_VOCAB: readonly string[] = [
+  "leidet an",
+  "anders begabt",
+  "besondere Bedürfnisse",
+];
+
+// Patronising / toxic-positive phrases named inline in the preamble below.
+// Same contract as PREAMBLE_BANNED_ND_VOCAB — dedup-only, not rendered
+// from this constant.
+export const PREAMBLE_BANNED_TOXIC_POSITIVE: readonly string[] = [
+  "besonders",
+  "einzigartig",
+  "Du schaffst das!",
+  "Großartig!",
 ];
 
 // Compare deduplication on a normalized form so 15 hand-authored YAML
@@ -58,8 +79,12 @@ function normalizeBan(phrase: string): string {
   return phrase.trim().toLowerCase();
 }
 
-const PREAMBLE_BANNED_EXIT_SET: ReadonlySet<string> = new Set(
-  PREAMBLE_BANNED_EXITS.map(normalizeBan),
+const PREAMBLE_BANNED_ALL: ReadonlySet<string> = new Set(
+  [
+    ...PREAMBLE_BANNED_EXITS,
+    ...PREAMBLE_BANNED_ND_VOCAB,
+    ...PREAMBLE_BANNED_TOXIC_POSITIVE,
+  ].map(normalizeBan),
 );
 
 const PREAMBLE_BANNED_EXITS_INLINE = PREAMBLE_BANNED_EXITS.map(
@@ -108,7 +133,7 @@ function dedupedRegisterBans(bans: readonly string[]): string[] {
   const out: string[] = [];
   for (const phrase of bans) {
     const norm = normalizeBan(phrase);
-    if (PREAMBLE_BANNED_EXIT_SET.has(norm) || seen.has(norm)) continue;
+    if (PREAMBLE_BANNED_ALL.has(norm) || seen.has(norm)) continue;
     seen.add(norm);
     out.push(phrase);
   }


### PR DESCRIPTION
## Summary

- `promptBuilder.ts` dedup set only covered the 5 dismissive-exit phrases, but `VOICE_PREAMBLE` also names 3 ND deficit-framing and 4 toxic-positive phrases inline. All 15 register YAMLs currently list at least one of those 7 phrases, so the assembled prompt was emitting them in both the preamble prose AND the register bullet list.
- Adds `PREAMBLE_BANNED_ND_VOCAB` and `PREAMBLE_BANNED_TOXIC_POSITIVE`, combines all three groups into `PREAMBLE_BANNED_ALL`, and points the existing `dedupedRegisterBans` at the combined set.
- `VOICE_PREAMBLE` prose intentionally unchanged — only the dedup set widens. The U1-gated voice content is preserved.

## Changes

- `apps/native-rd/scripts/i18n/promptBuilder.ts`: two new exported `readonly string[]` constants (ND vocab + toxic-positive); `PREAMBLE_BANNED_EXITS` made `export`; `PREAMBLE_BANNED_EXIT_SET` → `PREAMBLE_BANNED_ALL` built from all three groups via `normalizeBan`; module docstring updated.
- `apps/native-rd/scripts/i18n/__tests__/promptBuilder.test.ts`: 3 new tests iterating the imported constants — ND-vocab dedup, toxic-positive dedup, and a cross-group fallback case for `(none beyond preamble defaults)`.
- `apps/native-rd/docs/plans/dev-plans/issue-183-promptbuilder-preamble-dedup.md`: dev plan checked off.

## Intent Verification

- [x] When a register YAML lists `"leidet an"`, `"anders begabt"`, or `"besondere Bedürfnisse"` in `banned_phrasings`, those phrases do NOT appear as register bullet points in the assembled prompt — they are deduplicated away as preamble defaults.
- [x] When a register YAML lists `"besonders"`, `"einzigartig"`, `"Du schaffst das!"`, or `"Großartig!"` in `banned_phrasings`, those phrases do NOT appear as register bullet points — deduplicated away.
- [x] When a register's `banned_phrasings` contains only phrases already covered by `PREAMBLE_BANNED_ALL` (exits + ND vocab + toxic-positive), the register section renders `(none beyond preamble defaults)`.
- [x] Dedup is case- and whitespace-insensitive for all three phrase groups (same normalization as the existing exit dedup).
- [x] The module docstring correctly says dedup is against `PREAMBLE_BANNED_ALL` (or equivalent), not just `PREAMBLE_BANNED_EXITS`.
- [x] `bun run type-check` and `bun run lint` pass clean.
- [x] All existing `promptBuilder.test.ts` tests continue to pass without modification.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Option A: grouped constants + combined set, preamble prose unchanged | Option B (collapse to single source-of-truth + render preamble from data) restructures the U1-gated voice preamble shape and requires Joe review. Option A is a pure expansion of the dedup set — zero change to the rendered preamble string, self-contained in ~20 LOC. |
| Export the three phrase arrays as named exports | Tests can assert against the canonical lists without hardcoding the phrases twice. Future additions to any group are automatically covered by the iterating tests. |

## Review notes (non-blocking)

Test-analyzer flagged two medium-severity (gap 6) follow-ups that the code-reviewer judged safe given current preamble prose:

- The two new dedup tests use `not.toContain("- ${phrase}")` rather than the occurrence-counting `match(...).length === 1` pattern used by the existing exits-dedup test. Substring-trap is currently inert because `"besonders"` appears only inside quotes in the preamble prose, but tightening to occurrence-counting would harden against future preamble edits.
- The case/whitespace-insensitive test still only feeds exit phrases. Extending it via `test.each` over all three groups would catch a hypothetical regression where one group bypassed `normalizeBan`.

Neither is a current bug — flagging here so the human reviewer can decide whether to fold into this PR or fast-follow.

## Test Plan

- [x] `bun run type-check` passes
- [x] `bun run lint` passes (0 errors)
- [x] `bun test --testPathPatterns promptBuilder` — 24/24 pass (21 existing + 3 new)
- [x] `bun run build` returns successfully (no-op for native-rd)

---

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)