### PR TITLE
fix(native-rd): header safe-area cleanup + small UI/i18n polish

### DIFF
--- a/apps/native-rd/src/badges/IconPickerModal.tsx
+++ b/apps/native-rd/src/badges/IconPickerModal.tsx
@@ -243,7 +243,7 @@ function IconPickerModalContent({
 
   return (
     <View style={styles.modalRoot} testID={testID}>
-      <HeaderBand>
+      <HeaderBand safeAreaTop>
         <Pressable
           onPress={onClose}
           accessibilityRole="button"

--- a/apps/native-rd/src/components/ScreenHeader/HeaderBand.tsx
+++ b/apps/native-rd/src/components/ScreenHeader/HeaderBand.tsx
@@ -3,14 +3,20 @@ import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { styles } from "./ScreenHeader.styles";
 
-// Paints the inset directly via useSafeAreaInsets — using SafeAreaView
-// here would two-tone on theme switch (Unistyles v3 plugin doesn't
-// rewrite style props on third-party components).
+// Normally the safe-area inset is painted by App.tsx (it offsets the
+// navigator by insets.top), so the band uses plain symmetric padding.
+// Detached presentations that escape that offset (a fullScreen RN Modal
+// with its own SafeAreaProvider) pass `safeAreaTop` to pay the inset here.
 export interface HeaderBandProps {
   children: React.ReactNode;
+  safeAreaTop?: boolean;
 }
 
-export function HeaderBand({ children }: HeaderBandProps) {
+export function HeaderBand({ children, safeAreaTop = false }: HeaderBandProps) {
   const insets = useSafeAreaInsets();
-  return <View style={styles.band(insets.top)}>{children}</View>;
+  return (
+    <View style={[styles.band, safeAreaTop && styles.bandSafeTop(insets.top)]}>
+      {children}
+    </View>
+  );
 }

--- a/apps/native-rd/src/components/ScreenHeader/ScreenHeader.styles.ts
+++ b/apps/native-rd/src/components/ScreenHeader/ScreenHeader.styles.ts
@@ -4,16 +4,24 @@ import { shadowStyle } from "../../styles/shadows";
 const SPACER_WIDTH = 44;
 
 export const styles = StyleSheet.create((theme) => ({
-  band: (insetTop: number) => ({
+  band: {
     flexDirection: "row" as const,
     alignItems: "center" as const,
     justifyContent: "space-between" as const,
-    paddingTop: insetTop + theme.space[2],
+    // App.tsx already offsets the navigator by the safe-area inset, so the
+    // band only needs symmetric padding around its content — no inset here.
+    paddingTop: theme.space[4],
     paddingBottom: theme.space[4],
     paddingHorizontal: theme.space[4],
     backgroundColor: theme.colors.accentPurple,
     zIndex: 1,
     ...shadowStyle(theme, "cardElevation"),
+  },
+  // Opt-in override for detached presentations (e.g. a fullScreen RN Modal
+  // with its own SafeAreaProvider) that don't sit under App.tsx's inset
+  // offset and so must pay the top inset themselves.
+  bandSafeTop: (insetTop: number) => ({
+    paddingTop: insetTop + theme.space[4],
   }),
   title: {
     color: theme.colors.accentPurpleFg,

--- a/apps/native-rd/src/components/StepCard/__tests__/StepCard.test.tsx
+++ b/apps/native-rd/src/components/StepCard/__tests__/StepCard.test.tsx
@@ -222,7 +222,7 @@ describe("StepCard", () => {
       />,
     );
     expect(
-      screen.getByLabelText("Add Take Photo to complete this step"),
+      screen.getByLabelText("Add Photo to complete this step"),
     ).toBeOnTheScreen();
   });
 

--- a/apps/native-rd/src/i18n/resources/de/common.json
+++ b/apps/native-rd/src/i18n/resources/de/common.json
@@ -23,9 +23,11 @@
   },
   "evidenceTypes": {
     "photo": {
+      "label": "Foto",
       "shortLabel": "Foto"
     },
     "video": {
+      "label": "Video",
       "shortLabel": "Video"
     },
     "voice_memo": {
@@ -33,12 +35,15 @@
       "shortLabel": "Audio"
     },
     "text": {
+      "label": "Notiz",
       "shortLabel": "Notiz"
     },
     "link": {
+      "label": "Link",
       "shortLabel": "Link"
     },
     "file": {
+      "label": "Datei",
       "shortLabel": "Datei"
     }
   },

--- a/apps/native-rd/src/i18n/resources/de/common.json
+++ b/apps/native-rd/src/i18n/resources/de/common.json
@@ -23,27 +23,22 @@
   },
   "evidenceTypes": {
     "photo": {
-      "label": "Foto machen",
       "shortLabel": "Foto"
     },
     "video": {
-      "label": "Video aufnehmen",
       "shortLabel": "Video"
     },
     "voice_memo": {
-      "label": "Sprachmemo aufnehmen",
-      "shortLabel": "Sprachmemo"
+      "label": "Audio",
+      "shortLabel": "Audio"
     },
     "text": {
-      "label": "Notiz schreiben",
       "shortLabel": "Notiz"
     },
     "link": {
-      "label": "Link hinzufügen",
       "shortLabel": "Link"
     },
     "file": {
-      "label": "Datei anhängen",
       "shortLabel": "Datei"
     }
   },

--- a/apps/native-rd/src/i18n/resources/en/common.json
+++ b/apps/native-rd/src/i18n/resources/en/common.json
@@ -22,12 +22,12 @@
     }
   },
   "evidenceTypes": {
-    "photo": { "label": "Take Photo", "shortLabel": "Photo" },
-    "video": { "label": "Record Video", "shortLabel": "Video" },
-    "voice_memo": { "label": "Record Voice Memo", "shortLabel": "Voice Memo" },
-    "text": { "label": "Write a Note", "shortLabel": "Note" },
-    "link": { "label": "Add Link", "shortLabel": "Link" },
-    "file": { "label": "Attach File", "shortLabel": "File" }
+    "photo": { "label": "Photo", "shortLabel": "Photo" },
+    "video": { "label": "Video", "shortLabel": "Video" },
+    "voice_memo": { "label": "Audio", "shortLabel": "Audio" },
+    "text": { "label": "Note", "shortLabel": "Note" },
+    "link": { "label": "Link", "shortLabel": "Link" },
+    "file": { "label": "File", "shortLabel": "File" }
   },
   "theme": {
     "options": {

--- a/apps/native-rd/src/navigation/FocusPillTabBar.tsx
+++ b/apps/native-rd/src/navigation/FocusPillTabBar.tsx
@@ -293,8 +293,8 @@ const styles = StyleSheet.create((theme) => {
       justifyContent: "center" as const,
     },
     plusIcon: {
-      fontSize: 24,
-      lineHeight: 28,
+      fontSize: 32,
+      lineHeight: 36,
       // FAB bg is accentYellow (#ffe50c) in both modes; dark fg pairs with
       // it at ~17:1. theme.colors.text would flip to #fafafa in dark and
       // give ~1.1:1, so we lock the contrast value here.

--- a/apps/native-rd/src/screens/BadgeDesignerScreen/BadgeDesignerScreen.tsx
+++ b/apps/native-rd/src/screens/BadgeDesignerScreen/BadgeDesignerScreen.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useCallback, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
-  Animated,
+  ScrollView,
   TextInput,
   View,
 } from "react-native";
@@ -117,8 +117,6 @@ function DesignEditor({
   const { t } = useTranslation("badgeDesigner");
   const resolvedSaveLabel = saveLabel ?? t("actions.save");
 
-  const scrollY = useRef(new Animated.Value(0)).current;
-  const [topBarHeight, setTopBarHeight] = useState(64);
   const insets = useSafeAreaInsets();
   const tabBarHeight = TAB_BAR_HEIGHT + insets.bottom;
 
@@ -298,20 +296,15 @@ function DesignEditor({
 
   return (
     <View style={styles.editorRoot}>
-      <Animated.ScrollView
+      <ScrollView
         contentContainerStyle={[
           styles.scrollContent,
           {
-            paddingTop: topBarHeight + PREVIEW_OVERLAY_HEIGHT,
+            paddingTop: PREVIEW_OVERLAY_HEIGHT,
             paddingBottom: tabBarHeight + 16,
           },
         ]}
         keyboardShouldPersistTaps="handled"
-        onScroll={Animated.event(
-          [{ nativeEvent: { contentOffset: { y: scrollY } } }],
-          { useNativeDriver: true },
-        )}
-        scrollEventThrottle={16}
       >
         <View style={styles.sectionContainer}>
           <Text style={styles.sectionLabel}>{t("sections.shape")}</Text>
@@ -418,40 +411,16 @@ function DesignEditor({
           />
           {extraFooter}
         </View>
-      </Animated.ScrollView>
+      </ScrollView>
 
-      <View
-        style={styles.topBar}
-        onLayout={(e) => {
-          const next = e.nativeEvent.layout.height;
-          setTopBarHeight((prev) => (prev === next ? prev : next));
-        }}
-      >
+      <View style={styles.topBar}>
         <ScreenSubHeader label={t("title")} onBack={onBack} />
       </View>
 
-      <Animated.View
-        style={[
-          styles.previewOverlay,
-          {
-            top: topBarHeight,
-            transform: [
-              {
-                // Stop the upward slide at the bottom edge of the safe-area
-                // inset so the preview never crosses into the notch / dynamic
-                // island. `topBarHeight` (from onLayout) includes
-                // `paddingTop: insets.top` from HeaderBand, hence the subtract.
-                translateY: scrollY.interpolate({
-                  inputRange: [0, topBarHeight],
-                  outputRange: [0, -Math.max(0, topBarHeight - insets.top)],
-                  extrapolate: "clamp",
-                }),
-              },
-            ],
-          },
-        ]}
-        pointerEvents="none"
-      >
+      {/* Static badge preview pinned to the top of the content area (which
+          already sits below the safe-area inset via App.tsx's offset), drawn
+          over the header band. No scroll-linked motion. */}
+      <View style={[styles.previewOverlay, { top: 0 }]} pointerEvents="none">
         <View
           style={styles.previewContainer}
           accessibilityRole="image"
@@ -461,7 +430,7 @@ function DesignEditor({
             <BadgeRenderer ref={previewRef} design={currentDesign} size={160} />
           </View>
         </View>
-      </Animated.View>
+      </View>
     </View>
   );
 }

--- a/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
@@ -9,7 +9,6 @@ import {
 } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useQuery } from "@evolu/react";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "phosphor-react-native";
@@ -106,10 +105,6 @@ function BadgeDetailContent({
   const navigation =
     useNavigation<NativeStackNavigationProp<BadgesStackParamList>>();
   const { t } = useTranslation("badgeDetail");
-  // Pin the floating preview right below the notch — matches the Designer's
-  // max-scroll resting position (top: insets.top) so both screens land on
-  // the same vertical anchor.
-  const insets = useSafeAreaInsets();
   const query = useMemo(
     () => badgeWithGoalQuery(badgeId as BadgeId),
     [badgeId],
@@ -179,7 +174,7 @@ function BadgeDetailContent({
       <ScrollView
         contentContainerStyle={[
           styles.scrollContent,
-          { paddingTop: insets.top + previewHeight },
+          { paddingTop: previewHeight },
         ]}
       >
         <Text style={styles.title}>{goalTitle}</Text>
@@ -297,7 +292,7 @@ function BadgeDetailContent({
       />
 
       <View
-        style={[styles.previewOverlay, { top: insets.top }]}
+        style={[styles.previewOverlay, { top: 0 }]}
         pointerEvents="none"
         onLayout={(e) => {
           const next = e.nativeEvent.layout.height;

--- a/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx
@@ -508,6 +508,7 @@ function CompletionContent({
                 ref={textInputRef}
                 style={styles.inlineNoteInput}
                 placeholder={tCompletion("evidencePhase.notePlaceholder")}
+                placeholderTextColor={theme.colors.textMuted}
                 value={noteText}
                 onChangeText={setNoteText}
                 multiline

--- a/apps/native-rd/src/screens/CompletionFlowScreen/__tests__/CompletionFlowScreen.test.tsx
+++ b/apps/native-rd/src/screens/CompletionFlowScreen/__tests__/CompletionFlowScreen.test.tsx
@@ -236,17 +236,17 @@ describe("CompletionFlowScreen", () => {
       renderWithProviders(<CompletionFlowScreen {...routeProps} />);
       expect(screen.getByText("Or capture another way")).toBeOnTheScreen();
       // Text is excluded from chips (handled inline)
-      expect(screen.getByLabelText(/Take Photo/)).toBeOnTheScreen();
-      expect(screen.getByLabelText(/Record Video/)).toBeOnTheScreen();
-      expect(screen.getByLabelText(/Record Voice Memo/)).toBeOnTheScreen();
-      expect(screen.getByLabelText(/Add Link/)).toBeOnTheScreen();
-      expect(screen.getByLabelText(/Attach File/)).toBeOnTheScreen();
+      expect(screen.getByLabelText(/Photo/)).toBeOnTheScreen();
+      expect(screen.getByLabelText(/Video/)).toBeOnTheScreen();
+      expect(screen.getByLabelText(/Audio/)).toBeOnTheScreen();
+      expect(screen.getByLabelText(/Link/)).toBeOnTheScreen();
+      expect(screen.getByLabelText(/File/)).toBeOnTheScreen();
     });
 
     it("navigates to CapturePhoto when photo chip is tapped", () => {
       setupQueries();
       renderWithProviders(<CompletionFlowScreen {...routeProps} />);
-      fireEvent.press(screen.getByLabelText(/Take Photo/));
+      fireEvent.press(screen.getByLabelText(/Photo/));
       expect(mockNavigate).toHaveBeenCalledWith("CapturePhoto", {
         goalId: "goal-1",
       });
@@ -255,7 +255,7 @@ describe("CompletionFlowScreen", () => {
     it("navigates to CaptureVoiceMemo when voice memo chip is tapped", () => {
       setupQueries();
       renderWithProviders(<CompletionFlowScreen {...routeProps} />);
-      fireEvent.press(screen.getByLabelText(/Record Voice Memo/));
+      fireEvent.press(screen.getByLabelText(/Audio/));
       expect(mockNavigate).toHaveBeenCalledWith("CaptureVoiceMemo", {
         goalId: "goal-1",
       });

--- a/apps/native-rd/src/screens/WelcomeScreen/WelcomeScreen.tsx
+++ b/apps/native-rd/src/screens/WelcomeScreen/WelcomeScreen.tsx
@@ -24,7 +24,7 @@ export function WelcomeScreen({ onGetStarted }: WelcomeScreenProps) {
     <View
       style={[styles.container, { backgroundColor: theme.colors.background }]}
     >
-      <HeaderBand>
+      <HeaderBand safeAreaTop>
         <View style={styles.heroRow}>
           <BrandMark size={56} />
           <View style={styles.heroText}>


### PR DESCRIPTION
## Summary

Four small, independent fixes bundled on one branch. Each is its own commit.

### 1. HeaderBand safe-area inset → opt-in `safeAreaTop`
`App.tsx` already offsets the navigator by the top safe-area inset, so the band was double-counting it. HeaderBand now uses symmetric padding by default and exposes an opt-in `safeAreaTop` prop for **detached** presentations that escape that offset — a fullScreen RN Modal with its own `SafeAreaProvider` (`IconPickerModal`) and the pre-navigator `WelcomeScreen`.

With the inset no longer baked into header height, the **Designer** and **Detail** badge previews no longer need scroll-linked motion to dodge the notch — they pin statically at `top: 0` over the content area (which already sits below the inset). This drops the `Animated.ScrollView` + `onLayout` topBar-measurement plumbing in `BadgeDesignerScreen`.

### 2. Simplify evidence-type labels (i18n)
Collapse verb-phrase labels ("Take Photo", "Record Voice Memo") to plain nouns matching the short labels, and rename `voice_memo` → "Audio", in both `en` and `de`.

### 3. Enlarge FAB plus icon
Center tab-bar plus glyph 24/28 → 32/36 (fontSize/lineHeight) for a clearer target against the yellow FAB.

### 4. Placeholder color on inline note input
`CompletionFlowScreen`'s multiline note input relied on the platform default placeholder color, which under-contrasts on the themed background. Now uses `theme.colors.textMuted`.

## Test plan
- [ ] Headers sit correctly below the notch on Welcome, IconPicker modal, Designer, and Detail (no double inset, no clipping into the dynamic island)
- [ ] Badge previews on Designer/Detail stay pinned, no jump on scroll
- [ ] Evidence picker shows the simplified labels in en + de
- [ ] FAB plus icon reads clearly; note-input placeholder is legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)