### PR TITLE
ci(release-please): split tag and next-PR phases to fix race

### DIFF
--- a/.github/workflows/release-please-next-pr.yml
+++ b/.github/workflows/release-please-next-pr.yml
@@ -1,0 +1,103 @@
+name: release-please-next-pr
+
+# Companion to release-please.yml. Runs the next-PR phase of
+# release-please-action AFTER a release was published (and tagged).
+#
+# Why this exists: in a single release-please-action invocation that both cuts
+# a tag AND opens the next PR, the next-PR phase computes its CHANGELOG diff
+# before the new tag is visible to its own walker, so it anchors on the
+# *previous* tag and re-lists the just-released work. Splitting the next-PR
+# phase onto release:published guarantees the new tag is on the remote when
+# the diff is calculated, so the anchor is correct.
+#
+# release-please.yml runs the next-PR phase inline on the no-release-cut path
+# (normal feat/fix merges between releases). This workflow runs it on the
+# release-cut path. The two are mutually exclusive by construction.
+on:
+  release:
+    types: [published]
+  # Manual trigger so a stuck or stale release PR can be regenerated without
+  # waiting for the next release-published event.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: release-please-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  next-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release-please — next-PR phase (post-publish path)
+        id: pr
+        uses: googleapis/release-please-action@v5
+        with:
+          config-file: .github/release-please-config.json
+          manifest-file: .github/.release-please-manifest.json
+          skip-github-release: true
+
+      # See release-please.yml for the rationale on the Prettier and scaffold
+      # steps — kept in sync between the two workflows. Only fire when the
+      # action actually opened or updated a PR.
+      - name: Checkout release PR branch
+        if: ${{ steps.pr.outputs.pr }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJSON(steps.pr.outputs.pr).headBranchName }}
+
+      - name: Setup Bun
+        if: ${{ steps.pr.outputs.pr }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Re-format release files with Prettier
+        if: ${{ steps.pr.outputs.pr }}
+        env:
+          PR_BRANCH: ${{ steps.pr.outputs.pr && fromJSON(steps.pr.outputs.pr).headBranchName || '' }}
+        run: |
+          set -euo pipefail
+          bunx prettier@3 --write apps/native-rd/app.json
+          if git diff --quiet -- apps/native-rd/app.json; then
+            echo "app.json already Prettier-clean — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -s -m "chore: prettier-format app.json after release bump" -- apps/native-rd/app.json
+          git push origin "HEAD:${PR_BRANCH}"
+
+      - name: Scaffold testing notes for release PR
+        if: ${{ steps.pr.outputs.pr }}
+        env:
+          PR_BRANCH: ${{ steps.pr.outputs.pr && fromJSON(steps.pr.outputs.pr).headBranchName || '' }}
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r .version apps/native-rd/package.json)"
+          NOTES="apps/native-rd/docs/release/testing-notes/${VERSION}.md"
+          if [ -f "$NOTES" ]; then
+            echo "$NOTES already exists — leaving in place (subsequent release-please update)."
+            exit 0
+          fi
+          GEN_STDERR=$(mktemp)
+          if ! bun apps/native-rd/scripts/release-notes-generate.ts "$VERSION" 2>"$GEN_STDERR"; then
+            if grep -q "no Features or Bug Fixes" "$GEN_STDERR"; then
+              echo "No tester-facing changes in CHANGELOG for ${VERSION} — skipping scaffold."
+              rm -f "$GEN_STDERR"
+              exit 0
+            fi
+            cat "$GEN_STDERR" >&2
+            rm -f "$GEN_STDERR"
+            exit 1
+          fi
+          rm -f "$GEN_STDERR"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$NOTES"
+          git commit -s -m "chore: scaffold testing notes for ${VERSION}"
+          git push origin "HEAD:${PR_BRANCH}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,19 @@
 name: release-please
 
+# Two-phase to avoid a release-please-action race:
+#
+#   When the action runs both `github-release` (cut tag) and `release-pr`
+#   (open/update the next PR) in the same invocation, the next-PR phase can't
+#   see the tag it just minted — it anchors on the *previous* tag and emits a
+#   CHANGELOG that re-lists the just-released work. v0.1.11 → 0.1.12 PR #236
+#   was the empirical confirmation (commit 890dc7e, 2026-06-04).
+#
+# Split:
+#   1. Tag phase always runs here on push:main (skip-github-pull-request: true).
+#   2. Next-PR phase runs here only when no release was just cut. When a
+#      release IS cut, the GitHub `release: published` event triggers
+#      release-please-next-pr.yml, which runs the next-PR phase against the
+#      now-published tag (correct anchor → correct CHANGELOG).
 on:
   push:
     branches: [main]
@@ -9,15 +23,40 @@ permissions:
   pull-requests: write
   issues: write
 
+# Shared across release-please.yml and release-please-next-pr.yml so a
+# push-triggered run and a release-triggered run can't update the same PR in
+# parallel and clobber each other's API writes.
+concurrency:
+  group: release-please-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
-        id: release
+      # Phase 1: cut the tag (if a release PR was just merged). Suppress the
+      # next-PR side of the action — if a release IS cut here, the next-PR
+      # generation must happen AFTER the tag is pushed (handled by
+      # release-please-next-pr.yml on release:published).
+      - name: Release-please — tag phase
+        id: tag
+        uses: googleapis/release-please-action@v5
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+          skip-github-pull-request: true
+
+      # Phase 2: next-PR generation, but ONLY when no release was just cut.
+      # When a release WAS cut, skip this and let release-please-next-pr.yml
+      # handle it after the release-published event lands.
+      - name: Release-please — next-PR phase (no-release-cut path)
+        id: pr
+        if: ${{ steps.tag.outputs.releases_created != 'true' }}
+        uses: googleapis/release-please-action@v5
+        with:
+          config-file: .github/release-please-config.json
+          manifest-file: .github/.release-please-manifest.json
+          skip-github-release: true
 
       # release-please bumps $.expo.version in apps/native-rd/app.json via its
       # generic JSON updater, which re-serialises the file with its own
@@ -28,25 +67,25 @@ jobs:
       # at PR time). Re-run Prettier on the release PR branch so the bumped file
       # lands already formatted.
       - name: Checkout release PR branch
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.pr.outputs.pr }}
         uses: actions/checkout@v6
         with:
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          ref: ${{ fromJSON(steps.pr.outputs.pr).headBranchName }}
 
       - name: Setup Bun
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.pr.outputs.pr }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
 
       - name: Re-format release files with Prettier
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.pr.outputs.pr }}
         env:
           # GHA evaluates `env:` before `if:`, so a bare `fromJSON(...)` here
           # throws on any merge to main that isn't a release-PR merge (the
           # action emits an empty `pr` output). Short-circuit so fromJSON only
           # runs when the output is non-empty.
-          PR_BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
+          PR_BRANCH: ${{ steps.pr.outputs.pr && fromJSON(steps.pr.outputs.pr).headBranchName || '' }}
         run: |
           set -euo pipefail
           # Pinned to the repo's Prettier major; app.json has no config/plugins,
@@ -70,10 +109,10 @@ jobs:
       # TODO into actual tester-facing language. That gate is what stops a
       # release being Published with empty/placeholder notes.
       - name: Scaffold testing notes for release PR
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.pr.outputs.pr }}
         env:
           # See note on the Prettier step above re: env-before-if evaluation.
-          PR_BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
+          PR_BRANCH: ${{ steps.pr.outputs.pr && fromJSON(steps.pr.outputs.pr).headBranchName || '' }}
         run: |
           set -euo pipefail
           VERSION="$(jq -r .version apps/native-rd/package.json)"


### PR DESCRIPTION
## Summary

`release-please-action@v5` runs `github-release` (cut tag) and `release-pr` (open/update next PR) in the same invocation. The next-PR phase computes its CHANGELOG diff before the tag it just minted is visible to its own walker — so it anchors on the *previous* tag and re-lists the just-released work.

**Empirical confirmation:** v0.1.11 → 0.1.12 PR #236 (commit `890dc7e`, 2026-06-04). 108-line CHANGELOG insert spanning all of 0.1.10 + 0.1.11, despite only two non-bumping commits since v0.1.11.

Fix: split into two workflows joined by `release: published`.

- `release-please.yml` always runs the **tag phase** on `push:main` with `skip-github-pull-request: true`. Runs the next-PR phase inline only when no release was just cut (no-race path — regular feat/fix merges between releases).
- `release-please-next-pr.yml` (new) runs the **next-PR phase** on `release: published` (+ `workflow_dispatch`). By the time this fires, the tag is on the remote and release-please's diff anchor is correct.

Concurrency group `release-please-${{ github.repository }}` is shared across both workflows so a push-triggered run and a release-triggered run can't update the same PR in parallel.

## Why splitting on `release:published` works here

The `release-please-action` cuts releases via the default `GITHUB_TOKEN`. The GitHub anti-recursion rule blocks `pull_request` workflows from firing on bot commits — but the `release` event *does* fire here, as confirmed by run `26934728416` (build-production triggered on v0.1.11's release event, conclusion: failure on validate, exactly the symptom that started this thread).

## Test plan

After merge, verification will need a real release cycle to fully prove:

- [ ] Land any `feat:` or `fix:` commit to main. Confirm `release-please.yml` opens/updates a PR via the inline next-PR step (no-release-cut path) and the CHANGELOG diffs from the latest tag, not earlier.
- [ ] Merge a release PR. Confirm `release-please.yml` cuts the tag and skips the inline next-PR step (per `if: steps.tag.outputs.releases_created != 'true'`).
- [ ] Confirm `release-please-next-pr.yml` fires on the resulting `release: published` event and opens/updates the next PR with the freshly published tag as diff anchor — CHANGELOG should contain only commits since the new tag.
- [ ] Spot-check PR #236 after this lands: it will need to be regenerated against `v0.1.11` to clear the bloated CHANGELOG. (Action TBD — see PR description note below.)

## Notes / follow-ups for reviewer

- **PR #236 (0.1.12 release PR) is still bloated.** Closing #236 and re-running release-please will not help until a release event fires. Practical path after this lands: land a `feat:` or `fix:` to main → inline next-PR step regenerates PR with `v0.1.11` as anchor. Or close #236 and use `workflow_dispatch` on `release-please-next-pr.yml` (won't trigger though, since that workflow only fires on `release:published` and `workflow_dispatch`). Easiest: close #236 + land a no-op `fix:` to main + watch the inline path regenerate.
- The Prettier + scaffold steps are duplicated across the two workflows. Kept in sync by hand for now; can be extracted to a reusable workflow later if drift becomes a problem.
- Pinned to `googleapis/release-please-action@v5` (same as before — `v5.0.0` is current, released 2026-04-22). Inputs `skip-github-release` and `skip-github-pull-request` are present in v5.0.0's `action.yml`.

## Race walkthrough (for the curious)

Old behavior on a release-PR merge:

1. PR #221 (chore: release 0.1.11) merges to main
2. `push:main` fires → `release-please-action` runs
3. Action's `github-release` phase cuts `v0.1.11` tag at commit `150c372`
4. Action's `release-pr` phase runs **in the same job** → walker queries "latest tag", but the action's internal state hasn't picked up `v0.1.11` yet → anchors on `v0.1.10` → emits "0.1.12" PR with CHANGELOG that includes all 0.1.10 + 0.1.11 work

New behavior:

1. PR #221 merges → `push:main` fires → `release-please.yml` runs
2. Tag phase cuts `v0.1.11`; `releases_created=true`
3. Inline next-PR phase is **skipped** by the `if:`
4. GitHub fires `release: published` for v0.1.11 → `release-please-next-pr.yml` runs
5. Tag is on the remote; walker correctly anchors on `v0.1.11` → CHANGELOG only lists commits since `v0.1.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)