### PR TITLE
ci(release-notes): run lint on every PR so it can be required

### DIFF
--- a/.github/workflows/release-notes-lint.yml
+++ b/.github/workflows/release-notes-lint.yml
@@ -7,23 +7,25 @@
 # the tag freezes. (build-production.yml runs the same lint at publish time,
 # but that gate fires AFTER the tag is cut: too late to fix the tagged commit.)
 #
+# This workflow intentionally has no `paths:` filter on pull_request — it fires
+# on every PR so the "Release Notes Lint" status context can serve as a
+# required status check (configured in repo ruleset `rulez` targeting `main`).
+# A required check that never reports blocks merge forever, so any required
+# check has to run on every PR. The lint is cheap (~30s, one bun script) and
+# is a no-op on PRs that don't touch testing-notes, so the cost is negligible.
+#
 # IMPORTANT — bot-authored commits don't trigger CI: commits pushed with the
 # default GITHUB_TOKEN (the scaffold commit, the release PR itself) do NOT
-# start workflow runs. So this check does NOT run when the bot opens the PR.
-# It runs the moment a human pushes a commit to the release branch — i.e. when
-# someone edits the TODO lines — which is exactly when we want to validate.
-# To make it BLOCK the merge, add "Release Notes Lint" as a required status
-# check in branch protection for `main` (a one-time repo-settings step; a
-# required check that has not reported is treated as pending and blocks merge,
-# forcing a human push that turns it green).
+# start workflow runs. When release-please opens the release PR, this check
+# therefore does NOT report — under the required-status-checks rule that shows
+# as "Expected — waiting for status to be reported" and blocks merge. The
+# block clears only after a HUMAN pushes a commit to the release PR branch
+# (i.e. when someone rewrites the TODO lines), which fires this workflow and
+# reports green or red. That is exactly the manual gate the bot PR is missing.
 name: release-notes-lint
 
 on:
   pull_request:
-    paths:
-      - "apps/native-rd/docs/release/testing-notes/**"
-      - "apps/native-rd/scripts/release-notes-*.ts"
-      - ".github/workflows/release-notes-lint.yml"
   push:
     branches: [main]
 


### PR DESCRIPTION
## Why

After diagnosing the v0.1.11 hollow-release post-mortem, the fix the workflow author originally documented (\`release-notes-lint.yml:15-18\`) — *"add 'Release Notes Lint' as a required status check in branch protection for \`main\`"* — was never completed. With the repo flipped back to public, branch protection / rulesets are now available again, and the existing \`rulez\` ruleset is the place to add the rule.

But required status checks have a sharp edge: a required check that **never reports** blocks the PR indefinitely. The current workflow has a \`pull_request: paths:\` filter so it only fires on PRs that touch testing-notes — meaning if it were marked required as-is, every unrelated PR would freeze.

## What this PR does

- Removes the \`pull_request: paths:\` filter from \`.github/workflows/release-notes-lint.yml\`.
- The workflow now fires on every PR. It's a single bun script (~30s) and a no-op on PRs that don't touch the notes, so the cost is negligible.
- Updates the workflow header comment to reflect the new state and explain why the filter is gone.

## Follow-up (separate, after this lands)

PATCH the \`rulez\` ruleset to add a \`required_status_checks\` rule with context \`Release Notes Lint\`. Order matters: this PR has to land first, or in-flight PRs will be stuck waiting for a check that doesn't exist on their head ref yet.

## Test plan

- [x] Diff is a single-file workflow change.
- [ ] On this PR itself, \`Release Notes Lint\` reports green (proves the unfiltered trigger works).
- [ ] After merge + ruleset PATCH, the next bot-authored release-please PR shows \`Release Notes Lint\` as "Expected — waiting for status to be reported" and is unmergeable until a human pushes a commit.