### PR TITLE
ci(release): wire testing-notes flow into release pipeline (#215)

### DIFF
--- a/.github/workflows/_release-validate.yml
+++ b/.github/workflows/_release-validate.yml
@@ -50,3 +50,12 @@ jobs:
 
       - name: Test
         run: bun run test
+
+      # Gate releases on tester-facing notes being authored. release-notes:lint
+      # fails if any docs/release/testing-notes/<version>.md still contains the
+      # `TODO:` scaffold lines that release-please writes when opening the
+      # release PR. No file (older tags re-validated via workflow_dispatch, or
+      # chore-only releases that skipped scaffold) is a deliberate no-op pass.
+      - name: Lint release notes
+        run: bun run release-notes:lint
+        working-directory: apps/native-rd

--- a/.github/workflows/_release-validate.yml
+++ b/.github/workflows/_release-validate.yml
@@ -7,6 +7,11 @@ on:
         description: "Git ref to check out and validate. Defaults to the caller workflow's commit."
         required: false
         type: string
+      lint-release-notes:
+        description: "Run release-notes:lint as part of validation. Only the production publish path opts in — internal/play-internal builds skip it so they can build a release-please PR branch whose testing notes still carry TODO scaffold lines."
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   validate:
@@ -51,11 +56,19 @@ jobs:
       - name: Test
         run: bun run test
 
-      # Gate releases on tester-facing notes being authored. release-notes:lint
-      # fails if any docs/release/testing-notes/<version>.md still contains the
-      # `TODO:` scaffold lines that release-please writes when opening the
-      # release PR. No file (older tags re-validated via workflow_dispatch, or
-      # chore-only releases that skipped scaffold) is a deliberate no-op pass.
+      # Publish-time backstop: gate releases on tester-facing notes being
+      # authored. release-notes:lint fails if any
+      # docs/release/testing-notes/<version>.md still contains the `TODO:`
+      # scaffold lines that release-please writes when opening the release PR.
+      # No file (older tags re-validated via workflow_dispatch, or chore-only
+      # releases that skipped scaffold) is a deliberate no-op pass.
+      #
+      # Gated on the caller: only build-production opts in (lint-release-notes:
+      # true). build-internal / build-play-internal leave it off so they can
+      # build a release-please PR branch whose notes still carry TODOs — those
+      # profiles never consume the notes, so the gate would only be a blocker.
+      # The merge-blocking PR-time gate lives in release-notes-lint.yml.
       - name: Lint release notes
+        if: ${{ inputs.lint-release-notes }}
         run: bun run release-notes:lint
         working-directory: apps/native-rd

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -64,6 +64,25 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: .
 
+      # Generate TestFlight "What to Test" + App Store store.config.json from
+      # apps/native-rd/docs/release/testing-notes/<version>.md (scaffolded by
+      # release-please.yml, edited by humans, gated by release-notes:lint in
+      # _release-validate.yml). Missing notes file falls back to a copy of
+      # store.config.base.json so eas submit's metadataPath remains valid.
+      - name: Generate release-notes artifacts
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r .version package.json)"
+          NOTES="docs/release/testing-notes/${VERSION}.md"
+          mkdir -p .release-artifacts
+          if [ ! -f "$NOTES" ]; then
+            echo "::warning::No testing notes at $NOTES — TestFlight What-to-Test will be empty and store metadata will fall back to store.config.base.json."
+            printf '' > .release-artifacts/what-to-test.txt
+            cp store.config.base.json store.config.json
+            exit 0
+          fi
+          bun run release-notes:split
+
       - name: Build (EAS, production profile, iOS)
         id: build
         env:
@@ -72,8 +91,17 @@ jobs:
         run: |
           # Write JSON outside the repo: `cmd > file` opens the file before
           # eas-cli runs, and eas-cli aborts on a dirty working tree.
+          set -euo pipefail
           out="$RUNNER_TEMP/eas-build-ios.json"
-          npx eas-cli@latest build --profile production --platform ios --non-interactive --json > "$out"
+          args=(eas-cli@latest build --profile production --platform ios --non-interactive --json)
+          # --what-to-test is stored on the EAS build record and consumed by
+          # `eas submit --id <build_id>` when it creates the App Store Connect
+          # submission. Only pass it when the file has content — passing an
+          # empty string would overwrite TestFlight notes with blank.
+          if [ -s .release-artifacts/what-to-test.txt ]; then
+            args+=(--what-to-test "$(cat .release-artifacts/what-to-test.txt)")
+          fi
+          npx "${args[@]}" > "$out"
           build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
@@ -166,6 +194,23 @@ jobs:
           printf '%s\n' "$APPLE_ASC_KEY_P8" > ../../secrets/asc-api-key.p8
           printf '%s\n' "$ANDROID_PLAY_SA" > ../../secrets/play-service-account.json
           chmod 600 ../../secrets/asc-api-key.p8 ../../secrets/play-service-account.json
+
+      # Regenerate store.config.json from this version's testing-notes file
+      # so the iOS submit profile's metadataPath (./store.config.json in
+      # eas.json) resolves. Same logic as the build-ios prepare step — kept
+      # local because jobs don't share filesystem state.
+      - name: Generate release-notes artifacts
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r .version package.json)"
+          NOTES="docs/release/testing-notes/${VERSION}.md"
+          mkdir -p .release-artifacts
+          if [ ! -f "$NOTES" ]; then
+            echo "::warning::No testing notes at $NOTES — store metadata falls back to store.config.base.json."
+            cp store.config.base.json store.config.json
+            exit 0
+          fi
+          bun run release-notes:split
 
       - name: Submit (EAS, production profile, iOS)
         env:

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/_release-validate.yml
     with:
       ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
+      lint-release-notes: true
 
   build-ios:
     needs: validate

--- a/.github/workflows/release-notes-lint.yml
+++ b/.github/workflows/release-notes-lint.yml
@@ -1,0 +1,66 @@
+# Gate the release PR on tester-facing notes being authored.
+#
+# release-please opens the release PR and (via release-please.yml) commits a
+# docs/release/testing-notes/<version>.md scaffold full of `TODO:` lines. This
+# workflow runs `release-notes:lint`, which fails while any TODO remains — so
+# the notes must be rewritten into real copy BEFORE the release PR merges and
+# the tag freezes. (build-production.yml runs the same lint at publish time,
+# but that gate fires AFTER the tag is cut: too late to fix the tagged commit.)
+#
+# IMPORTANT — bot-authored commits don't trigger CI: commits pushed with the
+# default GITHUB_TOKEN (the scaffold commit, the release PR itself) do NOT
+# start workflow runs. So this check does NOT run when the bot opens the PR.
+# It runs the moment a human pushes a commit to the release branch — i.e. when
+# someone edits the TODO lines — which is exactly when we want to validate.
+# To make it BLOCK the merge, add "Release Notes Lint" as a required status
+# check in branch protection for `main` (a one-time repo-settings step; a
+# required check that has not reported is treated as pending and blocks merge,
+# forcing a human push that turns it green).
+name: release-notes-lint
+
+on:
+  pull_request:
+    paths:
+      - "apps/native-rd/docs/release/testing-notes/**"
+      - "apps/native-rd/scripts/release-notes-*.ts"
+      - ".github/workflows/release-notes-lint.yml"
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-notes-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Release Notes Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/native-rd
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: .
+
+      - name: Lint release notes
+        run: bun run release-notes:lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,3 +58,44 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -s -m "chore: prettier-format app.json after release bump" -- apps/native-rd/app.json
           git push origin "HEAD:${PR_BRANCH}"
+
+      # Scaffold docs/release/testing-notes/<version>.md from CHANGELOG.md so
+      # the release PR carries a tester-facing notes file from the moment it
+      # opens. The scaffold is full of `TODO:` lines — release-notes:lint
+      # (run by _release-validate.yml) fails until a human has rewritten each
+      # TODO into actual tester-facing language. That gate is what stops a
+      # release being Published with empty/placeholder notes.
+      - name: Scaffold testing notes for release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r .version apps/native-rd/package.json)"
+          NOTES="apps/native-rd/docs/release/testing-notes/${VERSION}.md"
+          if [ -f "$NOTES" ]; then
+            echo "$NOTES already exists — leaving in place (subsequent release-please update)."
+            exit 0
+          fi
+          # release-notes-generate fails when CHANGELOG has no Features/Bug
+          # Fixes for this version (chore-only release). That's fine: no
+          # tester-facing changes → no notes file → release-notes:lint passes
+          # via its missing-file no-op path. Surface other failures as real
+          # errors.
+          GEN_STDERR=$(mktemp)
+          if ! bun apps/native-rd/scripts/release-notes-generate.ts "$VERSION" 2>"$GEN_STDERR"; then
+            if grep -q "no Features or Bug Fixes" "$GEN_STDERR"; then
+              echo "No tester-facing changes in CHANGELOG for ${VERSION} — skipping scaffold."
+              rm -f "$GEN_STDERR"
+              exit 0
+            fi
+            cat "$GEN_STDERR" >&2
+            rm -f "$GEN_STDERR"
+            exit 1
+          fi
+          rm -f "$GEN_STDERR"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$NOTES"
+          git commit -s -m "chore: scaffold testing notes for ${VERSION}"
+          git push origin "HEAD:${PR_BRANCH}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,12 @@ apps/native-rd/android/
 # (e.g. packages/*/CHANGELOG.md) are not in release-please scope and stay
 # enforced.
 apps/native-rd/CHANGELOG.md
+
+# Tester/store release notes. The scaffold is generated from CHANGELOG.md by
+# release-notes-generate.ts and then hand-edited into store copy, so its
+# formatting is content-driven (Prettier escapes `*` in changelog titles, wants
+# blockquote-continuation `>` lines, etc.) and can't be kept Prettier-clean at
+# generation time. format:check scans **/*.md, and _release-validate.yml runs it
+# at publish — without this ignore, every release fails format:check on the notes
+# file before EAS even starts. release-notes:lint enforces the real contract here.
+apps/native-rd/docs/release/testing-notes/

--- a/apps/native-rd/docs/release.md
+++ b/apps/native-rd/docs/release.md
@@ -66,12 +66,28 @@ Why this workflow exists:
      `feat:` → minor, `fix:` → patch, `BREAKING CHANGE:` → major.
    - If the PR isn't there, no qualifying commits have landed.
 2. Review the PR. The diff bumps `apps/native-rd/package.json`,
-   `apps/native-rd/app.json` (`expo.version`), and `apps/native-rd/CHANGELOG.md`.
-3. Merge the PR. release-please pushes the `vX.Y.Z` tag **and publishes a
-   GitHub Release**.
-4. `build-production` workflow fires automatically on the published Release.
-   Watch it in Actions.
-5. After EAS finishes:
+   `apps/native-rd/app.json` (`expo.version`), and `apps/native-rd/CHANGELOG.md`,
+   and includes a scaffolded `docs/release/testing-notes/<version>.md` (committed
+   to the PR branch by release-please.yml).
+3. **Fill in the testing notes _on the release PR branch_, before merging.** The
+   scaffold is full of `TODO:` lines; rewrite each into real copy — `play` /
+   `appstore` are user-facing (no jargon, no PR numbers), `testflight` is a QA
+   brief (steps to exercise → expected result). See
+   `docs/release/testing-notes/README.md` for the per-store length limits.
+   - **Why before merge:** release-please tags at the _merge commit_. Notes
+     filled after merge land in a commit _after_ the tag, so the tagged build
+     ships placeholder/empty notes. The `release-notes-lint` check enforces this
+     (see "Release-notes gate" below).
+   - Verify locally first: `bun run release-notes:lint`.
+   - A chore-only release (no Features/Bug Fixes) has no scaffold and nothing to
+     fill — `release-notes-lint` passes via its missing-file no-op path.
+4. Merge the PR. release-please pushes the `vX.Y.Z` tag **and publishes a
+   GitHub Release** (as a draft — `"draft": true` in the release-please config;
+   publishing is the manual "ship" click in the Releases UI).
+5. `build-production` workflow fires on the published Release. It re-runs
+   `release-notes-lint`, splits the notes into store artifacts, and passes
+   `--what-to-test` to `eas build`. Watch it in Actions.
+6. After EAS finishes:
    - iOS: build appears in App Store Connect → TestFlight. External testers
      get it automatically (if the build is in a beta group with
      auto-distribution). The App Store release still requires manual
@@ -84,6 +100,30 @@ If you need to re-run a production build against an existing tag (e.g.,
 because EAS failed transiently), use **Actions → build-production → "Run
 workflow"** and supply the tag (e.g., `v0.1.4`) as the `ref` input. You can
 also choose `platform` = `ios` or `android` for a platform-specific re-run.
+
+## Release-notes gate
+
+One markdown file per version (`docs/release/testing-notes/<version>.md`) is the
+single source for three store fields: Play "What's new", App Store "What's New",
+and TestFlight "What to Test". The slices are marker-delimited; the scripts under
+`scripts/release-notes-*.ts` generate, lint, and split them.
+
+Two checks run `release-notes:lint`, at two different moments:
+
+| Check                             | When                                 | Purpose                                                                |
+| --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------- |
+| `release-notes-lint.yml`          | On the release PR (human push)       | Force `TODO:` lines to be filled **before** the tag is cut.            |
+| `_release-validate.yml` (publish) | When the GitHub Release is published | Last-resort gate — fails the build rather than ship placeholder notes. |
+
+The PR check is the one that matters for getting real notes into the tagged
+commit. **It does not run when the bot opens the PR** — commits pushed with the
+default `GITHUB_TOKEN` (the scaffold commit) don't trigger workflows. It runs the
+moment a human pushes to the release branch (i.e. when you fill the TODOs).
+
+**One-time setup:** add **"Release Notes Lint"** as a required status check on
+`main` in branch protection (Settings → Branches). A required check that hasn't
+reported is treated as pending and blocks merge, so this also catches the case
+where someone tries to merge the raw scaffold without ever pushing a fill.
 
 ## Advancing the Android rollout
 

--- a/apps/native-rd/scripts/__tests__/release-notes-changelog.test.ts
+++ b/apps/native-rd/scripts/__tests__/release-notes-changelog.test.ts
@@ -1,0 +1,180 @@
+import {
+  buildScaffold,
+  extractVersionSection,
+  isUserFacing,
+  parseBullet,
+  parseSection,
+  todoList,
+  type ChangelogSection,
+} from "../release-notes-changelog";
+
+describe("parseBullet", () => {
+  test("extracts a conventional-commit scope and strips a trailing PR link", () => {
+    const entry = parseBullet(
+      "* **goals:** add next-step hint to home card ([#42](https://x/pull/42))",
+    );
+    expect(entry).toEqual({
+      scope: "goals",
+      title: "add next-step hint to home card",
+    });
+  });
+
+  test("returns a null scope for an unscoped bullet", () => {
+    expect(parseBullet("- plain change with no scope")).toEqual({
+      scope: null,
+      title: "plain change with no scope",
+    });
+  });
+
+  test("peels release-please's ', closes [#NN](url)' suffix", () => {
+    const entry = parseBullet(
+      "* **ci:** unbreak format check, closes [#213](https://x/issues/213)",
+    );
+    expect(entry.title).toBe("unbreak format check");
+  });
+
+  test("peels multiple stacked link groups", () => {
+    const entry = parseBullet(
+      "* **native-rd:** localise date ([abc123](https://x/commit/abc123)) ([#210](https://x/pull/210))",
+    );
+    expect(entry.title).toBe("localise date");
+  });
+});
+
+describe("extractVersionSection", () => {
+  const changelog = [
+    "# Changelog",
+    "",
+    "## [0.1.41] (2026-06-01)",
+    "",
+    "### Features",
+    "",
+    "* later feature",
+    "",
+    "## [0.1.4] (2026-05-20)",
+    "",
+    "### Bug Fixes",
+    "",
+    "* the target fix",
+    "",
+    "## 0.1.3 (2026-05-10)",
+    "",
+    "### Features",
+    "",
+    "* an older feature",
+  ].join("\n");
+
+  test("returns only the requested linked-form section", () => {
+    const section = extractVersionSection(changelog, "0.1.4");
+    expect(section).toContain("the target fix");
+    expect(section).not.toContain("later feature");
+    expect(section).not.toContain("an older feature");
+  });
+
+  test("does not match a longer version sharing the prefix (0.1.4 vs 0.1.41)", () => {
+    // The \b guard means looking up 0.1.4 must skip the 0.1.41 heading.
+    const section = extractVersionSection(changelog, "0.1.4");
+    expect(section).not.toContain("later feature");
+  });
+
+  test("matches the unlinked '## X.Y.Z' heading form", () => {
+    const section = extractVersionSection(changelog, "0.1.3");
+    expect(section).toContain("an older feature");
+  });
+
+  test("throws when the version is absent", () => {
+    expect(() => extractVersionSection(changelog, "9.9.9")).toThrow(
+      /Could not find version 9\.9\.9/,
+    );
+  });
+});
+
+describe("parseSection", () => {
+  test("buckets Features and Bug Fixes and ignores other headings", () => {
+    const section = [
+      "### Features",
+      "* **goals:** add hint",
+      "* add streaks",
+      "",
+      "### Bug Fixes",
+      "* **ui:** fix crash",
+      "",
+      "### Miscellaneous Chores",
+      "* bump deps",
+    ].join("\n");
+    const parsed = parseSection(section);
+    expect(parsed.features).toHaveLength(2);
+    expect(parsed.fixes).toHaveLength(1);
+    expect(parsed.features.map((f) => f.title)).toEqual([
+      "add hint",
+      "add streaks",
+    ]);
+    // The chore bullet sits under a non-tracked heading → excluded entirely.
+    expect(parsed.fixes[0].title).toBe("fix crash");
+  });
+});
+
+describe("isUserFacing", () => {
+  test("treats an unscoped entry as user-facing", () => {
+    expect(isUserFacing({ scope: null, title: "x" })).toBe(true);
+  });
+
+  test.each(["ci", "chore", "build", "deps", "release"])(
+    "hides internal scope %p",
+    (scope) => {
+      expect(isUserFacing({ scope, title: "x" })).toBe(false);
+    },
+  );
+
+  test("matches internal scopes case-insensitively", () => {
+    expect(isUserFacing({ scope: "CI", title: "x" })).toBe(false);
+  });
+
+  test("treats a product scope as user-facing", () => {
+    expect(isUserFacing({ scope: "goals", title: "x" })).toBe(true);
+  });
+});
+
+describe("todoList", () => {
+  test("renders a (none) placeholder for an empty list", () => {
+    expect(todoList([])).toBe("- TODO: (none in this release)");
+  });
+
+  test("prefixes each entry with 'TODO: '", () => {
+    expect(todoList([{ scope: null, title: "do a thing" }])).toBe(
+      "- TODO: do a thing",
+    );
+  });
+});
+
+describe("buildScaffold", () => {
+  const section: ChangelogSection = {
+    features: [
+      { scope: "goals", title: "add hint" },
+      { scope: "ci", title: "tweak pipeline" },
+    ],
+    fixes: [{ scope: null, title: "fix a crash" }],
+  };
+
+  test("embeds the version and injected date, and stays linter-failing", () => {
+    const { content } = buildScaffold("0.1.5", section, "2026-05-29");
+    expect(content).toContain("version: 0.1.5");
+    expect(content).toContain("date: 2026-05-29");
+    // The scaffold MUST contain TODO markers so release-notes:lint blocks it.
+    expect(content).toContain("TODO:");
+  });
+
+  test("counts user-facing vs internal entries", () => {
+    const scaffold = buildScaffold("0.1.5", section, "2026-05-29");
+    expect(scaffold.userFacingFeatureCount).toBe(1);
+    expect(scaffold.internalFeatureCount).toBe(1);
+    expect(scaffold.userFacingFixCount).toBe(1);
+    expect(scaffold.internalFixCount).toBe(0);
+  });
+
+  test("excludes internal-scope entries from the user-facing slices", () => {
+    const { content } = buildScaffold("0.1.5", section, "2026-05-29");
+    expect(content).toContain("add hint");
+    expect(content).not.toContain("tweak pipeline");
+  });
+});

--- a/apps/native-rd/scripts/__tests__/release-notes-shared.test.ts
+++ b/apps/native-rd/scripts/__tests__/release-notes-shared.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  checkSlice,
+  extractSlice,
+  LIMITS,
+  resolveVersion,
+} from "../release-notes-shared";
+
+describe("extractSlice", () => {
+  const src = [
+    "intro",
+    "<!-- play:start -->",
+    "  Goals now show your next step.  ",
+    "<!-- play:end -->",
+    "outro",
+  ].join("\n");
+
+  test("returns the trimmed body between markers", () => {
+    expect(extractSlice(src, "play")).toBe("Goals now show your next step.");
+  });
+
+  test("returns null when the start marker is missing", () => {
+    expect(extractSlice("<!-- play:end -->", "play")).toBeNull();
+  });
+
+  test("returns null when the end marker is missing", () => {
+    expect(extractSlice("<!-- play:start -->body", "play")).toBeNull();
+  });
+
+  test("returns null for a slice whose markers are absent", () => {
+    expect(extractSlice(src, "testflight")).toBeNull();
+  });
+
+  test("returns empty string when markers are adjacent", () => {
+    expect(extractSlice("<!-- play:start --><!-- play:end -->", "play")).toBe(
+      "",
+    );
+  });
+});
+
+describe("checkSlice", () => {
+  test("flags missing markers when body is null", () => {
+    expect(checkSlice("play", null)).toEqual({
+      slice: "play",
+      reason: expect.stringContaining("missing"),
+    });
+  });
+
+  test("flags an empty body between markers", () => {
+    expect(checkSlice("play", "")).toEqual({
+      slice: "play",
+      reason: "empty body between markers",
+    });
+  });
+
+  test("flags the literal TODO: scaffold marker", () => {
+    const v = checkSlice("appstore", "**New**\n- TODO: add next-step hint");
+    expect(v?.reason).toContain("TODO:");
+  });
+
+  test("does not false-positive on prose containing the word TODO", () => {
+    // "TODO list" has no colon, so the \bTODO: guard must let it through.
+    expect(checkSlice("play", "We rebuilt the TODO list view.")).toBeNull();
+  });
+
+  test("flags a body that exceeds the per-store limit", () => {
+    const tooLong = "x".repeat(LIMITS.play + 1);
+    const v = checkSlice("play", tooLong);
+    expect(v?.reason).toContain(`exceeds limit of ${LIMITS.play}`);
+  });
+
+  test("accepts a body exactly at the limit", () => {
+    expect(checkSlice("play", "x".repeat(LIMITS.play))).toBeNull();
+  });
+
+  test("passes a well-formed body", () => {
+    expect(
+      checkSlice("testflight", "Create a goal, verify the hint."),
+    ).toBeNull();
+  });
+});
+
+describe("resolveVersion", () => {
+  // appRoot is only read for the no-arg fallback; the arg path never touches fs.
+  const NO_FS = "/this/path/does/not/exist";
+
+  test("returns a valid semver arg without reading the filesystem", () => {
+    expect(resolveVersion("0.1.4", NO_FS)).toBe("0.1.4");
+  });
+
+  test("accepts a prerelease version", () => {
+    expect(resolveVersion("0.1.4-rc.1", NO_FS)).toBe("0.1.4-rc.1");
+  });
+
+  test("accepts build metadata", () => {
+    expect(resolveVersion("1.2.3+build.5", NO_FS)).toBe("1.2.3+build.5");
+  });
+
+  test.each([
+    "1.2",
+    "v1.2.3",
+    "1.2.3.4",
+    "latest",
+    "../../etc/passwd",
+    "1.2.x",
+  ])("rejects non-semver arg %p", (bad) => {
+    expect(() => resolveVersion(bad, NO_FS)).toThrow(/Invalid version/);
+  });
+
+  test("falls back to package.json version when no arg is given", () => {
+    const appRoot = join(__dirname, "..", "..");
+    const pkgVersion = (
+      JSON.parse(readFileSync(join(appRoot, "package.json"), "utf8")) as {
+        version: string;
+      }
+    ).version;
+    expect(resolveVersion(undefined, appRoot)).toBe(pkgVersion);
+  });
+
+  test("throws a clear error when the fallback package.json is unreadable", () => {
+    expect(() => resolveVersion(undefined, NO_FS)).toThrow();
+  });
+});

--- a/apps/native-rd/scripts/__tests__/release-notes-store.test.ts
+++ b/apps/native-rd/scripts/__tests__/release-notes-store.test.ts
@@ -1,0 +1,51 @@
+import { mergeStoreConfig } from "../release-notes-store";
+
+describe("mergeStoreConfig", () => {
+  test("injects releaseNotes into apple.info['en-US']", () => {
+    const merged = mergeStoreConfig({}, "What's new copy");
+    expect(merged.apple?.info?.["en-US"]).toEqual({
+      releaseNotes: "What's new copy",
+    });
+  });
+
+  test("preserves unrelated base fields and other locales", () => {
+    const base = {
+      configVersion: 0,
+      apple: {
+        info: {
+          "en-US": { title: "Rollercoaster", subtitle: "Goals" },
+          "de-DE": { title: "Rollercoaster DE" },
+        },
+      },
+    };
+    const merged = mergeStoreConfig(base, "Notes");
+    expect(merged.configVersion).toBe(0);
+    expect(merged.apple?.info?.["en-US"]).toEqual({
+      title: "Rollercoaster",
+      subtitle: "Goals",
+      releaseNotes: "Notes",
+    });
+    expect(merged.apple?.info?.["de-DE"]).toEqual({
+      title: "Rollercoaster DE",
+    });
+  });
+
+  test("does not mutate the base object (defensive deep clone)", () => {
+    const base = { apple: { info: { "en-US": { title: "X" } } } };
+    const snapshot = JSON.stringify(base);
+    mergeStoreConfig(base, "Notes");
+    expect(JSON.stringify(base)).toBe(snapshot);
+  });
+
+  test("tolerates a base with no apple key", () => {
+    const merged = mergeStoreConfig({ configVersion: 0 }, "Notes");
+    expect(merged.configVersion).toBe(0);
+    expect(merged.apple?.info?.["en-US"]?.releaseNotes).toBe("Notes");
+  });
+
+  test("tolerates a null/undefined base", () => {
+    expect(mergeStoreConfig(null, "Notes").apple?.info?.["en-US"]).toEqual({
+      releaseNotes: "Notes",
+    });
+  });
+});

--- a/apps/native-rd/scripts/__tests__/release-notes-workflow-contract.test.ts
+++ b/apps/native-rd/scripts/__tests__/release-notes-workflow-contract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Cross-file contract test for the chore-only-release path.
+ *
+ * release-please.yml runs release-notes-generate.ts when it opens a release PR.
+ * For a chore-only release (no Features/Bug Fixes in CHANGELOG.md) the script
+ * exits non-zero on purpose; the workflow distinguishes that *expected* failure
+ * from a real one by grepping the script's stderr for a sentinel phrase:
+ *
+ *   if ! grep -q "no Features or Bug Fixes" "$GEN_STDERR"; then ... exit 1
+ *
+ * The two sides live in different files and languages (a `.ts` console.error and
+ * a `.yml` grep), so nothing but this test stops them drifting. If the error
+ * message is reworded, a chore-only release crashes the workflow; if the grep is
+ * reworded, every chore-only release silently scaffolds nothing. Both are
+ * invisible until a release actually happens. This test fails the moment either
+ * side moves. release-notes-generate.ts is not imported directly — it uses
+ * `import.meta`, which babel-preset-expo (Hermes target) can't parse — so we
+ * read it as source instead.
+ */
+const SENTINEL = "no Features or Bug Fixes";
+
+const SCRIPTS_DIR = join(__dirname, "..");
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+
+describe("chore-only release grep coupling", () => {
+  test("release-notes-generate.ts emits the sentinel phrase", () => {
+    const src = readFileSync(
+      join(SCRIPTS_DIR, "release-notes-generate.ts"),
+      "utf8",
+    );
+    expect(src).toContain(SENTINEL);
+  });
+
+  test("release-please.yml greps for the same sentinel phrase", () => {
+    const workflow = readFileSync(
+      join(REPO_ROOT, ".github", "workflows", "release-please.yml"),
+      "utf8",
+    );
+    expect(workflow).toContain(`grep -q "${SENTINEL}"`);
+  });
+});

--- a/apps/native-rd/scripts/release-notes-changelog.ts
+++ b/apps/native-rd/scripts/release-notes-changelog.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure changelog→scaffold logic for release-notes-generate.
+ *
+ * Parses a release-please CHANGELOG.md section into Features/Bug Fixes entries
+ * and builds the marker-delimited testing-notes scaffold. Kept free of
+ * `import.meta` and filesystem access so jest (babel-preset-expo, which targets
+ * Hermes) can import it directly — see release-notes-generate.ts for the thin
+ * CLI wrapper that owns the fs bootstrap and the `import.meta.main` guard.
+ */
+
+export type ChangelogEntry = {
+  scope: string | null;
+  title: string;
+};
+
+export type ChangelogSection = {
+  features: ChangelogEntry[];
+  fixes: ChangelogEntry[];
+};
+
+// Scopes whose entries are internal-only (build infra, CI, dependency bumps,
+// release-please chores). They stay in CHANGELOG.md but don't belong in any
+// user-facing or tester-facing release notes.
+export const INTERNAL_SCOPES = new Set([
+  "ci",
+  "chore",
+  "build",
+  "deps",
+  "release",
+]);
+
+export function parseBullet(line: string): ChangelogEntry {
+  let text = line.replace(/^[*-]\s+/, "");
+  // Extract the conventional-commit scope ("**scope:**") before stripping it,
+  // so downstream filters can act on scope rather than cleaned title text.
+  const scopeMatch = /^\*\*([^*]+):\*\*\s+/.exec(text);
+  const scope = scopeMatch ? scopeMatch[1].trim() : null;
+  if (scopeMatch) text = text.slice(scopeMatch[0].length);
+  // Strip trailing parenthetical link groups like ` ([#12](url))` or ` ([hash](url))`,
+  // including release-please's ", closes [#NN](url)" suffix. Iterate to peel them off.
+  while (true) {
+    const stripped = text
+      .replace(/,?\s+closes\s+\[[^\]]+\]\([^)]+\)\s*$/, "")
+      .replace(/\s+\(\[[^\]]+\]\([^)]+\)\)\s*$/, "");
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return { scope, title: text.trim() };
+}
+
+export function extractVersionSection(
+  changelog: string,
+  version: string,
+): string {
+  // Match heading lines: "## [X.Y.Z]..." (release-please linked form) or
+  // "## X.Y.Z..." (older hand-written entries — CHANGELOG.md mixes both).
+  // `version` is already sanitized to strict semver by resolveVersion, but we
+  // still apply the MDN-canonical full regex-meta escape here so CodeQL's
+  // "incomplete string escaping" heuristic doesn't trip on a partial escape.
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Use \b on the unlinked alternative so "## 0.1.4" does not match "## 0.1.41".
+  // The bracketed form is already self-delimiting via the closing "]".
+  const headingRe = new RegExp(
+    `^##\\s+(?:\\[${escaped}\\]|${escaped}\\b)[^\\n]*$`,
+    "m",
+  );
+  const match = headingRe.exec(changelog);
+  if (!match) {
+    throw new Error(
+      `Could not find version ${version} in CHANGELOG.md ` +
+        `(looked for "## [${version}]..." or "## ${version}..."). ` +
+        `If release-please has not run yet, pass the version explicitly.`,
+    );
+  }
+  const start = match.index + match[0].length;
+  // Next heading is the start of the previous (older) release section. Match
+  // both linked ("## [x.y.z]") and unlinked ("## x.y.z") forms so we stop at
+  // the first older entry regardless of which form CHANGELOG.md uses there.
+  const nextHeadingRe = /^##\s+(?:\[|\d)/m;
+  const rest = changelog.slice(start);
+  const nextMatch = nextHeadingRe.exec(rest);
+  return nextMatch ? rest.slice(0, nextMatch.index) : rest;
+}
+
+export function parseSection(section: string): ChangelogSection {
+  const result: ChangelogSection = { features: [], fixes: [] };
+  const lines = section.split("\n");
+  let bucket: "features" | "fixes" | null = null;
+  for (const line of lines) {
+    if (/^###\s+Features\b/.test(line)) {
+      bucket = "features";
+      continue;
+    }
+    if (/^###\s+Bug\s+Fixes\b/.test(line)) {
+      bucket = "fixes";
+      continue;
+    }
+    if (/^###\s+/.test(line)) {
+      bucket = null;
+      continue;
+    }
+    if (bucket && /^[*-]\s+/.test(line)) {
+      result[bucket].push(parseBullet(line));
+    }
+  }
+  return result;
+}
+
+export function todoList(items: ChangelogEntry[]): string {
+  if (items.length === 0) return "- TODO: (none in this release)";
+  return items.map((item) => `- TODO: ${item.title}`).join("\n");
+}
+
+export function isUserFacing(entry: ChangelogEntry): boolean {
+  if (entry.scope === null) return true;
+  return !INTERNAL_SCOPES.has(entry.scope.toLowerCase());
+}
+
+export type Scaffold = {
+  content: string;
+  userFacingFeatureCount: number;
+  userFacingFixCount: number;
+  internalFeatureCount: number;
+  internalFixCount: number;
+};
+
+export function buildScaffold(
+  version: string,
+  section: ChangelogSection,
+  today: string,
+): Scaffold {
+  const userFacingFeatures = section.features.filter(isUserFacing);
+  const userFacingFixes = section.fixes.filter(isUserFacing);
+  const content = `---
+version: ${version}
+versionCode: TODO
+date: ${today}
+---
+
+# Testing notes — ${version}
+
+> Scaffold generated from CHANGELOG.md. Rewrite each \`TODO: \` line:
+> - **play** / **appstore**: user-facing copy (no jargon, no PR numbers)
+> - **testflight**: tester instructions (steps to exercise + expected result)
+>
+> The release-notes:lint check fails while any \`TODO\` remains.
+
+## Google Play — What's new (en-US, max 500 chars)
+
+End-user copy. Lead with the user benefit. Tight — 500 chars goes fast.
+
+<!-- play:start -->
+
+TODO: 2–4 short bullets or a single paragraph describing what improved for the user in plain language.
+
+<!-- play:end -->
+
+## App Store — Release notes (en-US, max 4000 chars)
+
+End-user copy. Same voice as Play, but more room.
+
+<!-- appstore:start -->
+
+**New**
+
+${todoList(userFacingFeatures)}
+
+**Fixed**
+
+${todoList(userFacingFixes)}
+
+<!-- appstore:end -->
+
+## TestFlight — What to test (max 4000 chars)
+
+Tester-facing QA brief. Rewrite each line as: what to do → expected result.
+
+<!-- testflight:start -->
+
+**Focus areas this build**
+
+${todoList(userFacingFeatures)}
+
+**Recent fixes worth a sanity check**
+
+${todoList(userFacingFixes)}
+
+**Reporting**
+
+- File anything weird in GitHub issues with the build number from Settings → About.
+
+<!-- testflight:end -->
+`;
+  return {
+    content,
+    userFacingFeatureCount: userFacingFeatures.length,
+    userFacingFixCount: userFacingFixes.length,
+    internalFeatureCount: section.features.length - userFacingFeatures.length,
+    internalFixCount: section.fixes.length - userFacingFixes.length,
+  };
+}

--- a/apps/native-rd/scripts/release-notes-generate.ts
+++ b/apps/native-rd/scripts/release-notes-generate.ts
@@ -16,199 +16,28 @@
  * (i.e. the version release-please just bumped to). Pass a version arg
  * to override: `bun run scripts/release-notes-generate.ts 0.1.5`.
  *
+ * Parsing + scaffold-building live in release-notes-changelog.ts (pure, no
+ * `import.meta`) so they're unit-testable; this file owns the fs bootstrap.
+ *
  * Run: bun run release-notes:generate
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { APP_ROOT, resolveVersion } from "./release-notes-shared";
+import {
+  buildScaffold,
+  extractVersionSection,
+  parseSection,
+} from "./release-notes-changelog";
+import { resolveVersion } from "./release-notes-shared";
 
+const APP_ROOT = join(import.meta.dir, "..");
 const CHANGELOG_PATH = join(APP_ROOT, "CHANGELOG.md");
 const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 
-type ChangelogEntry = {
-  scope: string | null;
-  title: string;
-};
-
-type ChangelogSection = {
-  features: ChangelogEntry[];
-  fixes: ChangelogEntry[];
-};
-
-// Scopes whose entries are internal-only (build infra, CI, dependency bumps,
-// release-please chores). They stay in CHANGELOG.md but don't belong in any
-// user-facing or tester-facing release notes.
-const INTERNAL_SCOPES = new Set(["ci", "chore", "build", "deps", "release"]);
-
-function parseBullet(line: string): ChangelogEntry {
-  let text = line.replace(/^[*-]\s+/, "");
-  // Extract the conventional-commit scope ("**scope:**") before stripping it,
-  // so downstream filters can act on scope rather than cleaned title text.
-  const scopeMatch = /^\*\*([^*]+):\*\*\s+/.exec(text);
-  const scope = scopeMatch ? scopeMatch[1].trim() : null;
-  if (scopeMatch) text = text.slice(scopeMatch[0].length);
-  // Strip trailing parenthetical link groups like ` ([#12](url))` or ` ([hash](url))`,
-  // including release-please's ", closes [#NN](url)" suffix. Iterate to peel them off.
-  while (true) {
-    const stripped = text
-      .replace(/,?\s+closes\s+\[[^\]]+\]\([^)]+\)\s*$/, "")
-      .replace(/\s+\(\[[^\]]+\]\([^)]+\)\)\s*$/, "");
-    if (stripped === text) break;
-    text = stripped;
-  }
-  return { scope, title: text.trim() };
-}
-
-function extractVersionSection(changelog: string, version: string): string {
-  // Match heading lines: "## [X.Y.Z]..." (release-please linked form) or
-  // "## X.Y.Z..." (older hand-written entries — CHANGELOG.md mixes both).
-  // `version` is already sanitized to strict semver by resolveVersion, but we
-  // still apply the MDN-canonical full regex-meta escape here so CodeQL's
-  // "incomplete string escaping" heuristic doesn't trip on a partial escape.
-  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Use \b on the unlinked alternative so "## 0.1.4" does not match "## 0.1.41".
-  // The bracketed form is already self-delimiting via the closing "]".
-  const headingRe = new RegExp(
-    `^##\\s+(?:\\[${escaped}\\]|${escaped}\\b)[^\\n]*$`,
-    "m",
-  );
-  const match = headingRe.exec(changelog);
-  if (!match) {
-    throw new Error(
-      `Could not find version ${version} in CHANGELOG.md ` +
-        `(looked for "## [${version}]..." or "## ${version}..."). ` +
-        `If release-please has not run yet, pass the version explicitly.`,
-    );
-  }
-  const start = match.index + match[0].length;
-  // Next heading is the start of the previous (older) release section. Match
-  // both linked ("## [x.y.z]") and unlinked ("## x.y.z") forms so we stop at
-  // the first older entry regardless of which form CHANGELOG.md uses there.
-  const nextHeadingRe = /^##\s+(?:\[|\d)/m;
-  const rest = changelog.slice(start);
-  const nextMatch = nextHeadingRe.exec(rest);
-  return nextMatch ? rest.slice(0, nextMatch.index) : rest;
-}
-
-function parseSection(section: string): ChangelogSection {
-  const result: ChangelogSection = { features: [], fixes: [] };
-  const lines = section.split("\n");
-  let bucket: "features" | "fixes" | null = null;
-  for (const line of lines) {
-    if (/^###\s+Features\b/.test(line)) {
-      bucket = "features";
-      continue;
-    }
-    if (/^###\s+Bug\s+Fixes\b/.test(line)) {
-      bucket = "fixes";
-      continue;
-    }
-    if (/^###\s+/.test(line)) {
-      bucket = null;
-      continue;
-    }
-    if (bucket && /^[*-]\s+/.test(line)) {
-      result[bucket].push(parseBullet(line));
-    }
-  }
-  return result;
-}
-
-function todoList(items: ChangelogEntry[]): string {
-  if (items.length === 0) return "- TODO: (none in this release)";
-  return items.map((item) => `- TODO: ${item.title}`).join("\n");
-}
-
-function isUserFacing(entry: ChangelogEntry): boolean {
-  if (entry.scope === null) return true;
-  return !INTERNAL_SCOPES.has(entry.scope.toLowerCase());
-}
-
-type Scaffold = {
-  content: string;
-  userFacingFeatureCount: number;
-  userFacingFixCount: number;
-  internalFeatureCount: number;
-  internalFixCount: number;
-};
-
-function buildScaffold(version: string, section: ChangelogSection): Scaffold {
-  const today = new Date().toISOString().slice(0, 10);
-  const userFacingFeatures = section.features.filter(isUserFacing);
-  const userFacingFixes = section.fixes.filter(isUserFacing);
-  const content = `---
-version: ${version}
-versionCode: TODO
-date: ${today}
----
-
-# Testing notes — ${version}
-
-> Scaffold generated from CHANGELOG.md. Rewrite each \`TODO: \` line:
-> - **play** / **appstore**: user-facing copy (no jargon, no PR numbers)
-> - **testflight**: tester instructions (steps to exercise + expected result)
->
-> The release-notes:lint check fails while any \`TODO\` remains.
-
-## Google Play — What's new (en-US, max 500 chars)
-
-End-user copy. Lead with the user benefit. Tight — 500 chars goes fast.
-
-<!-- play:start -->
-
-TODO: 2–4 short bullets or a single paragraph describing what improved for the user in plain language.
-
-<!-- play:end -->
-
-## App Store — Release notes (en-US, max 4000 chars)
-
-End-user copy. Same voice as Play, but more room.
-
-<!-- appstore:start -->
-
-**New**
-
-${todoList(userFacingFeatures)}
-
-**Fixed**
-
-${todoList(userFacingFixes)}
-
-<!-- appstore:end -->
-
-## TestFlight — What to test (max 4000 chars)
-
-Tester-facing QA brief. Rewrite each line as: what to do → expected result.
-
-<!-- testflight:start -->
-
-**Focus areas this build**
-
-${todoList(userFacingFeatures)}
-
-**Recent fixes worth a sanity check**
-
-${todoList(userFacingFixes)}
-
-**Reporting**
-
-- File anything weird in GitHub issues with the build number from Settings → About.
-
-<!-- testflight:end -->
-`;
-  return {
-    content,
-    userFacingFeatureCount: userFacingFeatures.length,
-    userFacingFixCount: userFacingFixes.length,
-    internalFeatureCount: section.features.length - userFacingFeatures.length,
-    internalFixCount: section.fixes.length - userFacingFixes.length,
-  };
-}
-
 function main(): number {
-  const version = resolveVersion(process.argv[2]);
+  const version = resolveVersion(process.argv[2], APP_ROOT);
   const outPath = join(NOTES_DIR, `${version}.md`);
   if (existsSync(outPath)) {
     console.error(
@@ -225,7 +54,8 @@ function main(): number {
     );
     return 1;
   }
-  const scaffold = buildScaffold(version, parsed);
+  const today = new Date().toISOString().slice(0, 10);
+  const scaffold = buildScaffold(version, parsed, today);
   writeFileSync(outPath, scaffold.content);
   const hiddenFeatures =
     scaffold.internalFeatureCount > 0

--- a/apps/native-rd/scripts/release-notes-lint.ts
+++ b/apps/native-rd/scripts/release-notes-lint.ts
@@ -15,13 +15,13 @@ import { readdirSync, readFileSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import {
-  APP_ROOT,
   checkSlice,
   extractSlice,
   SLICES,
   type SliceViolation,
 } from "./release-notes-shared";
 
+const APP_ROOT = join(import.meta.dir, "..");
 const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 
 type FileViolation = SliceViolation & { file: string };

--- a/apps/native-rd/scripts/release-notes-shared.ts
+++ b/apps/native-rd/scripts/release-notes-shared.ts
@@ -8,8 +8,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-export const APP_ROOT = join(import.meta.dir, "..");
-
 export type SliceName = "play" | "appstore" | "testflight";
 
 export const SLICES: readonly SliceName[] = ["play", "appstore", "testflight"];
@@ -70,8 +68,11 @@ export function checkSlice(
 // release-notes-generate.ts, so CLI argv can't smuggle regex meta-chars in.
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
-export function resolveVersion(arg: string | undefined): string {
-  const candidate = arg && arg.length > 0 ? arg : readPackageVersion();
+export function resolveVersion(
+  arg: string | undefined,
+  appRoot: string,
+): string {
+  const candidate = arg && arg.length > 0 ? arg : readPackageVersion(appRoot);
   if (!SEMVER_RE.test(candidate)) {
     throw new Error(
       `Invalid version "${candidate}" — expected semver like 0.1.4 or 0.1.4-rc.1.`,
@@ -80,8 +81,8 @@ export function resolveVersion(arg: string | undefined): string {
   return candidate;
 }
 
-function readPackageVersion(): string {
-  const pkgPath = join(APP_ROOT, "package.json");
+function readPackageVersion(appRoot: string): string {
+  const pkgPath = join(appRoot, "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
   if (!pkg.version) throw new Error(`No version in ${pkgPath}`);
   return pkg.version;

--- a/apps/native-rd/scripts/release-notes-split.ts
+++ b/apps/native-rd/scripts/release-notes-split.ts
@@ -22,43 +22,22 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
-  APP_ROOT,
   checkSlice,
   extractSlice,
   resolveVersion,
   SLICES,
   type SliceName,
 } from "./release-notes-shared";
+import { mergeStoreConfig } from "./release-notes-store";
 
+const APP_ROOT = join(import.meta.dir, "..");
 const NOTES_DIR = join(APP_ROOT, "docs", "release", "testing-notes");
 const ARTIFACTS_DIR = join(APP_ROOT, ".release-artifacts");
 const STORE_CONFIG_PATH = join(APP_ROOT, "store.config.json");
 const STORE_CONFIG_BASE_PATH = join(APP_ROOT, "store.config.base.json");
 
-type StoreConfig = {
-  configVersion?: number;
-  apple?: {
-    info?: Record<string, Record<string, unknown> | undefined>;
-  };
-};
-
-function mergeStoreConfig(
-  base: unknown,
-  appstoreReleaseNotes: string,
-): StoreConfig {
-  const cloned = JSON.parse(JSON.stringify(base ?? {})) as StoreConfig;
-  cloned.apple ??= {};
-  cloned.apple.info ??= {};
-  const locale = cloned.apple.info["en-US"] ?? {};
-  cloned.apple.info["en-US"] = {
-    ...locale,
-    releaseNotes: appstoreReleaseNotes,
-  };
-  return cloned;
-}
-
 function main(): number {
-  const version = resolveVersion(process.argv[2]);
+  const version = resolveVersion(process.argv[2], APP_ROOT);
   const notesPath = join(NOTES_DIR, `${version}.md`);
 
   let source: string;

--- a/apps/native-rd/scripts/release-notes-store.ts
+++ b/apps/native-rd/scripts/release-notes-store.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure EAS Metadata (store.config.json) merge logic for release-notes-split.
+ *
+ * Kept free of `import.meta` and filesystem access so jest can import it
+ * directly — release-notes-split.ts owns reading store.config.base.json and
+ * writing the merged store.config.json.
+ */
+
+export type StoreConfig = {
+  configVersion?: number;
+  apple?: {
+    info?: Record<string, Record<string, unknown> | undefined>;
+  };
+};
+
+/**
+ * Deep-clones `base` and injects `appstoreReleaseNotes` into
+ * apple.info["en-US"].releaseNotes, leaving every other field intact. The
+ * clone is defensive: callers pass the parsed store.config.base.json and must
+ * not see it mutated.
+ */
+export function mergeStoreConfig(
+  base: unknown,
+  appstoreReleaseNotes: string,
+): StoreConfig {
+  const cloned = JSON.parse(JSON.stringify(base ?? {})) as StoreConfig;
+  cloned.apple ??= {};
+  cloned.apple.info ??= {};
+  const locale = cloned.apple.info["en-US"] ?? {};
+  cloned.apple.info["en-US"] = {
+    ...locale,
+    releaseNotes: appstoreReleaseNotes,
+  };
+  return cloned;
+}


### PR DESCRIPTION
Closes #215 (partially — Android wiring deferred, see below).

Connects the existing `release-notes-{generate,lint,split}` script suite to the automated release path. Today the scripts work but are completely manual; after this PR, every release PR carries a tester-facing notes file, lint blocks Publish if it's not edited, and the iOS build/submit consumes the resulting artifacts.

## Three workflow changes

### `release-please.yml` — scaffold notes on the release PR
After release-please opens or updates its release PR, scaffold `apps/native-rd/docs/release/testing-notes/<version>.md` from `CHANGELOG.md` and commit it to the PR branch (bot identity, DCO-exempt). Skips cleanly when:
- the file already exists (subsequent release-please updates), or
- the release has no Features / Bug Fixes (chore-only — script's "no Features or Bug Fixes" error is detected and treated as a soft skip rather than a workflow failure).

### `_release-validate.yml` — lint as the human gate
Final step in the reusable validate workflow runs `bun run release-notes:lint`. Fails if any scaffold `TODO:` lines remain — the gate that stops a release being Published before notes are edited. No-ops cleanly on older tags re-validated via `workflow_dispatch` (no notes file → pass).

### `build-production.yml` — split + consume
- **`build-ios`**: generate `.release-artifacts/what-to-test.txt` + `store.config.json` via `release-notes:split`, then pass `--what-to-test "$(cat …)"` on `eas build` so the value is stored on the build record (and picked up by `eas submit --id <build_id>` at submission time).
- **`submit-ios`**: regenerate `store.config.json` so the iOS submit profile's `metadataPath: ./store.config.json` (from `eas.json`) resolves. Each job runs on its own runner so artifacts have to be reproduced locally — same logic, called from both jobs.
- Both jobs **fall back** to copying `store.config.base.json` when no testing-notes file exists, so older-tag `workflow_dispatch` runs keep working.

## Deferred — Android wiring

The Play internal track (current target until Google grants production access — see #217) doesn't consume per-release notes via the EAS submit API in the same way TestFlight + App Store do. Revisiting alongside the eventual production-track flip-back: that's the right moment to wire `metadataPath` / per-locale changelogs into `submit-android`.

## How it flows end-to-end

1. PR merges to `main` →
2. release-please opens/updates a release PR with the version bump **and** a `testing-notes/<version>.md` scaffold full of `TODO:` lines →
3. You edit the TODOs into real tester-facing language and merge the release PR →
4. release-please publishes a draft GitHub Release (still draft per config) →
5. You click **Publish** on the draft →
6. `build-production` validates (lint blocks if TODOs remained), builds iOS with `--what-to-test`, submits with `store.config.json` →
7. TestFlight gets *"What to Test"*, App Store gets *"What's New"*.

## Test plan

- [ ] YAML validated locally (js-yaml) — done
- [ ] type-check passes (husky pre-commit) — done
- [ ] On merge, next release-please PR carries a `0.1.10.md` scaffold (or current next-version)
- [ ] `release-notes:lint` fails on the release PR until TODOs are edited
- [ ] Once edited + Published, `build-ios` logs show `--what-to-test` was passed
- [ ] `submit-ios` logs show `store.config.json` present and consumed