### PR TITLE
fix(ci): finalize Sentry release by resolved per-platform name

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -268,6 +268,8 @@ jobs:
 
   finalize-sentry:
     needs:
+      - build-ios
+      - build-android
       - submit-ios
       - submit-android
     if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && (needs.submit-ios.result == 'success' || needs.submit-android.result == 'success') }}
@@ -290,16 +292,53 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: .
 
-      - name: Read version
-        id: version
-        run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
-
-      - name: Finalize Sentry release
+      # The Sentry React Native SDK names releases <bundleId>@<version>+<buildNumber>
+      # and creates them lazily on the first runtime event — so right after submit the
+      # release usually does not exist yet, and a bare "<version>" never matches. The
+      # iOS buildNumber and Android versionCode also differ, so there is no single name.
+      # Resolve each shipped build's real version + buildNumber from its EAS build record
+      # and create-or-finalize the correctly-named release per platform. `releases new`
+      # is idempotent; identical names (when build numbers are in sync) are deduped so we
+      # don't emit duplicate deploy markers.
+      #
+      # Note: this only writes the release + deploy marker. Symbolication depends on
+      # build-time sourcemap upload, which is tracked separately.
+      - name: Finalize Sentry releases
         env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: rollercoasterdev
           SENTRY_PROJECT: native-rd
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          IOS_BUILD_ID: ${{ needs.build-ios.outputs.build_id }}
+          ANDROID_BUILD_ID: ${{ needs.build-android.outputs.build_id }}
         run: |
-          npx --yes @sentry/cli@latest releases finalize "$RELEASE_VERSION"
-          npx --yes @sentry/cli@latest releases deploys "$RELEASE_VERSION" new --env production
+          set -euo pipefail
+          IOS_BUNDLE_ID="$(jq -r '.expo.ios.bundleIdentifier' app.json)"
+          ANDROID_BUNDLE_ID="$(jq -r '.expo.android.package' app.json)"
+          finalized=""
+
+          finalize() {
+            local build_id="$1" bundle_id="$2" info ver num rel
+            if [ -z "$build_id" ] || [ "$build_id" = "null" ]; then
+              echo "No build id for $bundle_id — skipping (platform not built this run)."
+              return 0
+            fi
+            info="$(npx --yes eas-cli@latest build:view "$build_id" --json)"
+            ver="$(echo "$info" | jq -r '.appVersion')"
+            num="$(echo "$info" | jq -r '.appBuildVersion')"
+            rel="${bundle_id}@${ver}+${num}"
+            case " $finalized " in
+              *" $rel "*)
+                echo "Already finalized $rel — skipping duplicate."
+                return 0
+                ;;
+            esac
+            finalized="$finalized $rel"
+            echo "Finalizing Sentry release: $rel"
+            npx --yes @sentry/cli@latest releases new "$rel"
+            npx --yes @sentry/cli@latest releases finalize "$rel"
+            npx --yes @sentry/cli@latest releases deploys "$rel" new --env production
+          }
+
+          finalize "${IOS_BUILD_ID:-}" "$IOS_BUNDLE_ID"
+          finalize "${ANDROID_BUILD_ID:-}" "$ANDROID_BUNDLE_ID"


### PR DESCRIPTION
## What

Rewrites the `finalize-sentry` job in `build-production.yml` so it finalizes the **actual** Sentry release name instead of a bare semver.

## Why

The v0.1.10 release pipeline ([run 26664728564](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/26664728564)) was marked **failed** even though both store submissions succeeded. The only failing job was `finalize-sentry`:

```
$ sentry-cli releases finalize "0.1.10"
error: Release not found. Ensure that you configured the correct release, project, and organization.
```

Root cause is three stacked problems:

1. **Name mismatch.** The Sentry React Native SDK names releases `<bundleId>@<version>+<buildNumber>` (e.g. `dev.rollercoaster.app@0.1.10+15`). The job asked for bare `0.1.10`, which never exists. This failed on *every* release — latent until `finalize-sentry` became its own gating job.
2. **Per-platform build numbers diverge.** iOS shipped `buildNumber 15`, Android shipped `versionCode 12`, so there is no single release name — there are two (`…+15`, `…+12`).
3. **Lazy creation race.** The SDK creates the release on the first *runtime* event. For v0.1.10 the only release that existed (`dev.rollercoaster.app@0.1.10+12`) was created by an Android device event at 23:02 — *after* finalize ran at 22:57. So even the correct name wouldn't have existed yet.

## How

For each platform actually built this run, resolve its real `version` + `buildNumber` from the EAS build record (`eas build:view <build_id> --json`) and **create-or-finalize** the correctly-named release:

```bash
rel="dev.rollercoaster.app@${ver}+${num}"
sentry-cli releases new "$rel"        # idempotent — guarantees existence (handles the race)
sentry-cli releases finalize "$rel"
sentry-cli releases deploys "$rel" new --env production
```

- `build-ios` / `build-android` added to `needs` so their `build_id` outputs are available; `EXPO_TOKEN` added for `build:view`.
- Bundle IDs read from `app.json` (not hardcoded).
- Runs per platform → drift-safe. Identical names (once build numbers are synced) are deduped so no duplicate deploy markers.
- Skips a platform not built in a single-platform `workflow_dispatch`.

## Scope / follow-ups

- **Build-number sync** (iOS 15 / Android 12) is being handled operationally via a one-time `eas build:version:set` to re-align both platforms, keeping EAS remote `autoIncrement`. Not part of this PR (no code change).
- **Symbolication.** Build-time sourcemap upload appears not to be creating releases (the v0.1.10 Xcode log shows no Sentry activity; only a runtime-created release exists). If confirmed, production stack traces are unsymbolicated. Tracked separately — **not** addressed here. This PR only writes the release + deploy marker.

## Validation

- `ruby -ryaml` parse: OK
- `bash -n` on the finalize script (portable, no bash-4 `declare -A`): OK
- Local `type-check`: passing (husky pre-commit)

Full end-to-end only exercises on the next `release: published`.