### PR TITLE
fix(release): move TestFlight notes to eas submit + pin eas-cli

### DIFF
--- a/.github/workflows/build-internal.yml
+++ b/.github/workflows/build-internal.yml
@@ -22,6 +22,10 @@ concurrency:
   group: build-internal-${{ inputs.ref || github.ref }}-${{ inputs.platform || 'all' }}
   cancel-in-progress: false
 
+# Pinned to match build-production.yml — see comment there for rationale.
+env:
+  EAS_CLI_VERSION: "20.0.0"
+
 jobs:
   validate:
     uses: ./.github/workflows/_release-validate.yml
@@ -66,7 +70,7 @@ jobs:
           # Write JSON outside the repo: `cmd > file` opens the file before
           # eas-cli runs, and eas-cli aborts on a dirty working tree.
           out="$RUNNER_TEMP/eas-build-ios.json"
-          npx eas-cli@latest build --profile preview --platform ios --non-interactive --json > "$out"
+          npx "eas-cli@$EAS_CLI_VERSION" build --profile preview --platform ios --non-interactive --json > "$out"
           build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
@@ -109,7 +113,7 @@ jobs:
           # Write JSON outside the repo: `cmd > file` opens the file before
           # eas-cli runs, and eas-cli aborts on a dirty working tree.
           out="$RUNNER_TEMP/eas-build-android.json"
-          npx eas-cli@latest build --profile preview --platform android --non-interactive --json > "$out"
+          npx "eas-cli@$EAS_CLI_VERSION" build --profile preview --platform android --non-interactive --json > "$out"
           build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
@@ -161,7 +165,7 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
           APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
-        run: npx eas-cli@latest submit --profile preview --platform ios --id "${{ needs.build-ios.outputs.build_id }}" --non-interactive --wait
+        run: npx "eas-cli@$EAS_CLI_VERSION" submit --profile preview --platform ios --id "${{ needs.build-ios.outputs.build_id }}" --non-interactive --wait
 
   submit-android:
     needs: build-android
@@ -203,4 +207,4 @@ jobs:
       - name: Submit (EAS, preview profile, Android)
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: npx eas-cli@latest submit --profile preview --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait
+        run: npx "eas-cli@$EAS_CLI_VERSION" submit --profile preview --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait

--- a/.github/workflows/build-play-internal.yml
+++ b/.github/workflows/build-play-internal.yml
@@ -14,6 +14,10 @@ concurrency:
   group: build-play-internal-${{ inputs.ref || github.ref }}
   cancel-in-progress: false
 
+# Pinned to match build-production.yml — see comment there for rationale.
+env:
+  EAS_CLI_VERSION: "20.0.0"
+
 jobs:
   validate:
     uses: ./.github/workflows/_release-validate.yml
@@ -55,7 +59,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           out="$RUNNER_TEMP/eas-build-android.json"
-          npx eas-cli@latest build --profile production --platform android --non-interactive --json > "$out"
+          npx "eas-cli@$EAS_CLI_VERSION" build --profile production --platform android --non-interactive --json > "$out"
           build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
@@ -99,4 +103,4 @@ jobs:
       - name: Submit (EAS, Google Play internal track)
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: npx eas-cli@latest submit --profile play-internal --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait
+        run: npx "eas-cli@$EAS_CLI_VERSION" submit --profile play-internal --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -29,6 +29,12 @@ concurrency:
   group: build-production-${{ inputs.ref || github.event.release.tag_name || github.ref }}-${{ inputs.platform || 'all' }}
   cancel-in-progress: false
 
+# Pin eas-cli to avoid silent breakage when upstream tightens flag validation.
+# v20.0.0 (2026-06) moved `--what-to-test` to require `--auto-submit`/submit-side.
+# Bump deliberately: read eas-cli release notes, run an internal build first.
+env:
+  EAS_CLI_VERSION: "20.0.0"
+
 jobs:
   validate:
     uses: ./.github/workflows/_release-validate.yml
@@ -65,24 +71,10 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: .
 
-      # Generate TestFlight "What to Test" + App Store store.config.json from
-      # apps/native-rd/docs/release/testing-notes/<version>.md (scaffolded by
-      # release-please.yml, edited by humans, gated by release-notes:lint in
-      # _release-validate.yml). Missing notes file falls back to a copy of
-      # store.config.base.json so eas submit's metadataPath remains valid.
-      - name: Generate release-notes artifacts
-        run: |
-          set -euo pipefail
-          VERSION="$(jq -r .version package.json)"
-          NOTES="docs/release/testing-notes/${VERSION}.md"
-          mkdir -p .release-artifacts
-          if [ ! -f "$NOTES" ]; then
-            echo "::warning::No testing notes at $NOTES — TestFlight What-to-Test will be empty and store metadata will fall back to store.config.base.json."
-            printf '' > .release-artifacts/what-to-test.txt
-            cp store.config.base.json store.config.json
-            exit 0
-          fi
-          bun run release-notes:split
+      # release-notes artifacts (what-to-test.txt, store.config.json) are only
+      # consumed by `eas submit`, so they live in the submit-ios job. Sentry
+      # sourcemaps for the build come from the Expo Sentry plugin via
+      # SENTRY_AUTH_TOKEN — no artifact files needed here.
 
       - name: Build (EAS, production profile, iOS)
         id: build
@@ -94,15 +86,7 @@ jobs:
           # eas-cli runs, and eas-cli aborts on a dirty working tree.
           set -euo pipefail
           out="$RUNNER_TEMP/eas-build-ios.json"
-          args=(eas-cli@latest build --profile production --platform ios --non-interactive --json)
-          # --what-to-test is stored on the EAS build record and consumed by
-          # `eas submit --id <build_id>` when it creates the App Store Connect
-          # submission. Only pass it when the file has content — passing an
-          # empty string would overwrite TestFlight notes with blank.
-          if [ -s .release-artifacts/what-to-test.txt ]; then
-            args+=(--what-to-test "$(cat .release-artifacts/what-to-test.txt)")
-          fi
-          npx "${args[@]}" > "$out"
+          npx "eas-cli@$EAS_CLI_VERSION" build --profile production --platform ios --non-interactive --json > "$out"
           build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
@@ -145,7 +129,7 @@ jobs:
           # Write JSON outside the repo: `cmd > file` opens the file before
           # eas-cli runs, and eas-cli aborts on a dirty working tree.
           out="$RUNNER_TEMP/eas-build-android.json"
-          npx eas-cli@latest build --profile production --platform android --non-interactive --json > "$out"
+          npx "eas-cli@$EAS_CLI_VERSION" build --profile production --platform android --non-interactive --json > "$out"
           build_id="$(jq -r 'if type == "array" then .[0].id else .id end' "$out")"
           test -n "$build_id" && test "$build_id" != "null"
           echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
@@ -218,7 +202,16 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
           APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
-        run: npx eas-cli@latest submit --profile production --platform ios --id "${{ needs.build-ios.outputs.build_id }}" --non-interactive --wait
+        # --what-to-test rides on submit, not build (eas-cli ≥ 20 rejects it on
+        # build unless paired with --auto-submit). Skip the flag when the file
+        # has no content — passing an empty string blanks TestFlight notes.
+        run: |
+          set -euo pipefail
+          args=("eas-cli@$EAS_CLI_VERSION" submit --profile production --platform ios --id "${{ needs.build-ios.outputs.build_id }}" --non-interactive --wait)
+          if [ -s .release-artifacts/what-to-test.txt ]; then
+            args+=(--what-to-test "$(cat .release-artifacts/what-to-test.txt)")
+          fi
+          npx "${args[@]}"
 
   submit-android:
     needs: build-android
@@ -264,7 +257,7 @@ jobs:
       - name: Submit (EAS, production profile, Android, 10% rollout)
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: npx eas-cli@latest submit --profile production --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait
+        run: npx "eas-cli@$EAS_CLI_VERSION" submit --profile production --platform android --id "${{ needs.build-android.outputs.build_id }}" --non-interactive --wait
 
   finalize-sentry:
     needs:
@@ -323,7 +316,7 @@ jobs:
               echo "No build id for $bundle_id — skipping (platform not built this run)."
               return 0
             fi
-            info="$(npx --yes eas-cli@latest build:view "$build_id" --json)"
+            info="$(npx --yes "eas-cli@$EAS_CLI_VERSION" build:view "$build_id" --json)"
             ver="$(echo "$info" | jq -r '.appVersion')"
             num="$(echo "$info" | jq -r '.appBuildVersion')"
             rel="${bundle_id}@${ver}+${num}"

--- a/apps/native-rd/docs/release.md
+++ b/apps/native-rd/docs/release.md
@@ -86,7 +86,8 @@ Why this workflow exists:
    publishing is the manual "ship" click in the Releases UI).
 5. `build-production` workflow fires on the published Release. It re-runs
    `release-notes-lint`, splits the notes into store artifacts, and passes
-   `--what-to-test` to `eas build`. Watch it in Actions.
+   `--what-to-test` to `eas submit` so the TestFlight notes attach to the
+   App Store Connect submission. Watch it in Actions.
 6. After EAS finishes:
    - iOS: build appears in App Store Connect → TestFlight. External testers
      get it automatically (if the build is in a beta group with


### PR DESCRIPTION
## Summary

- **Fix:** move `--what-to-test` from `eas build` to `eas submit` in `build-production.yml`. eas-cli 20.0.0 rejects the flag on `build` unless paired with `--auto-submit`, which would collapse our intentional build/submit job split. The new home is the canonical post-20.0.0 pattern and matches what `release-notes-split.ts`'s "next" hints have been documenting all along.
- **Cleanup:** drop the now-dead `Generate release-notes artifacts` step from `build-ios`. `submit-ios` already regenerates the artifacts locally before consuming them. Sentry sourcemaps come from the Expo Sentry plugin via `SENTRY_AUTH_TOKEN` — nothing on the build side needs the files.
- **Hardening:** pin `eas-cli` to `20.0.0` via a workflow-level `EAS_CLI_VERSION` env var across all three EAS workflows (`build-production`, `build-internal`, `build-play-internal`). This is exactly how the regression landed silently — `eas-cli@latest` resolved to a stricter version between v0.1.11 (shipped fine) and v0.1.12 (broken). Bumps become deliberate.
- **Doc:** fix the now-stale `docs/release.md` line that said the flag rides on `eas build`.

## Root cause (from the failed run)

[build-production run 26965110552](https://github.com/rollercoaster-dev/Rollercoaster.dev-mobile/actions/runs/26965110552), step "Build (EAS, production profile, iOS)", in 51s:

```
The --what-to-test flag can only be used with the --auto-submit or --auto-submit-with-profile flag.
    Error: build command failed.
```

`npx eas-cli@latest` resolved to `eas-cli@20.0.0` for the first time this release cycle.

## Test plan

- [ ] PR checks pass (Native-RD Validate, DCO, etc.) — workflow files only, no runtime code touched.
- [ ] Merge.
- [ ] Manually re-run **Actions → build-production → Run workflow** with `ref: v0.1.12`, `platform: all`. (v0.1.12 was cancelled mid-flight; tag still exists at the right SHA.)
- [ ] Confirm iOS build completes, submit attaches TestFlight notes correctly, Android ships to Play 10%, Sentry finalize covers both platforms.