### PR TITLE
fix(release): drop --what-to-test, harden ref input, scope submit credentials

### DIFF
--- a/.github/workflows/_release-validate.yml
+++ b/.github/workflows/_release-validate.yml
@@ -18,6 +18,26 @@ jobs:
     name: Release Format, Typecheck, Lint & Test
     runs-on: ubuntu-latest
     steps:
+      # Catch the workflow_dispatch paste mistake where the operator types
+      # `ref: v0.1.12` into the form field instead of `v0.1.12` — actions/checkout
+      # treats the whole string as a refspec and dies with an opaque
+      # "invalid refspec '+refs/heads/ref: v0.1.12*'" several jobs deep. Failing
+      # here keeps the error pointed at the actual cause.
+      - name: Validate ref input
+        if: ${{ inputs.ref != '' }}
+        env:
+          REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF" == ref:* || "$REF" == "ref "* ]]; then
+            echo "::error::ref input starts with a 'ref:' prefix. Pass the bare tag/branch/sha (e.g. 'v0.1.12'), not 'ref: v0.1.12'."
+            exit 1
+          fi
+          if [[ "$REF" == *[[:space:]]* ]]; then
+            echo "::error::ref input contains whitespace. Pass the bare tag/branch/sha with no surrounding text."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-internal.yml
+++ b/.github/workflows/build-internal.yml
@@ -145,20 +145,17 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: .
 
-      - name: Write credential files
+      - name: Write Apple ASC key
         # Pass secrets via env (not ${{ secrets.* }} inside the script body) so
         # arbitrary content — newlines, quotes, backslashes — stays inside the
         # shell variable instead of being expanded into the script source.
-        # Trailing newline is appended for the PEM key per Apple/OpenSSL
-        # parser expectations; harmless on the JSON.
+        # Trailing newline is appended per Apple/OpenSSL PEM parser expectations.
         env:
           APPLE_ASC_KEY_P8: ${{ secrets.APPLE_ASC_KEY_P8 }}
-          ANDROID_PLAY_SA: ${{ secrets.ANDROID_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           mkdir -p ../../secrets
           printf '%s\n' "$APPLE_ASC_KEY_P8" > ../../secrets/asc-api-key.p8
-          printf '%s\n' "$ANDROID_PLAY_SA" > ../../secrets/play-service-account.json
-          chmod 600 ../../secrets/asc-api-key.p8 ../../secrets/play-service-account.json
+          chmod 600 ../../secrets/asc-api-key.p8
 
       - name: Submit (EAS, preview profile, iOS)
         env:
@@ -194,15 +191,13 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: .
 
-      - name: Write credential files
+      - name: Write Google Play service account
         env:
-          APPLE_ASC_KEY_P8: ${{ secrets.APPLE_ASC_KEY_P8 }}
           ANDROID_PLAY_SA: ${{ secrets.ANDROID_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           mkdir -p ../../secrets
-          printf '%s\n' "$APPLE_ASC_KEY_P8" > ../../secrets/asc-api-key.p8
           printf '%s\n' "$ANDROID_PLAY_SA" > ../../secrets/play-service-account.json
-          chmod 600 ../../secrets/asc-api-key.p8 ../../secrets/play-service-account.json
+          chmod 600 ../../secrets/play-service-account.json
 
       - name: Submit (EAS, preview profile, Android)
         env:

--- a/.github/workflows/build-internal.yml
+++ b/.github/workflows/build-internal.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to build (branch, tag, or commit SHA). Leave blank to use the branch picked in the 'Use workflow from' dropdown."
+        description: "Git ref to build — bare branch, tag, or commit SHA, e.g. `main` or `v0.1.12` (no `ref:` prefix). Leave blank to use the branch picked in the 'Use workflow from' dropdown."
         required: false
       platform:
         description: "Platform to build and submit."

--- a/.github/workflows/build-play-internal.yml
+++ b/.github/workflows/build-play-internal.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to build (branch, tag, or commit SHA). Leave blank to use the branch picked in the 'Use workflow from' dropdown."
+        description: "Git ref to build — bare branch, tag, or commit SHA, e.g. `main` or `v0.1.12` (no `ref:` prefix). Leave blank to use the branch picked in the 'Use workflow from' dropdown."
         required: false
 
 concurrency:

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to build (tag or commit SHA)"
+        description: "Git ref to build — bare tag or commit SHA, e.g. `v0.1.12` (no `ref:` prefix, no quotes)."
         required: true
       platform:
         description: "Platform to build and submit."

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -165,20 +165,17 @@ jobs:
         id: version
         run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Write credential files
+      - name: Write Apple ASC key
         # Pass secrets via env (not ${{ secrets.* }} inside the script body) so
         # arbitrary content — newlines, quotes, backslashes — stays inside the
         # shell variable instead of being expanded into the script source.
-        # Trailing newline is appended for the PEM key per Apple/OpenSSL
-        # parser expectations; harmless on the JSON.
+        # Trailing newline is appended per Apple/OpenSSL PEM parser expectations.
         env:
           APPLE_ASC_KEY_P8: ${{ secrets.APPLE_ASC_KEY_P8 }}
-          ANDROID_PLAY_SA: ${{ secrets.ANDROID_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           mkdir -p ../../secrets
           printf '%s\n' "$APPLE_ASC_KEY_P8" > ../../secrets/asc-api-key.p8
-          printf '%s\n' "$ANDROID_PLAY_SA" > ../../secrets/play-service-account.json
-          chmod 600 ../../secrets/asc-api-key.p8 ../../secrets/play-service-account.json
+          chmod 600 ../../secrets/asc-api-key.p8
 
       # Regenerate store.config.json from this version's testing-notes file
       # so the iOS submit profile's metadataPath (./store.config.json in
@@ -240,15 +237,13 @@ jobs:
         id: version
         run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Write credential files
+      - name: Write Google Play service account
         env:
-          APPLE_ASC_KEY_P8: ${{ secrets.APPLE_ASC_KEY_P8 }}
           ANDROID_PLAY_SA: ${{ secrets.ANDROID_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           mkdir -p ../../secrets
-          printf '%s\n' "$APPLE_ASC_KEY_P8" > ../../secrets/asc-api-key.p8
           printf '%s\n' "$ANDROID_PLAY_SA" > ../../secrets/play-service-account.json
-          chmod 600 ../../secrets/asc-api-key.p8 ../../secrets/play-service-account.json
+          chmod 600 ../../secrets/play-service-account.json
 
       - name: Submit (EAS, production profile, Android, 10% rollout)
         env:

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -202,16 +202,12 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
           APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
-        # --what-to-test rides on submit, not build (eas-cli ≥ 20 rejects it on
-        # build unless paired with --auto-submit). Skip the flag when the file
-        # has no content — passing an empty string blanks TestFlight notes.
-        run: |
-          set -euo pipefail
-          args=("eas-cli@$EAS_CLI_VERSION" submit --profile production --platform ios --id "${{ needs.build-ios.outputs.build_id }}" --non-interactive --wait)
-          if [ -s .release-artifacts/what-to-test.txt ]; then
-            args+=(--what-to-test "$(cat .release-artifacts/what-to-test.txt)")
-          fi
-          npx "${args[@]}"
+        # TestFlight "What to Test" must be entered manually in App Store
+        # Connect: EAS gates the equivalent --what-to-test / changelog field
+        # behind their Enterprise plan, so passing it fails the submission
+        # outright. The split notes still live in .release-artifacts/ for
+        # copy-paste; see docs/release.md.
+        run: npx "eas-cli@$EAS_CLI_VERSION" submit --profile production --platform ios --id "${{ needs.build-ios.outputs.build_id }}" --non-interactive --wait
 
   submit-android:
     needs: build-android

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -256,6 +256,12 @@ jobs:
       - build-android
       - submit-ios
       - submit-android
+    # Single-platform dispatch (platform=ios or platform=android) is supported:
+    # the unrequested platform's build/submit jobs resolve to `skipped`, which
+    # does not match `failure`, and the OR clause accepts one platform's
+    # `success`. The contains-failure guard is intentionally strict — if either
+    # platform's submit fails, this job sits out and the runbook's "Sentry
+    # finalize fails" entry documents the manual recovery.
     if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && (needs.submit-ios.result == 'success' || needs.submit-android.result == 'success') }}
     runs-on: ubuntu-latest
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ packages/claude-knowledge/.claude/
 # CI-only secret material written at workflow runtime; never committed.
 /secrets/
 apps/native-rd/play-service-account.json
+
+# Stray scaffold dropped by `eas` subcommands when run from the repo root by
+# mistake — the real Expo config lives at apps/native-rd/app.json.
+/app.json

--- a/apps/native-rd/docs/release.md
+++ b/apps/native-rd/docs/release.md
@@ -88,14 +88,11 @@ Why this workflow exists:
    `release-notes-lint`, splits the notes into store artifacts, and runs
    `eas submit` for iOS and Android. TestFlight "What to Test" is **not**
    sent automatically — `eas submit --what-to-test` is gated behind EAS's
-   Enterprise plan (see [eas-cli #3023][what-to-test-pr]: _"this consumes
-   extra computing resources during the process so we're going to make this
-   enabled only for enterprise plan"_), so paste the contents of the iOS
-   slice into App Store Connect → TestFlight by hand. Watch the workflow
-   in Actions.
-
-[what-to-test-pr]: https://github.com/expo/eas-cli/pull/3023
-
+   Enterprise plan (see [eas-cli #3023](https://github.com/expo/eas-cli/pull/3023):
+   _"this consumes extra computing resources during the process so we're going
+   to make this enabled only for enterprise plan"_), so paste the contents of
+   the iOS slice into App Store Connect → TestFlight by hand. Watch the
+   workflow in Actions.
 6. After EAS finishes:
    - iOS: build appears in App Store Connect → TestFlight. External testers
      get it automatically (if the build is in a beta group with

--- a/apps/native-rd/docs/release.md
+++ b/apps/native-rd/docs/release.md
@@ -85,9 +85,12 @@ Why this workflow exists:
    GitHub Release** (as a draft — `"draft": true` in the release-please config;
    publishing is the manual "ship" click in the Releases UI).
 5. `build-production` workflow fires on the published Release. It re-runs
-   `release-notes-lint`, splits the notes into store artifacts, and passes
-   `--what-to-test` to `eas submit` so the TestFlight notes attach to the
-   App Store Connect submission. Watch it in Actions.
+   `release-notes-lint`, splits the notes into store artifacts, and runs
+   `eas submit` for iOS and Android. TestFlight "What to Test" is **not**
+   sent automatically — EAS gates that field (`--what-to-test` /
+   `changelog`) behind their Enterprise plan, so paste the contents of the
+   iOS slice into App Store Connect → TestFlight by hand. Watch the
+   workflow in Actions.
 6. After EAS finishes:
    - iOS: build appears in App Store Connect → TestFlight. External testers
      get it automatically (if the build is in a beta group with

--- a/apps/native-rd/docs/release.md
+++ b/apps/native-rd/docs/release.md
@@ -87,10 +87,15 @@ Why this workflow exists:
 5. `build-production` workflow fires on the published Release. It re-runs
    `release-notes-lint`, splits the notes into store artifacts, and runs
    `eas submit` for iOS and Android. TestFlight "What to Test" is **not**
-   sent automatically — EAS gates that field (`--what-to-test` /
-   `changelog`) behind their Enterprise plan, so paste the contents of the
-   iOS slice into App Store Connect → TestFlight by hand. Watch the
-   workflow in Actions.
+   sent automatically — `eas submit --what-to-test` is gated behind EAS's
+   Enterprise plan (see [eas-cli #3023][what-to-test-pr]: _"this consumes
+   extra computing resources during the process so we're going to make this
+   enabled only for enterprise plan"_), so paste the contents of the iOS
+   slice into App Store Connect → TestFlight by hand. Watch the workflow
+   in Actions.
+
+[what-to-test-pr]: https://github.com/expo/eas-cli/pull/3023
+
 6. After EAS finishes:
    - iOS: build appears in App Store Connect → TestFlight. External testers
      get it automatically (if the build is in a beta group with

--- a/apps/native-rd/docs/release/testing-notes/README.md
+++ b/apps/native-rd/docs/release/testing-notes/README.md
@@ -116,7 +116,7 @@ eas metadata:push --profile production
 eas submit --platform ios --profile production
 ```
 
-Then paste `apps/native-rd/.release-artifacts/what-to-test.txt` into App Store Connect → TestFlight → the build → "What to Test". `eas submit --what-to-test` is not used (the flag does not work on our EAS plan tier, so the pipeline stopped trying to send it automatically).
+Then paste `apps/native-rd/.release-artifacts/what-to-test.txt` into App Store Connect → TestFlight → the build → "What to Test". `eas submit --what-to-test` is not used: the flag is gated behind EAS's Enterprise plan (see [eas-cli #3023](https://github.com/expo/eas-cli/pull/3023): _"this consumes extra computing resources during the process so we're going to make this enabled only for enterprise plan"_), so the pipeline pastes manually instead of sending it on submit.
 
 **Android Play "What's new":** there is no `eas submit` flag for this. Three options, in increasing order of automation:
 

--- a/apps/native-rd/docs/release/testing-notes/README.md
+++ b/apps/native-rd/docs/release/testing-notes/README.md
@@ -103,7 +103,7 @@ Produces:
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `apps/native-rd/store.config.json`                           | EAS Metadata config — read by `eas metadata:push` to set App Store "What's New" |
 | `apps/native-rd/.release-artifacts/play-changelog-en-US.txt` | Raw text for Play Console "What's new" (manual paste or future API push)        |
-| `apps/native-rd/.release-artifacts/what-to-test.txt`         | Raw text for `eas submit --what-to-test "$(cat ...)"`                           |
+| `apps/native-rd/.release-artifacts/what-to-test.txt`         | Raw text to paste into App Store Connect → TestFlight → "What to Test"          |
 
 The splitter refuses to write any output if the notes file still contains `TODO` markers — same check as `release-notes:lint`, enforced again here so CI can't sneak past it.
 
@@ -113,9 +113,10 @@ The splitter refuses to write any output if the notes file still contains `TODO`
 
 ```sh
 eas metadata:push --profile production
-eas submit --platform ios --profile production \
-  --what-to-test "$(cat apps/native-rd/.release-artifacts/what-to-test.txt)"
+eas submit --platform ios --profile production
 ```
+
+Then paste `apps/native-rd/.release-artifacts/what-to-test.txt` into App Store Connect → TestFlight → the build → "What to Test". `eas submit --what-to-test` is not used (the flag does not work on our EAS plan tier, so the pipeline stopped trying to send it automatically).
 
 **Android Play "What's new":** there is no `eas submit` flag for this. Three options, in increasing order of automation:
 
@@ -144,4 +145,4 @@ Update `store.config.base.json` through a normal PR. Schema is validated by `eas
 | ------------------- | ------------------------------------------------ | ----------------- | ----------------------------------------------------------------------- |
 | `play`              | Play Console → "What's new in this version"      | 500 chars/locale  | Play Developer API: `edits.tracks.update` → `releases[].releaseNotes[]` |
 | `appstore`          | App Store Connect → "What's New in This Version" | 4000 chars/locale | EAS Metadata: `apple.info.<locale>.releaseNotes`                        |
-| `testflight`        | TestFlight → "What to Test"                      | 4000 chars        | `eas submit --what-to-test`                                             |
+| `testflight`        | TestFlight → "What to Test"                      | 4000 chars        | Manual paste into App Store Connect (no automated API on our plan)      |

--- a/apps/native-rd/scripts/release-notes-split.ts
+++ b/apps/native-rd/scripts/release-notes-split.ts
@@ -7,7 +7,8 @@
  *   2. .release-artifacts/play-changelog-en-US.txt
  *      → Play Console "What's new" (manual paste or future API push)
  *   3. .release-artifacts/what-to-test.txt
- *      → `eas submit --what-to-test "$(cat ...)"` for TestFlight "What to Test"
+ *      → paste into App Store Connect → TestFlight → "What to Test"
+ *        (manual step — `eas submit --what-to-test` is not used)
  *
  * Refuses to write any artifact if the testing-notes file fails the same
  * checks release-notes:lint enforces, so the pipeline halts before partial
@@ -95,7 +96,8 @@ function main(): number {
       `  ${testflightPath} (testflight, ${bodies.testflight.length} chars)\n` +
       `  next:\n` +
       `    iOS:     eas metadata:push --profile production\n` +
-      `             eas submit --platform ios --profile production --what-to-test "$(cat ${testflightPath})"\n` +
+      `             eas submit --platform ios --profile production\n` +
+      `             then paste ${testflightPath} into App Store Connect → TestFlight → "What to Test"\n` +
       `    Android: eas submit --platform android --profile production\n` +
       `             (then push play changelog via Play Developer API — see docs/release/testing-notes/README.md)`,
   );


### PR DESCRIPTION
## Summary

Release-CI cleanup pass after the v0.1.12 ship attempt. Six commits, four areas:

### 1. Drop `--what-to-test` from CI (`d126db7`)

- Remove the flag from `submit-ios` in `build-production.yml`. eas-cli v20 rejected it on `eas build` (the v0.1.12 failure).
- `.release-artifacts/what-to-test.txt` is still generated by `release-notes-split`; the operator pastes it into App Store Connect → TestFlight → "What to Test" by hand. Same flow Play Console already uses for Android changelogs.
- Update `docs/release.md`, `testing-notes/README.md`, and the `release-notes-split` hint output to describe the manual step.
- Gitignore `/app.json` at the repo root (eas-cli stub from cwd confusion — real Expo config lives at `apps/native-rd/app.json`).

### 2. Harden `workflow_dispatch` ref input (`9daf3db`)

- A `workflow_dispatch` retry earlier today failed with `fatal: invalid refspec '+refs/heads/ref: v0.1.12*'` because the operator pasted `ref: v0.1.12` into the form field. `actions/checkout` splices the input straight into a refspec.
- Add a `Validate ref input` step at the top of `_release-validate.yml`. Rejects strings that start with `ref:` or contain whitespace, with an actionable error message.
- Tighten the `ref` input descriptions in `build-production.yml`, `build-internal.yml`, and `build-play-internal.yml`.

### 3. Scope submit-job credentials to the consuming platform (`8307390`)

- `submit-ios` and `submit-android` each wrote both Apple ASC and Google Play credentials to disk, even though iOS submit only reads the `.p8` and Android submit only reads the service-account JSON.
- Trim each job to the credential its eas-cli invocation actually consumes. Matches the pattern already used in `build-play-internal.yml`.
- Smaller blast radius — less secret material sitting on the runner per job.

### 4. Cite the EAS Enterprise gate for `--what-to-test` (`25749f3`, `2b3e785`)

- The runbook claim "EAS gates `--what-to-test` behind their Enterprise plan" was originally inference, not verified.
- Confirmed via [eas-cli PR #3023](https://github.com/expo/eas-cli/pull/3023) (merged 2025-06-18, shipped in v16.12.0): _"this consumes extra computing resources during the process so we're going to make this enabled only for enterprise plan."_
- Add the citation to `docs/release.md` and `testing-notes/README.md` so this doesn't get re-litigated.

### 5. Document the `finalize-sentry` condition for single-platform dispatch (`b13beea`)

- Traced the `if:` expression against `workflow_dispatch` with `platform=ios` and `platform=android`: it correctly handles them because `skipped` ≠ `failure` and the OR clause accepts one platform's `success`.
- Add a comment block recording the trace so a future reader doesn't re-derive it from a partial-failure incident.

## Considered, not done

- **eas-cli caching across jobs** — v0.1.10 timing shows ~10s of eas-cli download per job, ~50s total across a ~60-minute workflow run (<1.5%). Doesn't pay for `actions/cache@v4` step noise in three workflows.
- **`--auto-submit-with-profile` consolidation** — would fold build+submit into one EAS invocation. Bigger architectural change, can't smoke-test without burning EAS build credits, and the current split is working. Leaving for a future PR if/when build-vs-submit boundaries become a problem in practice.

## Context

- v0.1.12 was tagged but the build fails on `--what-to-test` rejection in eas-cli v20. We don't re-tag (no-retag rule).
- release-please PR #243 (0.1.13) will absorb this fix; 0.1.13 is the next ship attempt.

## Test plan

Pre-merge (this PR):

- [x] `Native-RD Validate` passes (format / lint / typecheck / test).
- [x] DCO check passes.
- [x] Local `bun run release-notes:split 0.1.12` produces clean output with the manual-paste hint.

Post-merge (verified on the 0.1.13 release run):

- [ ] `eas build` for iOS succeeds with no `--what-to-test` arg in the resolved command line.
- [ ] `eas submit` for iOS succeeds with only the Apple `.p8` written on disk (no Play SA on the iOS submit job).
- [ ] `eas submit` for Android succeeds with only the Play service-account JSON written on disk.
- [ ] `release-notes-split` writes `.release-artifacts/what-to-test.txt` and prints the manual-paste hint.
- [ ] After the build appears in TestFlight, operator pastes `what-to-test.txt` contents into App Store Connect → TestFlight → "What to Test".
- [ ] `finalize-sentry` runs and creates Sentry releases for both platforms (release-published trigger) or for the selected platform only (workflow_dispatch trigger).

Ref-input hardening — can't fully verify without a dispatch:

- [ ] Try a deliberate bad dispatch (paste `ref: main` into the form) → the `Validate ref input` step fails with the actionable error before any checkout runs.
- [ ] Run a normal dispatch (`main` or `v0.1.13`) → validate step passes, downstream jobs run as before.

What **won't** show the effect on this PR:

- v0.1.12 release tag — frozen at the broken commit; we don't re-tag (no-retag rule). 0.1.12 stays a lost release like v0.1.11 did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)