### PR TITLE
fix(native-rd): keep Save button above keyboard on CaptureTextNote (#232)

### DIFF
--- a/apps/native-rd/App.tsx
+++ b/apps/native-rd/App.tsx
@@ -5,6 +5,7 @@ import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import {
   NavigationContainer,
   DefaultTheme,
@@ -124,7 +125,9 @@ export function App() {
     <ThemeProvider value={themeState}>
       <EvoluAppProvider>
         <SafeAreaProvider>
-          <ThemedApp />
+          <KeyboardProvider>
+            <ThemedApp />
+          </KeyboardProvider>
         </SafeAreaProvider>
       </EvoluAppProvider>
     </ThemeProvider>

--- a/apps/native-rd/src/__tests__/mocks/keyboard-controller.ts
+++ b/apps/native-rd/src/__tests__/mocks/keyboard-controller.ts
@@ -1,8 +1,10 @@
 /**
  * Mock for react-native-keyboard-controller
  *
- * Stubs the native keyboard event system. KeyboardProvider is a
- * passthrough; KeyboardAwareScrollView renders a standard ScrollView.
+ * Stubs the native keyboard event system. KeyboardProvider is a passthrough;
+ * KeyboardAwareScrollView renders a standard ScrollView;
+ * useReanimatedKeyboardAnimation returns SharedValue-shaped zeros so the
+ * keyboard appears permanently closed under jest/RNTL.
  */
 import React from "react";
 import { ScrollView } from "react-native";
@@ -17,3 +19,8 @@ export const KeyboardAwareScrollView = ({
   children: React.ReactNode;
   [key: string]: unknown;
 }) => React.createElement(ScrollView, rest, children);
+
+export const useReanimatedKeyboardAnimation = () => ({
+  height: { value: 0 },
+  progress: { value: 0 },
+});

--- a/apps/native-rd/src/screens/CaptureTextNote/CaptureTextNote.styles.ts
+++ b/apps/native-rd/src/screens/CaptureTextNote/CaptureTextNote.styles.ts
@@ -8,7 +8,8 @@ export const styles = StyleSheet.create((theme) => ({
   },
   content: {
     flex: 1,
-    padding: theme.space[4],
+    paddingHorizontal: theme.space[4],
+    paddingTop: theme.space[4],
     gap: theme.space[3],
   },
   textInput: {
@@ -23,7 +24,6 @@ export const styles = StyleSheet.create((theme) => ({
     fontFamily: theme.fontFamily.body,
     color: theme.colors.text,
     backgroundColor: theme.colors.backgroundSecondary,
-    minHeight: 200,
     textAlignVertical: "top",
     ...shadowStyle(theme, "cardElevation"),
   },
@@ -34,8 +34,6 @@ export const styles = StyleSheet.create((theme) => ({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingHorizontal: theme.space[4],
-    paddingVertical: theme.space[3],
   },
   charCount: {
     color: theme.colors.textMuted,

--- a/apps/native-rd/src/screens/CaptureTextNote/CaptureTextNote.tsx
+++ b/apps/native-rd/src/screens/CaptureTextNote/CaptureTextNote.tsx
@@ -1,13 +1,8 @@
 import React, { useState, useRef } from "react";
-import {
-  View,
-  TextInput,
-  KeyboardAvoidingView,
-  AccessibilityInfo,
-  Alert,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { KEYBOARD_AVOIDING_PROPS } from "../../utils/keyboard";
+import { View, TextInput, AccessibilityInfo, Alert } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { useUnistyles } from "react-native-unistyles";
@@ -19,6 +14,7 @@ import { createEvidence, EvidenceType, TEXT_EVIDENCE_PREFIX } from "../../db";
 import type { GoalId, StepId } from "../../db";
 import { reportError } from "../../services/sentry-report";
 import { useEvidenceStartBreadcrumb } from "../../hooks/useEvidenceStartBreadcrumb";
+import { useTabScreenContentInset } from "../../navigation/useTabScreenContentInset";
 import type { CaptureTextNoteScreenProps } from "../../navigation/types";
 import { styles } from "./CaptureTextNote.styles";
 
@@ -34,6 +30,20 @@ export function CaptureTextNote({ route }: CaptureTextNoteScreenProps) {
   const { theme } = useUnistyles();
   const { goalId, stepId } = route.params;
   const textInputRef = useRef<TextInput>(null);
+  const { paddingBottom: tabBarInset } = useTabScreenContentInset();
+  const insets = useSafeAreaInsets();
+  // height.value: 0 when keyboard closed, -keyboardHeight when open.
+  // Reanimated lets the padding interpolate in lockstep with the keyboard.
+  const { height } = useReanimatedKeyboardAnimation();
+  const contentAnimatedStyle = useAnimatedStyle(() => {
+    // iOS folds the bottom safe area into the keyboard frame; strip it so
+    // the footer sits flush against the visible keyboard top instead of
+    // floating one home-indicator-height above it.
+    const keyboardPad = Math.max(0, -height.value - insets.bottom);
+    return {
+      paddingBottom: Math.max(tabBarInset, keyboardPad),
+    };
+  });
 
   const [content, setContent] = useState("");
   const [caption, setCaption] = useState("");
@@ -85,7 +95,8 @@ export function CaptureTextNote({ route }: CaptureTextNoteScreenProps) {
     <View style={styles.container}>
       <ScreenSubHeader label={t("title")} onBack={() => navigation.goBack()} />
 
-      <KeyboardAvoidingView style={styles.content} {...KEYBOARD_AVOIDING_PROPS}>
+      <Animated.View style={[styles.content, contentAnimatedStyle]}>
+        {/* eslint-disable-next-line local/no-shared-component-reimplementation */}
         <TextInput
           ref={textInputRef}
           style={[styles.textInput, isFocused && styles.textInputFocused]}
@@ -114,9 +125,7 @@ export function CaptureTextNote({ route }: CaptureTextNoteScreenProps) {
             returnKeyType="done"
           />
         </View>
-      </KeyboardAvoidingView>
 
-      <SafeAreaView edges={["bottom"]}>
         <View style={styles.footer}>
           <Text
             variant="caption"
@@ -138,7 +147,7 @@ export function CaptureTextNote({ route }: CaptureTextNoteScreenProps) {
             loading={saving}
           />
         </View>
-      </SafeAreaView>
+      </Animated.View>
     </View>
   );
 }

--- a/apps/native-rd/src/screens/CaptureTextNote/CaptureTextNote.tsx
+++ b/apps/native-rd/src/screens/CaptureTextNote/CaptureTextNote.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useRef } from "react";
-import { View, TextInput, AccessibilityInfo, Alert } from "react-native";
+import {
+  View,
+  TextInput,
+  AccessibilityInfo,
+  Alert,
+  Platform,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
@@ -35,11 +41,13 @@ export function CaptureTextNote({ route }: CaptureTextNoteScreenProps) {
   // height.value: 0 when keyboard closed, -keyboardHeight when open.
   // Reanimated lets the padding interpolate in lockstep with the keyboard.
   const { height } = useReanimatedKeyboardAnimation();
+  // iOS folds the bottom safe area into the keyboard frame, so strip it to
+  // keep the footer flush. Android's keyboard-controller already subtracts
+  // the navigation-bar inset, so subtracting again would under-pad and let
+  // the keyboard cover the Save button on devices with a bottom inset.
+  const bottomInsetOffset = Platform.OS === "ios" ? insets.bottom : 0;
   const contentAnimatedStyle = useAnimatedStyle(() => {
-    // iOS folds the bottom safe area into the keyboard frame; strip it so
-    // the footer sits flush against the visible keyboard top instead of
-    // floating one home-indicator-height above it.
-    const keyboardPad = Math.max(0, -height.value - insets.bottom);
+    const keyboardPad = Math.max(0, -height.value - bottomInsetOffset);
     return {
       paddingBottom: Math.max(tabBarInset, keyboardPad),
     };

--- a/apps/native-rd/src/screens/EditModeScreen/EditModeScreen.tsx
+++ b/apps/native-rd/src/screens/EditModeScreen/EditModeScreen.tsx
@@ -6,10 +6,7 @@ import React, {
   useState,
 } from "react";
 import { View, TextInput, ActivityIndicator, Alert } from "react-native";
-import {
-  KeyboardProvider,
-  KeyboardAwareScrollView,
-} from "react-native-keyboard-controller";
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import { useQuery } from "@evolu/react";
 import { useTranslation } from "react-i18next";
@@ -243,7 +240,7 @@ function EditContent({
   const canDelete = stepRows.length > 1;
 
   return (
-    <KeyboardProvider>
+    <>
       <KeyboardAwareScrollView
         contentContainerStyle={[styles.scrollContent, tabInset]}
         bottomOffset={40}
@@ -337,7 +334,7 @@ function EditContent({
         title={t("confirmDelete.title")}
         message={t("confirmDelete.message", { title: goal.title })}
       />
-    </KeyboardProvider>
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #232.

## Summary

- Wrap the note content area in an `Animated.View` whose `paddingBottom` interpolates with the keyboard via `useReanimatedKeyboardAnimation`. The note `TextInput` shrinks; caption + Save footer ride above the keyboard in lockstep with the native open/close animation.
- iOS folds the bottom safe area into the keyboard frame, so subtract `insets.bottom` to keep the Save button flush against the visible keyboard top instead of floating ~34px above it.
- Keep `KeyboardProvider` at the App root (per official docs: preload warm-up, single native listener subscription).
- Update the `react-native-keyboard-controller` test mock to expose `useReanimatedKeyboardAnimation` returning SharedValue-shaped zeros; existing reanimated mock already handles `useAnimatedStyle` synchronously.

## Why not the alternatives

- **Stock RN `KeyboardAvoidingView`** (original code): footer was a sibling, keyboard covered it.
- **kc `KeyboardAvoidingView` + `automaticOffset`**: uses the focused input as reference. Autofocused TextInput already filled the upper screen, so the lib decided no offset was needed — Save button stayed under the keyboard.
- **`KeyboardStickyView` around caption + footer**: translated the footer up correctly but didn't reflow the note area — caption + button visibly overlaid the TextInput. Doesn't match "entire view adjusts."

## Test plan

- [x] `bun run type-check` passes
- [x] `bun run lint` clean for changed files
- [x] `npx jest --testPathPatterns CaptureTextNote` — 19/19 passing
- [x] iOS sim (iPhone, iOS 26.1): with keyboard open, caption input + char counter + Save button all fully visible and tappable above keyboard; gap between button and keyboard top is tight; TextInput shrinks smoothly with keyboard animation
- [ ] Android emulator: pending visual confirmation. `android:windowSoftInputMode="adjustResize"` is already set in AndroidManifest and `useReanimatedKeyboardAnimation` is cross-platform, so it should work — but issue acceptance includes Android verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)