### PR TITLE
fix(native-rd/eas): submit Android to internal track until Play production access is granted

### DIFF
--- a/apps/native-rd/eas.json
+++ b/apps/native-rd/eas.json
@@ -60,9 +60,7 @@
       },
       "android": {
         "serviceAccountKeyPath": "../../secrets/play-service-account.json",
-        "track": "production",
-        "releaseStatus": "inProgress",
-        "rollout": 0.1
+        "track": "internal"
       }
     },
     "preview": {


### PR DESCRIPTION
Flips `submit.production.android.track` from `production` to `internal` in `apps/native-rd/eas.json`. The Play Developer API was rejecting every upload with `Precondition check failed` because production access hasn't been granted on the personal dev account yet.

After this lands, Publishing a release sends Android builds to **Play internal testing** (alongside iOS TestFlight) in one Publish click — no more red `submit-android` job.

Also drops `rollout: 0.1` and `releaseStatus: inProgress` since both are production-track only and EAS refuses them on internal.

**Reverse when Google grants production access** (after closed-testing graduation + production access form).
