### PR TITLE
fix(ci): guard release-please env block against empty pr output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,11 @@ jobs:
       - name: Re-format release files with Prettier
         if: ${{ steps.release.outputs.pr }}
         env:
-          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          # GHA evaluates `env:` before `if:`, so a bare `fromJSON(...)` here
+          # throws on any merge to main that isn't a release-PR merge (the
+          # action emits an empty `pr` output). Short-circuit so fromJSON only
+          # runs when the output is non-empty.
+          PR_BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
         run: |
           set -euo pipefail
           # Pinned to the repo's Prettier major; app.json has no config/plugins,
@@ -68,7 +72,8 @@ jobs:
       - name: Scaffold testing notes for release PR
         if: ${{ steps.release.outputs.pr }}
         env:
-          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          # See note on the Prettier step above re: env-before-if evaluation.
+          PR_BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
         run: |
           set -euo pipefail
           VERSION="$(jq -r .version apps/native-rd/package.json)"


### PR DESCRIPTION
## Summary

- The two new release-PR helper steps in `release-please.yml` (Prettier reformat, testing-notes scaffold) read `fromJSON(steps.release.outputs.pr).headBranchName` inside their `env:` blocks.
- GHA evaluates `env:` **before** `if:`, so when release-please emits an empty `pr` output (any non-release-PR merge to main), those steps fail with `Error reading JToken from JsonReader` instead of being skipped.
- This bit on the #222 merge — the first non-release-PR push to main since #215/#218 landed — and turned the `release-please` workflow red ([run 26758604671](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/26758604671)).
- Fix: short-circuit the expression so `fromJSON` only runs when the output is non-empty. The `if:` gate continues to skip the step body for non-release merges; this just keeps the `env:` block evaluable when the step is going to be skipped.

## Why this was missed pre-merge

`release-please.yml` only runs on `push: main`, never on `pull_request` — so the regression couldn't have surfaced on the originating PR (#215/#218). It only manifests on the first `push: main` that isn't a release-PR merge.

## Test plan

- [ ] Watch the next `push: main` (this PR's merge) — `release-please` job should pass cleanly. Because there are no release-worthy commits queued, the `if:` gate will short-circuit both helper steps and release PR #221 will not be touched.
- [ ] Next time a release-worthy commit lands and release-please opens/updates a release PR, both helper steps run as before (no behavior change when `pr` is non-empty).