### PR TITLE
docs(release): backfill 0.1.11 testing notes

### DIFF
--- a/apps/native-rd/docs/release/testing-notes/0.1.11.md
+++ b/apps/native-rd/docs/release/testing-notes/0.1.11.md
@@ -18,7 +18,12 @@ End-user copy. Lead with the user benefit. Tight — 500 chars goes fast.
 
 <!-- play:start -->
 
-TODO: 2–4 short bullets or a single paragraph describing what improved for the user in plain language.
+What's new in 0.1.11:
+
+- Jump straight to a badge's timeline with the new View timeline button.
+- Pick from 321 icons when designing a badge (up from 152).
+- Save button on text notes now stays above the keyboard.
+- Clearer "To Your Goals" call to action on the empty badges screen.
 
 <!-- play:end -->
 
@@ -30,13 +35,13 @@ End-user copy. Same voice as Play, but more room.
 
 **New**
 
-- TODO: wire View timeline button + cross-tab back routing
-- TODO: expand icon picker from 152 to 321 phosphor icons
+- Badge detail now has a View timeline button — open a badge and jump straight to the journey behind it. Back returns you to the tab you came from.
+- The icon picker offers 321 phosphor icons when designing a badge, up from 152.
 
 **Fixed**
 
-- TODO: change button translation to to your goals
-- TODO: keep Save button above keyboard on CaptureTextNote
+- Save button on the text-note capture screen stays above the keyboard so you can finish writing.
+- The empty badges screen now reads "To Your Goals" (and the German equivalent reads "Zu deinen Zielen") — clearer than the previous label.
 
 <!-- appstore:end -->
 
@@ -48,13 +53,13 @@ Tester-facing QA brief. Rewrite each line as: what to do → expected result.
 
 **Focus areas this build**
 
-- TODO: wire View timeline button + cross-tab back routing
-- TODO: expand icon picker from 152 to 321 phosphor icons
+- View timeline from badge detail: open any earned badge → tap **View timeline**. Expected: navigates to that badge's timeline screen. Tap Back. Expected: returns to the tab you came from (badges list, timeline tab, or a deep link) — not always to the badges list.
+- Icon picker: edit or create a badge → open the icon picker. Expected: 321 icons available, search and scroll stay responsive on older devices.
 
 **Recent fixes worth a sanity check**
 
-- TODO: change button translation to to your goals
-- TODO: keep Save button above keyboard on CaptureTextNote
+- Text-note capture keyboard: open a goal → add evidence → text note. Type enough that the keyboard would normally cover the Save button. Expected on both iOS and Android: Save stays visible above the keyboard.
+- Empty badges CTA copy: launch a fresh profile with no badges earned, or switch UI language. Expected: button reads "To Your Goals" (en) / "Zu deinen Zielen" (de) / pseudo equivalent — not the previous "Go to Goals" / "Zu Zielen" wording.
 
 **Reporting**
 


### PR DESCRIPTION
## Summary

- Replaces TODO placeholders in `apps/native-rd/docs/release/testing-notes/0.1.11.md` with real user-facing copy (Play, App Store) and QA steps (TestFlight) for the four changes that shipped in 0.1.11.
- Resolves the `release-notes-lint` failure on the `chore(main): release 0.1.11 (#221)` merge commit (workflow run [26934681724](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/26934681724)).
- The release-please scaffold was merged with the `TODO:` markers still in place. Going forward, those should be rewritten on the release-please PR *before* merging; this PR is just to unblock main and produce the canonical 0.1.11 notes to copy into store consoles.

## Slice budgets (verified locally)

- Play: 282 / 500 chars
- App Store: 487 / 4000 chars
- TestFlight: 1028 / 4000 chars
- `bun run release-notes:lint` → `1 file(s) OK.`

## Changes covered

- feat(badge-detail): View timeline button + cross-tab back routing (#235)
- feat(badges): icon picker 152 → 321 icons (#230)
- fix(native-rd): Save button stays above keyboard on CaptureTextNote (#232 / #233)
- fix(badges): empty-state CTA copy → "To Your Goals" / "Zu deinen Zielen"

## Test plan

- [x] `bun run release-notes:lint` passes locally
- [x] Each slice well under its store budget
- [ ] CI `release-notes-lint` green on this PR