### PR TITLE
fix(ci): unbreak format:check after release-please bump + prevent recurrence

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,19 +28,19 @@ jobs:
       # at PR time). Re-run Prettier on the release PR branch so the bumped file
       # lands already formatted.
       - name: Checkout release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v6
         with:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
 
       - name: Setup Bun
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.pr }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
 
       - name: Re-format release files with Prettier
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.pr }}
         env:
           PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      # release-please bumps $.expo.version in apps/native-rd/app.json via its
+      # generic JSON updater, which re-serialises the file with its own
+      # pretty-printer and expands short arrays (e.g. supportedLocales) onto
+      # multiple lines. Prettier's format:check then rejects the file, so every
+      # release commit turns ci-docs / ci-packages / ci-native-rd red on merge
+      # to main (release PRs are bot-opened, so pull_request CI never catches it
+      # at PR time). Re-run Prettier on the release PR branch so the bumped file
+      # lands already formatted.
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+
+      - name: Setup Bun
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Re-format release files with Prettier
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          # Pinned to the repo's Prettier major; app.json has no config/plugins,
+          # so output is stable across 3.x patch releases.
+          bunx prettier@3 --write apps/native-rd/app.json
+          if git diff --quiet -- apps/native-rd/app.json; then
+            echo "app.json already Prettier-clean — nothing to commit."
+            exit 0
+          fi
+          # Bot identity matches the DCO exemption in dco.yml; -s keeps the
+          # trailer valid even if a future DCO run inspects this commit.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -s -m "chore: prettier-format app.json after release bump" -- apps/native-rd/app.json
+          git push origin "HEAD:${PR_BRANCH}"

--- a/apps/native-rd/app.json
+++ b/apps/native-rd/app.json
@@ -104,10 +104,7 @@
       [
         "expo-localization",
         {
-          "supportedLocales": [
-            "en",
-            "de"
-          ]
+          "supportedLocales": ["en", "de"]
         }
       ]
     ],


### PR DESCRIPTION
## What

`main` went red on the `chore(main): release 0.1.8 (#119)` commit across **ci-docs**, **ci-packages**, and **ci-native-rd**. This PR clears all of them and stops it recurring.

## Root cause

release-please bumps `$.expo.version` in `apps/native-rd/app.json` via its generic JSON updater, which re-serialises the whole file with its own pretty-printer. That expanded a short array onto multiple lines:

```diff
-          "supportedLocales": ["en", "de"]
+          "supportedLocales": [
+            "en",
+            "de"
+          ]
```

Prettier (`format:check`, run by all three workflows) wants it collapsed back. So every release commit fails `format:check` on merge to `main`. Release PRs are bot-opened, so `pull_request` CI never runs on them — the break only surfaces on the push-to-main trigger.

> Note: the `a11y audit` step in ci-native-rd also showed red on that run, but that's a cascade — `format:check` is the first real step, so it skipped `Typecheck`/`Lint`/`Test`, and the `if: always()` a11y step then ran as the *first* jest invocation in a cold env and found 0 tests. It self-resolves once `format:check` is green (the `Test` step runs before a11y again). Left as-is for now.

## Changes

1. **`apps/native-rd/app.json`** — reformatted with Prettier (collapses the array). Immediate unblock for `main`.
2. **`.github/workflows/release-please.yml`** — after release-please opens/updates its PR, check out that branch, run `prettier --write apps/native-rd/app.json`, and commit the result back. Keeps Prettier coverage on the file while preventing the conflict from re-reddening `main` on the next release. Bot-authored commit matches the DCO exemption in `dco.yml`.

## Test plan

- [x] `prettier --check app.json` passes locally
- [x] Workflow YAML validated (`js-yaml`)
- [x] type-check passes (husky pre-commit)
- [ ] ci-docs / ci-packages / ci-native-rd green on this PR