### PR TITLE
docs(launch): mark privacy policy as live

### DIFF
--- a/apps/native-rd/docs/launch/app-store-launch-plan.md
+++ b/apps/native-rd/docs/launch/app-store-launch-plan.md
@@ -40,8 +40,8 @@ New personal accounts must complete closed testing before production access:
 
 ### Legal Documents
 
-- [ ] **Privacy Policy** — See `docs/launch/privacy-policy.md`
-  - Host at https://rollercoaster.dev/privacy (or similar)
+- [x] **Privacy Policy** — See `docs/launch/privacy-policy.md`
+  - Live at https://rollercoaster.dev/privacy
   - Required by both Apple and Google before submission
 - [ ] **Terms of Service** (optional but recommended)
   - Can be added post-launch

--- a/apps/native-rd/docs/launch/production-release-plan.md
+++ b/apps/native-rd/docs/launch/production-release-plan.md
@@ -106,7 +106,7 @@ formal closed testing track in Play Console.
 - [ ] Screenshots are current and match the app.
 - [ ] Privacy nutrition labels match shipped behavior, including Sentry crash
       reporting.
-- [ ] Privacy policy URL is live.
+- [x] Privacy policy URL is live — https://rollercoaster.dev/privacy
 - [ ] Support URL is live.
 - [ ] Age rating is complete.
 - [ ] Export compliance is set.
@@ -120,7 +120,7 @@ formal closed testing track in Play Console.
 - [ ] Screenshots are current and match the app.
 - [ ] Data safety form matches shipped behavior, including Sentry crash
       reporting.
-- [ ] Privacy policy URL is live.
+- [x] Privacy policy URL is live — https://rollercoaster.dev/privacy
 - [ ] Content rating is complete.
 - [ ] Target audience / families declarations are complete.
 - [ ] Internal testing track has the intended tester list.

--- a/apps/native-rd/docs/launch/production-release-plan.md
+++ b/apps/native-rd/docs/launch/production-release-plan.md
@@ -106,7 +106,7 @@ formal closed testing track in Play Console.
 - [ ] Screenshots are current and match the app.
 - [ ] Privacy nutrition labels match shipped behavior, including Sentry crash
       reporting.
-- [x] Privacy policy URL is live — https://rollercoaster.dev/privacy
+- [x] Privacy policy URL is live — https://rollercoaster.dev/privacy.
 - [ ] Support URL is live.
 - [ ] Age rating is complete.
 - [ ] Export compliance is set.
@@ -120,7 +120,7 @@ formal closed testing track in Play Console.
 - [ ] Screenshots are current and match the app.
 - [ ] Data safety form matches shipped behavior, including Sentry crash
       reporting.
-- [x] Privacy policy URL is live — https://rollercoaster.dev/privacy
+- [x] Privacy policy URL is live — https://rollercoaster.dev/privacy.
 - [ ] Content rating is complete.
 - [ ] Target audience / families declarations are complete.
 - [ ] Internal testing track has the intended tester list.


### PR DESCRIPTION
## Summary

- Privacy policy is hosted and live at https://rollercoaster.dev/privacy.
- Both launch plans (`app-store-launch-plan.md` Phase 1, `production-release-plan.md` Phase 3 iOS + Android) still carried it as a `[ ]` checkbox with placeholder \"host at … (or similar)\" wording. Launch-readiness reviews have been re-flagging it as pending as a result.
- This PR flips the three checkboxes and names the live URL inline. Docs-only, no behavior change.

## Test plan

- [ ] Read the diff — three checkboxes flipped, no other prose changes.