### PR TITLE
test(native-rd): add stable testIDs to load-bearing UI to decouple test churn (#64)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-64-testids-decouple-test-churn.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-64-testids-decouple-test-churn.md
@@ -1,0 +1,185 @@
+# Development Plan: Issue #64
+
+## Issue Summary
+
+**Title**: i18n: add stable testIDs to load-bearing UI to decouple test churn
+**Type**: refactor / test hygiene
+**Complexity**: SMALL
+**Estimated Lines**: ~360 lines changed (tests ~300, source ~60)
+
+## Intent Verification
+
+Observable criteria derived from the issue. These describe what success looks like from a user/system perspective — not generic checklists.
+
+- [x] Every `fireEvent.press` or `fireEvent` targeting a load-bearing interactive element (GoalCard, StepCard mark-complete, EditMode CTA button) uses `getByTestId` or an accessibility-role query — not `getByText` on UI copy
+- [x] `getByText("Step 1 of 2")`, `getByText("Mark complete")`, `getByText("Focus Mode")`, `getByText("Goal not found.")` and similar i18n-wrapped strings are replaced with `i18n.t()` lookups in FocusModeScreen.test.tsx
+- [x] `getByText("Start Working")` / `getByText("Back to Focus")` in EditModeScreen.test.tsx use `getByTestId("start-working")` / `getByTestId("back-to-focus")` (testIDs already exist in source)
+- [x] `getByText("00:00")` in VoiceMemoScreen.test.tsx and CaptureVideoScreen.test.tsx uses `getByTestId("voice-timer")` / `getByTestId("video-recorder-timer")` (with `toHaveTextContent` to keep the value check)
+- [x] `getByRole("button")` / `getByRole("checkbox")` accessibility-driven queries are preserved everywhere they are already stronger than testID; checkbox/dialog presses upgraded _to_ role queries (D1)
+- [x] All Jest tests pass: `npx jest --no-coverage`
+
+## Dependencies
+
+| Issue | Title                                                     | Status    | Type    |
+| ----- | --------------------------------------------------------- | --------- | ------- |
+| #70   | i18n: migrate evidence capture (photo, video, voice memo) | ✅ CLOSED | Blocker |
+| #71   | i18n: migrate evidence capture (text note, file, link)    | ✅ CLOSED | Blocker |
+| #72   | i18n: migrate evidence capture permission-denied UI       | ✅ CLOSED | Blocker |
+
+**Status**: ✅ All dependencies met
+
+## Objective
+
+Replace brittle `getByText("English copy")` assertions in screen tests with stable queries — either `getByTestId`, `getByRole`, or `i18n.t()`-wrapped `getByText`. Add the small number of source testIDs needed to support the new queries. Preserve all a11y-driven assertions.
+
+## Decisions
+
+| ID  | Decision                                                                                                                      | Alternatives Considered                        | Rationale                                                                                                                                                           |
+| --- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Replace "Mark complete" via `getByRole("checkbox", { name: i18n.t(...) })`, not a new testID                                  | Add `testID="step-card-checkbox"` to Checkbox  | `Checkbox` already exposes `accessibilityRole="checkbox"` + `accessibilityLabel`; role query is stronger a11y coverage                                              |
+| D2  | Keep `getByText("Badges")` in FocusPillTabBar line 96                                                                         | Replace with testID                            | That assertion intentionally verifies label text is visible for the active tab — it is the behavior under test, not a proxy for element presence                    |
+| D3  | Keep `getByText("Learn TypeScript")` / goal title assertions that verify USER DATA renders                                    | Replace with testID                            | Goal titles are dynamic user content, not UI copy; asserting by value is correct here                                                                               |
+| D4  | Replace `getByText("Learn TypeScript")` in `fireEvent` calls (GoalCard press/longPress) with `getByTestId(`goal-card-${id}`)` | Keep text-based fireEvent                      | Text-based fireEvent on a translatable label is brittle; testID targets the correct interaction surface                                                             |
+| D5  | Replace `getByText("Step 1 of 2")` etc. with `i18n.t("common:stepCard.progress", {...})` in tests                             | Add testID to step counter Text                | Step counter text is already i18n-wrapped in source; test just needs to use the same key. No source change needed.                                                  |
+| D6  | Add `testID="voice-timer"` to VoiceMemoScreen timer Text; `testID="video-recorder-timer"` to VideoRecorder timer Text         | Use `getByLabelText` with the a11y timer label | Timer elements already have `accessibilityLabel` with formatted time — `getByLabelText` is also valid here. testID is slightly clearer for a purely visual element. |
+| D7  | Add `testID={`goal-card-${goal.id}`}` to GoalCard root                                                                        | Static testID                                  | Dynamic ID lets test fixture target specific cards by ID                                                                                                            |
+
+## Affected Areas
+
+- `src/components/GoalCard/GoalCard.tsx`: add `testID` prop (dynamic, keyed on `goal.id`)
+- `src/components/VideoRecorder/VideoRecorder.tsx`: add `testID="video-recorder-timer"` to the recording timer `Text`
+- `src/screens/VoiceMemoScreen/VoiceMemoScreen.tsx`: add `testID="voice-timer"` to the timer `Text`
+- `src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx`: migrate `fireEvent` calls from `getByText(title)` to `getByTestId(`goal-card-${id}`)`; keep `getByText` assertions that verify user data renders
+- `src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx`: replace ~30 brittle assertions (Step N of M, Mark complete, Focus Mode, Goal not found, Delete evidence?, Delete, Cancel, Evidence deleted, Could not update step) with `i18n.t()` equivalents; replace `fireEvent.press(getByText("Mark complete"))` with `getByRole("checkbox", { name: i18n.t(...) })`
+- `src/screens/EditModeScreen/__tests__/EditModeScreen.test.tsx`: replace `getByText("Start Working")` / `getByText("Back to Focus")` with existing `getByTestId`; replace `getByText("Edit Goal")`, `getByText("Goal not found.")`, `getByText("3 steps")`, `getByText("Title cannot be empty")`, `getByText("Failed to update title")` with `i18n.t()` equivalents
+- `src/screens/WelcomeScreen/__tests__/WelcomeScreen.test.tsx`: replace `/rollercoaster\.dev is your personal goal tracker\./` regex with `i18n.t("welcome:intro.body1")`
+- `src/screens/VoiceMemoScreen/__tests__/VoiceMemoScreen.test.tsx`: replace `getByText("00:00")` etc. with `getByTestId("voice-timer")`
+- `src/screens/CaptureVideoScreen/__tests__/CaptureVideoScreen.test.tsx`: replace `getByText("00:00")` with `getByTestId("video-recorder-timer")`
+
+## Implementation Plan
+
+### Step 1: Add testIDs to GoalCard and timer components
+
+**Files**:
+
+- `src/components/GoalCard/GoalCard.tsx`
+- `src/screens/VoiceMemoScreen/VoiceMemoScreen.tsx`
+- `src/components/VideoRecorder/VideoRecorder.tsx`
+
+**Commit**: `test(testids): add testID to GoalCard, VoiceMemo timer, VideoRecorder timer`
+
+**Changes**:
+
+- [x] In `GoalCard.tsx`: pass `testID={`goal-card-${goal.id}`}` to the root `<Card>` component. Verify `Card` forwards `testID` — if not, add `testID?: string` to `CardProps` and forward it.
+- [x] In `VoiceMemoScreen.tsx`: add `testID="voice-timer"` to the `<Text style={styles.timerText} ...>` element (around line 161)
+- [x] In `VideoRecorder.tsx`: add `testID="video-recorder-timer"` to the recording-mode timer `<Text>` element (around line 289, the one with `styles.timerRecording`)
+
+**Note on Card forwarding**: Check `src/components/Card/Card.tsx` for testID prop forwarding before making this change.
+
+### Step 2: Migrate GoalsScreen test to testID-based fireEvent
+
+**Files**:
+
+- `src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx`
+
+**Commit**: `test(testids): migrate GoalsScreen fireEvent to goal-card testID`
+
+**Changes**:
+
+- [x] Replace all `fireEvent.press(screen.getByText("Learn TypeScript"))` with `fireEvent.press(screen.getByTestId("goal-card-goal-1"))` (using the test fixture's known ID)
+- [x] Replace all `fireEvent(screen.getByText("Learn TypeScript"), "longPress")` with `fireEvent(screen.getByTestId("goal-card-goal-1"), "longPress")`
+- [x] Keep `expect(screen.getByText("Learn TypeScript")).toBeOnTheScreen()` — asserting that user-data goal titles render is correct and should not be changed
+- [x] Keep `expect(screen.getByText("Open a savings account")).toBeOnTheScreen()` — same rationale (next-step title is user data)
+
+### Step 3: Migrate FocusModeScreen test assertions
+
+**Files**:
+
+- `src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx`
+
+**Commit**: `test(testids): migrate FocusModeScreen assertions to i18n.t() and role queries`
+
+**Changes**:
+
+- [x] `getByText("Focus Mode")` → `getByText(i18n.t("focusMode:title"))`
+- [x] `getByText("Goal not found.")` → `getByText(i18n.t("focusMode:errors.goalNotFound"))`
+- [x] `getByText("Step 1 of 2")` → `getByText(i18n.t("common:stepCard.progress", { current: 1, total: 2 }))` (and similarly for all Step N of M variants)
+- [x] `fireEvent.press(screen.getByText("Mark complete"))` → `fireEvent.press(screen.getByRole("checkbox", { name: i18n.t("common:stepCard.checkbox.markComplete") }))`
+- [x] `screen.getAllByText("Completed")` (line ~415) → `screen.getAllByRole("checkbox", { name: i18n.t("common:stepCard.checkbox.completed") })` — but note: "Completed" also appears as a StatusBadge. After i18n migration of StatusBadge, check what the assertion is actually testing. If it counts both StatusBadge and checkbox labels, a different approach (e.g. `getAllByLabelText`) may be needed. See open question OQ-1.
+- [x] `getByText("Delete evidence?")` → `getByText(i18n.t("focusMode:confirmDelete.title"))`
+- [x] `fireEvent.press(screen.getByText("Delete"))` → `fireEvent.press(screen.getByRole("button", { name: i18n.t("common:actions.delete") }))`
+- [x] `fireEvent.press(screen.getByText("Cancel"))` → `fireEvent.press(screen.getByRole("button", { name: i18n.t("common:actions.cancel") }))`
+- [x] `getByText("Evidence deleted")` → `getByText(i18n.t("focusMode:toast.evidenceDeleted"))`
+- [x] `getByText("Could not update step: DB write failed")` → `getByText(i18n.t("focusMode:errors.couldNotUpdateStep", { message: "DB write failed" }))`
+- [x] `getByText("Something went wrong")` — check the i18n key (`focusMode:errors.somethingWrong`) and which test uses this
+- [x] Keep step title assertions: `getByText("Read docs")`, `getByText("Practice")`, `getByText("Build it")` — these are user-data step titles from the test fixture, not UI copy
+
+### Step 4: Migrate EditModeScreen test assertions
+
+**Files**:
+
+- `src/screens/EditModeScreen/__tests__/EditModeScreen.test.tsx`
+
+**Commit**: `test(testids): migrate EditModeScreen assertions to i18n.t() and existing testIDs`
+
+**Changes**:
+
+- [x] `getByText("Edit Goal")` → `getByText(i18n.t("editGoal:title"))`
+- [x] `getByText("Goal not found.")` → `getByText(i18n.t("editGoal:errors.goalNotFound"))`
+- [x] `getByText("3 steps")` → `getByText(i18n.t("editGoal:stepList.count_other", { count: 3 }))`
+- [x] `getByText("Title cannot be empty")` → `getByText(i18n.t("editGoal:errors.titleRequired"))`
+- [x] `getByText("Failed to update title")` → `getByText(i18n.t("editGoal:errors.updateTitleFailed"))`
+- [x] `getByText("Start Working")` (in `expect`) → `getByTestId("start-working")`
+- [x] `getByText("Back to Focus")` (in `expect`) → `getByTestId("back-to-focus")`
+- [x] `fireEvent.press(screen.getByText("Start Working"))` → `fireEvent.press(screen.getByTestId("start-working"))`
+- [x] `getByRole("button", { name: "Start Working" })` → `getByTestId("start-working")` OR keep role query with i18n name — check which is more readable in context
+- [x] Keep step-title assertions: `getByText("Read docs")`, `getByText("Practice")`, `getByText("Build project")` — user data
+
+### Step 5: Migrate WelcomeScreen and timer test assertions
+
+**Files**:
+
+- `src/screens/WelcomeScreen/__tests__/WelcomeScreen.test.tsx`
+- `src/screens/VoiceMemoScreen/__tests__/VoiceMemoScreen.test.tsx`
+- `src/screens/CaptureVideoScreen/__tests__/CaptureVideoScreen.test.tsx`
+
+**Commit**: `test(testids): migrate WelcomeScreen regex + timer getByText to stable queries`
+
+**Changes**:
+
+- [x] In `WelcomeScreen.test.tsx`: replace `screen.getByText(/rollercoaster\.dev is your personal goal tracker\./)` with `screen.getByText(i18n.t("welcome:intro.body1"))`
+- [x] In `VoiceMemoScreen.test.tsx`: replace `screen.getByText("00:00")` → `screen.getByTestId("voice-timer")`; `screen.getByText("00:03")` → `screen.getByTestId("voice-timer")`; `screen.getByText("00:10")` → `screen.getByTestId("voice-timer")`; `screen.getByText("01:05")` → `screen.getByTestId("voice-timer")`
+- [x] In `CaptureVideoScreen.test.tsx`: replace `screen.getByText("00:00")` → `screen.getByTestId("video-recorder-timer")`
+
+## Testing Strategy
+
+- [x] Run full test suite after each step: `npx jest --no-coverage`
+- [x] Run targeted tests during each step:
+  - Step 1: `bun test --testPathPatterns GoalCard`
+  - Step 2: `bun test --testPathPatterns GoalsScreen`
+  - Step 3: `bun test --testPathPatterns FocusModeScreen`
+  - Step 4: `bun test --testPathPatterns EditModeScreen`
+  - Step 5: `bun test --testPathPatterns "WelcomeScreen|VoiceMemo|CaptureVideo"`
+- [x] No snapshot updates expected (no snapshots exist for these screens)
+- [x] Type-check after source changes: `bun run type-check`
+
+## Not in Scope
+
+| Item                                                                                                | Reason                                                                                                                                | Follow-up                                      |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Adding testIDs to BadgesScreen, BadgeDetailScreen, CompletionFlowScreen, EvidenceViewerScreen tests | These screens have brittle text assertions but are not in the issue's named scope (Welcome, Goals, Focus, NewGoal, Settings, capture) | Issue #64 can be extended or a new issue filed |
+| Adding testIDs to component tests (StepList, GoalEvidenceCard, EvidenceDrawer, etc.)                | Component-level getByText assertions are testing component behavior, not screen integration — lower priority                          | None                                           |
+| Adding testIDs to badge screen tests (BadgeDesignerScreen, BadgeRenderer)                           | Not in i18n migration scope for this milestone                                                                                        | None                                           |
+| Migrating `getByText` assertions on user-generated content (goal titles, step titles) to testID     | User-data assertions by value are semantically correct                                                                                | None                                           |
+| Pseudo-locale test assertions that use `getByText(pseudo)`                                          | These are already correct — they test i18n routing                                                                                    | None                                           |
+
+## Open Questions
+
+**OQ-1 — RESOLVED**: `getByRole("checkbox", { name: i18n.t("common:stepCard.checkbox.completed") })` scopes cleanly to the Checkbox — the StatusBadge has no checkbox role, so the ambiguity is gone with no source testID needed. Both `getAllByText("Completed")[length-1]` sites replaced with a single `getByRole` call. All 52 FocusModeScreen tests pass.
+
+**OQ-2 — Card component testID forwarding**: `GoalCard` uses the shared `Card` component as its root. Before Step 1, verify `Card.tsx` accepts and forwards a `testID` prop. If not, a one-line prop-forwarding change is needed there too.
+
+## Discovery Log
+
+- [2026-05-27] OQ-2 resolved: `Card.tsx` did NOT forward `testID`. Added `testID?: string` to `CardProps` and forwarded to both the `Pressable` branch and the `View` branch. Custom `Text` component already spreads `...rest` to RN `Text`, so the timer testIDs forward with no `Text.tsx` change needed.
+- [2026-05-27] `bun test --testPathPatterns` finds no files (bun's native runner doesn't match the jest suites); used `npx jest --no-coverage --testPathPatterns` instead, per `apps/native-rd/CLAUDE.md`. Step 1 source-change tests: 62 passed.

--- a/apps/native-rd/src/components/Card/Card.tsx
+++ b/apps/native-rd/src/components/Card/Card.tsx
@@ -11,6 +11,7 @@ export interface CardProps {
   onLongPress?: () => void;
   accessibilityLabel?: string;
   accessibilityHint?: string;
+  testID?: string;
 }
 
 export function Card({
@@ -20,6 +21,7 @@ export function Card({
   onLongPress,
   accessibilityLabel,
   accessibilityHint,
+  testID,
 }: CardProps) {
   if (onPress || onLongPress) {
     return (
@@ -30,6 +32,7 @@ export function Card({
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
+        testID={testID}
         style={({ pressed }) => [
           styles.pressable(size),
           pressed && styles.pressed,
@@ -40,5 +43,9 @@ export function Card({
     );
   }
 
-  return <View style={styles.container(size)}>{children}</View>;
+  return (
+    <View style={styles.container(size)} testID={testID}>
+      {children}
+    </View>
+  );
 }

--- a/apps/native-rd/src/components/GoalCard/GoalCard.tsx
+++ b/apps/native-rd/src/components/GoalCard/GoalCard.tsx
@@ -47,6 +47,7 @@ export function GoalCard({ goal, onPress, onLongPress }: GoalCardProps) {
       onLongPress={onLongPress}
       accessibilityLabel={onPress ? accessibilityLabel : undefined}
       accessibilityHint={onPress ? t("card.a11y.hint") : undefined}
+      testID={`goal-card-${goal.id}`}
     >
       <View style={styles.header}>
         <Text

--- a/apps/native-rd/src/components/VideoRecorder/VideoRecorder.tsx
+++ b/apps/native-rd/src/components/VideoRecorder/VideoRecorder.tsx
@@ -287,6 +287,7 @@ export const VideoRecorder = forwardRef<
       <Text
         variant="caption"
         style={[styles.timer, isRecording && styles.timerRecording]}
+        testID="video-recorder-timer"
         accessibilityLiveRegion="polite"
         accessibilityLabel={t("recorder.a11y.recordingTime", {
           time: formatDuration(elapsed * 1000),

--- a/apps/native-rd/src/screens/CaptureVideoScreen/__tests__/CaptureVideoScreen.test.tsx
+++ b/apps/native-rd/src/screens/CaptureVideoScreen/__tests__/CaptureVideoScreen.test.tsx
@@ -206,7 +206,9 @@ describe("CaptureVideoScreen — recorder mode", () => {
     fireEvent.press(
       screen.getByText(i18n.t("captureVideo:actions.recordVideo")),
     );
-    expect(screen.getByText("00:00")).toBeTruthy();
+    expect(screen.getByTestId("video-recorder-timer")).toHaveTextContent(
+      "00:00",
+    );
   });
 
   it("starts recording with 60s max duration", async () => {

--- a/apps/native-rd/src/screens/EditModeScreen/__tests__/EditModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/EditModeScreen/__tests__/EditModeScreen.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   fireEvent,
 } from "../../../__tests__/test-utils";
+import { i18n } from "../../../i18n";
 import { EditModeScreen } from "../EditModeScreen";
 
 // --- Mocks ---
@@ -167,31 +168,35 @@ describe("EditModeScreen", () => {
     it("renders step count", () => {
       setupQueries();
       renderWithProviders(<EditModeScreen {...makeRouteProps()} />);
-      expect(screen.getByText("3 steps")).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("editGoal:stepList.count_other", { count: 3 })),
+      ).toBeOnTheScreen();
     });
 
     it('renders "Start Working" when cameFromFocus is false', () => {
       setupQueries();
       renderWithProviders(<EditModeScreen {...makeRouteProps(false)} />);
-      expect(screen.getByText("Start Working")).toBeOnTheScreen();
+      expect(screen.getByTestId("start-working")).toBeOnTheScreen();
     });
 
     it('renders "Back to Focus" when cameFromFocus is true', () => {
       setupQueries();
       renderWithProviders(<EditModeScreen {...makeRouteProps(true)} />);
-      expect(screen.getByText("Back to Focus")).toBeOnTheScreen();
+      expect(screen.getByTestId("back-to-focus")).toBeOnTheScreen();
     });
 
     it('shows "Goal not found." when goal does not exist', () => {
       setupQueries(null, []);
       renderWithProviders(<EditModeScreen {...makeRouteProps()} />);
-      expect(screen.getByText("Goal not found.")).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("editGoal:errors.goalNotFound")),
+      ).toBeOnTheScreen();
     });
 
     it('renders "Edit Goal" header', () => {
       setupQueries();
       renderWithProviders(<EditModeScreen {...makeRouteProps()} />);
-      expect(screen.getByText("Edit Goal")).toBeOnTheScreen();
+      expect(screen.getByText(i18n.t("editGoal:title"))).toBeOnTheScreen();
     });
   });
 
@@ -222,7 +227,9 @@ describe("EditModeScreen", () => {
       await act(async () => {
         jest.advanceTimersByTime(500);
       });
-      expect(screen.getByText("Title cannot be empty")).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("editGoal:errors.titleRequired")),
+      ).toBeOnTheScreen();
       expect(mockUpdateGoal).not.toHaveBeenCalled();
     });
 
@@ -261,7 +268,7 @@ describe("EditModeScreen", () => {
     it("navigates to FocusMode when button pressed", () => {
       setupQueries();
       renderWithProviders(<EditModeScreen {...makeRouteProps()} />);
-      fireEvent.press(screen.getByText("Start Working"));
+      fireEvent.press(screen.getByTestId("start-working"));
       expect(mockNavigate).toHaveBeenCalledWith("FocusMode", {
         goalId: "goal-1",
       });
@@ -303,7 +310,9 @@ describe("EditModeScreen", () => {
       setupQueries();
       renderWithProviders(<EditModeScreen {...makeRouteProps()} />);
       expect(
-        screen.getByRole("button", { name: "Start Working" }),
+        screen.getByRole("button", {
+          name: i18n.t("editGoal:actions.startWorking"),
+        }),
       ).toBeOnTheScreen();
     });
   });
@@ -321,7 +330,10 @@ describe("EditModeScreen", () => {
       fireEvent.changeText(addInput, "Bad step");
       fireEvent(addInput, "submitEditing");
 
-      expect(alertSpy).toHaveBeenCalledWith("Error", "Could not create step.");
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("editGoal:errors.alertErrorTitle"),
+        i18n.t("editGoal:errors.createStepMessage"),
+      );
     });
 
     it("shows error text when updateGoal title fails", async () => {
@@ -337,7 +349,9 @@ describe("EditModeScreen", () => {
       await act(async () => {
         jest.advanceTimersByTime(500);
       });
-      expect(screen.getByText("Failed to update title")).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("editGoal:errors.updateTitleFailed")),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -204,7 +204,9 @@ describe("FocusModeScreen", () => {
   it('shows "Goal not found" when goal does not exist', () => {
     setupQueries({ goal: null, steps: [] });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    expect(screen.getByText("Goal not found.")).toBeOnTheScreen();
+    expect(
+      screen.getByText(i18n.t("focusMode:errors.goalNotFound")),
+    ).toBeOnTheScreen();
   });
 
   it("renders MiniTimeline with step navigation", () => {
@@ -236,7 +238,11 @@ describe("FocusModeScreen", () => {
   it("renders StepCard for current step", () => {
     setupQueries();
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    expect(screen.getByText("Step 1 of 2")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 1, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
     expect(screen.getByText("Read docs")).toBeOnTheScreen();
   });
 
@@ -262,11 +268,23 @@ describe("FocusModeScreen", () => {
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
     // Lands on step-1 (first pending). Mark it complete.
-    expect(screen.getByText("Step 1 of 2")).toBeOnTheScreen();
-    fireEvent.press(screen.getByText("Mark complete"));
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 1, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).toHaveBeenCalledWith("step-1", null, []);
     // Carousel should advance to step-2 instead of staying on the completed step.
-    expect(screen.getByText("Step 2 of 2")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 2, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
     expect(screen.getByText("Practice")).toBeOnTheScreen();
   });
 
@@ -281,7 +299,11 @@ describe("FocusModeScreen", () => {
     renderWithProviders(<FocusModeScreen {...routeProps} />);
     // The current step indicator reflects the snapped index, so users land on
     // the first pending step instead of swiping past completed ones.
-    expect(screen.getByText("Step 3 of 3")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 3, total: 3 }),
+      ),
+    ).toBeOnTheScreen();
     expect(screen.getByText("Build it")).toBeOnTheScreen();
   });
 
@@ -293,7 +315,11 @@ describe("FocusModeScreen", () => {
       ],
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    expect(screen.getByText("Step 1 of 2")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 1, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
     expect(screen.getByText("Read docs")).toBeOnTheScreen();
   });
 
@@ -311,12 +337,24 @@ describe("FocusModeScreen", () => {
     // step-3 (also pending), bypassing the completed step-2.
     fireEvent.press(screen.getByLabelText("Next card"));
     fireEvent.press(screen.getByLabelText("Next card"));
-    expect(screen.getByText("Step 3 of 3")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 3, total: 3 }),
+      ),
+    ).toBeOnTheScreen();
     // Complete step-3. Forward search finds nothing pending, so the wrap
     // path must pull the carousel back to step-1.
-    fireEvent.press(screen.getByText("Mark complete"));
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).toHaveBeenCalledWith("step-3", null, []);
-    expect(screen.getByText("Step 1 of 3")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 1, total: 3 }),
+      ),
+    ).toBeOnTheScreen();
   });
 
   it("does not advance when the last pending step is completed", () => {
@@ -329,12 +367,24 @@ describe("FocusModeScreen", () => {
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
     // Snap puts us on step-2 (the only pending one).
-    expect(screen.getByText("Step 2 of 2")).toBeOnTheScreen();
-    fireEvent.press(screen.getByText("Mark complete"));
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 2, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).toHaveBeenCalledWith("step-2", null, []);
     // No other pending steps — carousel stays put. The all-steps-complete
     // effect handles the navigation to CompletionFlow separately.
-    expect(screen.getByText("Step 2 of 2")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 2, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
   });
 
   it("closes the evidence drawer when auto-advancing after step completion", () => {
@@ -362,8 +412,16 @@ describe("FocusModeScreen", () => {
     ).toBe(true);
     // Complete step-1; advance to step-2 must also close the drawer so the
     // overlay doesn't persist over the next step's content.
-    fireEvent.press(screen.getByText("Mark complete"));
-    expect(screen.getByText("Step 2 of 2")).toBeOnTheScreen();
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 2, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
     expect(
       screen.getByLabelText("Close evidence drawer").props.accessible,
     ).toBe(false);
@@ -381,19 +439,39 @@ describe("FocusModeScreen", () => {
       throw new Error("DB write failed");
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    expect(screen.getByText("Step 1 of 2")).toBeOnTheScreen();
-    fireEvent.press(screen.getByText("Mark complete"));
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 1, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     // Error toast appears, carousel must NOT advance.
     expect(
-      screen.getByText("Could not update step: DB write failed"),
+      screen.getByText(
+        i18n.t("focusMode:errors.couldNotUpdateStep", {
+          message: "DB write failed",
+        }),
+      ),
     ).toBeOnTheScreen();
-    expect(screen.getByText("Step 1 of 2")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        i18n.t("common:stepCard.progress", { current: 1, total: 2 }),
+      ),
+    ).toBeOnTheScreen();
   });
 
   it("calls completeStep when step checkbox is toggled", () => {
     setupQueries();
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    fireEvent.press(screen.getByText("Mark complete"));
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).toHaveBeenCalledWith("step-1", null, [
       { type: "text" },
     ]);
@@ -410,11 +488,13 @@ describe("FocusModeScreen", () => {
     // FocusMode auto-snaps to the first pending step (step-2). Swipe back to
     // the completed step so its checkbox is the active card.
     fireEvent.press(screen.getByLabelText("Previous card"));
-    // "Completed" appears as both StatusBadge label and Checkbox label
-    // Target the checkbox specifically
-    const completedElements = screen.getAllByText("Completed");
-    // The checkbox's Completed text is the one we want to press
-    fireEvent.press(completedElements[completedElements.length - 1]);
+    // Role query scopes to the checkbox, skipping the StatusBadge that also
+    // shows "Completed" — no need to index into a getAllByText list.
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.completed"),
+      }),
+    );
     expect(mockUncompleteStep).toHaveBeenCalledWith("step-1");
   });
 
@@ -492,7 +572,7 @@ describe("FocusModeScreen", () => {
   it('renders "Focus Mode" label in top bar', () => {
     setupQueries();
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    expect(screen.getByText("Focus Mode")).toBeOnTheScreen();
+    expect(screen.getByText(i18n.t("focusMode:title"))).toBeOnTheScreen();
   });
 
   // The goal card lives at the end of the CardCarousel, which sets
@@ -703,10 +783,14 @@ describe("FocusModeScreen", () => {
     fireEvent(evidenceItem, "longPress");
 
     // Confirm dialog should appear
-    expect(screen.getByText("Delete evidence?")).toBeOnTheScreen();
+    expect(
+      screen.getByText(i18n.t("focusMode:confirmDelete.title")),
+    ).toBeOnTheScreen();
 
     // Confirm the deletion
-    fireEvent.press(screen.getByText("Delete"));
+    fireEvent.press(
+      screen.getByRole("button", { name: i18n.t("common:actions.delete") }),
+    );
     expect(mockDeleteEvidence).toHaveBeenCalledWith("ev-s1");
   });
 
@@ -722,7 +806,9 @@ describe("FocusModeScreen", () => {
     fireEvent(evidenceItem, "longPress");
 
     // Cancel the deletion
-    fireEvent.press(screen.getByText("Cancel"));
+    fireEvent.press(
+      screen.getByRole("button", { name: i18n.t("common:actions.cancel") }),
+    );
     expect(mockDeleteEvidence).not.toHaveBeenCalled();
   });
 
@@ -733,10 +819,14 @@ describe("FocusModeScreen", () => {
     // Open drawer → long-press → confirm
     fireEvent.press(screen.getByLabelText("Toggle evidence drawer"));
     fireEvent(screen.getByLabelText(/text evidence:/), "longPress");
-    fireEvent.press(screen.getByText("Delete"));
+    fireEvent.press(
+      screen.getByRole("button", { name: i18n.t("common:actions.delete") }),
+    );
 
     // Toast should appear with undo action
-    expect(screen.getByText("Evidence deleted")).toBeOnTheScreen();
+    expect(
+      screen.getByText(i18n.t("focusMode:toast.evidenceDeleted")),
+    ).toBeOnTheScreen();
     expect(screen.getByLabelText("Undo")).toBeOnTheScreen();
   });
 
@@ -747,7 +837,9 @@ describe("FocusModeScreen", () => {
     // Open drawer → long-press → confirm
     fireEvent.press(screen.getByLabelText("Toggle evidence drawer"));
     fireEvent(screen.getByLabelText(/text evidence:/), "longPress");
-    fireEvent.press(screen.getByText("Delete"));
+    fireEvent.press(
+      screen.getByRole("button", { name: i18n.t("common:actions.delete") }),
+    );
 
     // Press undo
     fireEvent.press(screen.getByLabelText("Undo"));
@@ -786,7 +878,11 @@ describe("FocusModeScreen", () => {
       ],
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    fireEvent.press(screen.getByText("Mark complete"));
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).not.toHaveBeenCalled();
   });
 
@@ -812,7 +908,11 @@ describe("FocusModeScreen", () => {
       stepEvidence: [],
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    fireEvent.press(screen.getByText("Mark complete"));
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCanCompleteStep).toHaveBeenCalledWith(null, []);
     expect(mockCompleteStep).toHaveBeenCalledWith("step-1", null, []);
   });
@@ -846,7 +946,11 @@ describe("FocusModeScreen", () => {
       ],
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    fireEvent.press(screen.getByText("Mark complete"));
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).toHaveBeenCalledWith("step-1", '["photo"]', [
       { type: "photo" },
     ]);
@@ -874,9 +978,12 @@ describe("FocusModeScreen", () => {
     renderWithProviders(<FocusModeScreen {...routeProps} />);
     // Auto-snap puts us on step-2 (pending); swipe back to the completed step.
     fireEvent.press(screen.getByLabelText("Previous card"));
-    // Target the checkbox — "Completed" appears in both StatusBadge and Checkbox
-    const completedElements = screen.getAllByText("Completed");
-    fireEvent.press(completedElements[completedElements.length - 1]);
+    // Role query scopes to the checkbox, skipping the StatusBadge "Completed".
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.completed"),
+      }),
+    );
     expect(mockUncompleteStep).toHaveBeenCalledWith("step-1");
     expect(mockCanCompleteStep).not.toHaveBeenCalled();
   });
@@ -954,7 +1061,11 @@ describe("FocusModeScreen", () => {
 
     view.unmount();
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    fireEvent.press(screen.getAllByLabelText("Mark complete")[0]);
+    fireEvent.press(
+      screen.getAllByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      })[0],
+    );
 
     expect(mockCompleteStep).toHaveBeenCalledWith("step-1", '["text"]', [
       { type: "text" },
@@ -1037,7 +1148,11 @@ describe("FocusModeScreen", () => {
       stepEvidence: [],
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    expect(screen.getByText("Mark complete")).toBeOnTheScreen();
+    expect(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    ).toBeOnTheScreen();
   });
 
   it("completes step without planned types even with no evidence", () => {
@@ -1061,7 +1176,11 @@ describe("FocusModeScreen", () => {
       stepEvidence: [],
     });
     renderWithProviders(<FocusModeScreen {...routeProps} />);
-    fireEvent.press(screen.getByText("Mark complete"));
+    fireEvent.press(
+      screen.getByRole("checkbox", {
+        name: i18n.t("common:stepCard.checkbox.markComplete"),
+      }),
+    );
     expect(mockCompleteStep).toHaveBeenCalledWith("step-1", null, []);
   });
 

--- a/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
@@ -121,7 +121,7 @@ describe("GoalsScreen", () => {
       });
 
       renderWithProviders(<GoalsScreen />);
-      fireEvent.press(screen.getByText("Learn TypeScript"));
+      fireEvent.press(screen.getByTestId("goal-card-goal-1"));
       expect(mockNavigate).toHaveBeenCalledWith("FocusMode", {
         goalId: "goal-1",
       });
@@ -231,7 +231,7 @@ describe("GoalsScreen", () => {
       renderWithProviders(<GoalsScreen />);
 
       // Long press to trigger delete
-      fireEvent(screen.getByText("Learn TypeScript"), "longPress");
+      fireEvent(screen.getByTestId("goal-card-goal-1"), "longPress");
 
       // Confirm modal should show the goal title
       expect(
@@ -281,7 +281,7 @@ describe("GoalsScreen", () => {
 
       await i18n.changeLanguage("pseudo");
       renderWithProviders(<GoalsScreen />);
-      fireEvent(screen.getByText("Learn TypeScript"), "longPress");
+      fireEvent(screen.getByTestId("goal-card-goal-1"), "longPress");
       const pseudo = i18n.t("goals:confirmDelete.message", {
         title: "Learn TypeScript",
       });
@@ -302,7 +302,7 @@ describe("GoalsScreen", () => {
 
         await i18n.changeLanguage("pseudo");
         renderWithProviders(<GoalsScreen />);
-        fireEvent(screen.getByText("Learn TypeScript"), "longPress");
+        fireEvent(screen.getByTestId("goal-card-goal-1"), "longPress");
         const pseudo = i18n.t(key);
         expect(pseudo.startsWith("[")).toBe(true);
         expect(screen.getByText(pseudo)).toBeOnTheScreen();

--- a/apps/native-rd/src/screens/VoiceMemoScreen/VoiceMemoScreen.tsx
+++ b/apps/native-rd/src/screens/VoiceMemoScreen/VoiceMemoScreen.tsx
@@ -160,6 +160,7 @@ export function VoiceMemoScreen({ route }: CaptureVoiceMemoScreenProps) {
         {/* Timer display */}
         <Text
           style={styles.timerText}
+          testID="voice-timer"
           accessibilityLabel={t("captureVoice:a11y.timerLabel", {
             time: formatDuration(
               status === "playing" ? playbackPositionMs : durationMs,

--- a/apps/native-rd/src/screens/VoiceMemoScreen/__tests__/VoiceMemoScreen.test.tsx
+++ b/apps/native-rd/src/screens/VoiceMemoScreen/__tests__/VoiceMemoScreen.test.tsx
@@ -86,7 +86,7 @@ describe("VoiceMemoScreen", () => {
 
     it("shows timer at 00:00", () => {
       renderScreen();
-      expect(screen.getByText("00:00")).toBeOnTheScreen();
+      expect(screen.getByTestId("voice-timer")).toHaveTextContent("00:00");
     });
 
     it("shows start recording hint", () => {
@@ -124,7 +124,7 @@ describe("VoiceMemoScreen", () => {
 
     it("shows formatted duration", () => {
       renderScreen();
-      expect(screen.getByText("00:03")).toBeOnTheScreen();
+      expect(screen.getByTestId("voice-timer")).toHaveTextContent("00:03");
     });
 
     it("shows stop recording button", () => {
@@ -179,7 +179,7 @@ describe("VoiceMemoScreen", () => {
 
     it("shows duration", () => {
       renderScreen();
-      expect(screen.getByText("00:10")).toBeOnTheScreen();
+      expect(screen.getByTestId("voice-timer")).toHaveTextContent("00:10");
     });
 
     it("shows play button", () => {
@@ -340,13 +340,13 @@ describe("VoiceMemoScreen", () => {
     it("formats seconds correctly", () => {
       mockDurationMs = 65000; // 1:05
       renderScreen();
-      expect(screen.getByText("01:05")).toBeOnTheScreen();
+      expect(screen.getByTestId("voice-timer")).toHaveTextContent("01:05");
     });
 
     it("formats zero correctly", () => {
       mockDurationMs = 0;
       renderScreen();
-      expect(screen.getByText("00:00")).toBeOnTheScreen();
+      expect(screen.getByTestId("voice-timer")).toHaveTextContent("00:00");
     });
   });
 });

--- a/apps/native-rd/src/screens/WelcomeScreen/__tests__/WelcomeScreen.test.tsx
+++ b/apps/native-rd/src/screens/WelcomeScreen/__tests__/WelcomeScreen.test.tsx
@@ -40,9 +40,7 @@ describe("WelcomeScreen", () => {
 
     it("renders the body intro copy", () => {
       renderWithProviders(<WelcomeScreen onGetStarted={jest.fn()} />);
-      expect(
-        screen.getByText(/rollercoaster\.dev is your personal goal tracker\./),
-      ).toBeOnTheScreen();
+      expect(screen.getByText(i18n.t("welcome:intro.body1"))).toBeOnTheScreen();
     });
 
     it("renders the picker label", () => {


### PR DESCRIPTION
## Summary

- Adds stable testIDs to load-bearing UI and migrates brittle `getByText("English copy")` screen-test assertions to resilient queries (`i18n.t()`, `getByTestId`, `getByRole`), so future i18n string changes don't churn unrelated test diffs.
- Source changes are minimal (4 props); the bulk is test-query migration across 6 screens.
- Net **a11y improvement**: checkbox/dialog interactions now use role queries, replacing fragile `getAllByText("Completed")[last]` index arithmetic.

## Changes

- **Card.tsx** — adds a forwarded `testID?` prop (both the `Pressable` and `View` branches), bringing it in line with sibling primitives (`Button`/`Input`/`IconButton`).
- **GoalCard.tsx** — passes `testID={`goal-card-${goal.id}`}` so list-card interactions target a stable surface.
- **VoiceMemoScreen / VideoRecorder** — add `voice-timer` / `video-recorder-timer` testIDs to the timer `Text` (a11y labels preserved).
- **FocusModeScreen.test** — ~30 brittle assertions → `i18n.t()`; `Mark complete` / `Completed` presses → `getByRole("checkbox", { name })`; confirm-dialog buttons → `getByRole("button", { name })`.
- **EditModeScreen.test** — CTA presence/press → existing `start-working`/`back-to-focus` testIDs; copy assertions → `i18n.t()`; the a11y-role test keeps `getByRole` but decouples its name.
- **GoalsScreen / WelcomeScreen / CaptureVideoScreen.test** — `fireEvent` on goal-card testID; body-copy regex → `i18n.t("welcome:intro.body1")`; timer assertions → `getByTestId(...).toHaveTextContent(...)` (value check preserved).
- User-data assertions (goal/step titles) intentionally left as literal `getByText` — they assert dynamic content, not UI copy.

## Intent Verification

- [x] Every `fireEvent.press`/`fireEvent` targeting a load-bearing interactive element (GoalCard, StepCard mark-complete, EditMode CTA) uses `getByTestId` or an accessibility-role query — not `getByText` on UI copy
- [x] `getByText("Step 1 of 2"/"Mark complete"/"Focus Mode"/"Goal not found.")` and similar i18n-wrapped strings replaced with `i18n.t()` lookups in FocusModeScreen.test
- [x] `getByText("Start Working")`/`"Back to Focus"` in EditModeScreen.test use existing `start-working`/`back-to-focus` testIDs
- [x] `getByText("00:00")` in VoiceMemo/CaptureVideo tests use `voice-timer`/`video-recorder-timer` testIDs (with `toHaveTextContent` to keep the value check)
- [x] `getByRole("button")`/`getByRole("checkbox")` accessibility-driven queries preserved where stronger; checkbox/dialog presses upgraded *to* role queries (D1)
- [x] All Jest tests pass: 168 suites, 8529 tests

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Mark complete / Completed via `getByRole("checkbox", { name })`, not a new testID (D1) | `Checkbox` already exposes `accessibilityRole="checkbox"` + label; role query is stronger a11y coverage and resolves the StatusBadge/Checkbox ambiguity (OQ-1) |
| Step counter via `i18n.t("common:stepCard.progress", …)` (D5) | Already i18n-wrapped in source; test references the same key, no source change |
| Add `testID="voice-timer"` / `"video-recorder-timer"` to timer Text (D6) | Stable target for a purely visual element; a11y label retained alongside |
| `testID={`goal-card-${goal.id}`}` on GoalCard root (D7); forward `testID` through Card | Dynamic ID lets fixtures target specific cards; Card had to learn to forward the prop (OQ-2) |
| Keep user-data title assertions as literal `getByText` (D3) | Goal/step titles are dynamic content, not UI copy — asserting by value is correct |

## Discovery Log

- [2026-05-27] OQ-2 resolved: `Card.tsx` did NOT forward `testID`. Added `testID?: string` to `CardProps` and forwarded to both the `Pressable` and `View` branches. Custom `Text` already spreads `...rest`, so timer testIDs forward with no `Text.tsx` change.
- [2026-05-27] `bun test --testPathPatterns` finds no files (bun's native runner doesn't match the jest suites); used `npx jest --no-coverage --testPathPatterns` per `apps/native-rd/CLAUDE.md`.
- [2026-05-27] OQ-1 resolved: `getByRole("checkbox", { name })` scopes cleanly to the Checkbox — StatusBadge has no checkbox role — so both `getAllByText("Completed")[last]` sites collapse to a single role query with no source testID needed.

## Test Plan

- [x] Type-check passes
- [x] Lint passes (0 errors)
- [x] Tests pass (168 suites, 8529 tests)
- [x] Build script (no-op for native-rd) returns successfully

---

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)