### PR TITLE
chore(sentry-triage): broaden Rule 3 to match title, auto-resolve closed-but-stale dups

### DIFF
--- a/.agents/skills/sentry-triage/SKILL.md
+++ b/.agents/skills/sentry-triage/SKILL.md
@@ -60,13 +60,17 @@ Rule 2 — Stale single occurrence
   THEN: archive in Sentry. action = "archived:stale-single"
 
 Rule 3 — Known native-lib upstream noise
-  IF culprit matches any of:
+  IF (culprit OR title) matches any of:
      /margelo::nitro/, /folly::dynamic/,
      /_axDictionaryKeyReplacement/, /google::logging_fail/,
      /__pthread_kill/
   AND events <= 3
   THEN: file GH issue. labels = ["bug", "app:native-rd", "priority:low"]
         action = "filed:upstream"
+  NOTE: title is matched because Sentry sometimes places the upstream
+        frame in title only (e.g. NATIVE-RD-8 ax-dict 2026-05-16/27,
+        NATIVE-RD-4 margelo::nitro 2026-06-07) with culprit pointing at
+        the Swift `main` thunk. See memory `sentry-triage-rule3-drift`.
 
 Rule 4 — High signal
   IF seerActionability == "high" OR events >= 10 OR users >= 3
@@ -102,10 +106,34 @@ gh issue list \
   --repo rollercoaster-dev/Rollercoaster.dev-mobile \
   --state all \
   --search "in:body $shortId" \
-  --json number,title,state,url
+  --json number,title,state,closedAt,url
 ```
 
-If any match: skip create. Record action as `skipped:dup:<number>` and capture the existing issue URL for the summary.
+If any match: check the dup's state.
+
+**Closed-but-stale (auto-resolve):**
+IF dup.state == CLOSED AND Sentry lastSeen < dup.closedAt
+THEN: the Sentry issue is just a stale `unresolved` row — the GH fix
+already landed and Sentry has been silent since before the close.
+Resolve it in Sentry.
+
+```
+mcp__sentry__update_issue({
+  organizationSlug: "rollercoasterdev",
+  issueId: shortId,
+  regionUrl: "https://de.sentry.io",
+  status: "resolved",
+  reason: "Resolved via GH #$N closed $closedAt; lastSeen $lastSeen (before close). Sentry status was stale."
+})
+```
+
+Record action as `resolved:closed-dup:<N>`. If Sentry ever sees this
+signature again, the resolved issue auto-reopens — so no information
+is lost if the GH close was premature.
+
+**Plain dup:**
+ELSE: skip create. Record action as `skipped:dup:<N>` and capture the
+existing issue URL for the summary.
 
 If no match: create the issue.
 
@@ -163,6 +191,7 @@ Build a single message. Use markdown (`tg-send` supports it).
 Week of <ISO date>
 
 ✅ Archived: <count>
+✅ Resolved: <count> ([list as Sentry shortId → GH #num — closed-but-stale])
 🆕 Filed: <count> ([list as Sentry shortId → GH #num links])
 ♻️ Dedup-skipped: <count>
 ⚠️ Errors: <count if any>

--- a/.agents/skills/sentry-triage/SKILL.md
+++ b/.agents/skills/sentry-triage/SKILL.md
@@ -109,7 +109,14 @@ gh issue list \
   --json number,title,state,closedAt,url
 ```
 
-If any match: check the dup's state.
+If matches exist, pick `dup` by precedence — open beats closed:
+
+- IF any match has `state == OPEN`: pick the most recently created open
+  match as `dup`, and treat it as a **Plain dup** below. Never
+  auto-resolve Sentry while an open GH issue is still tracking this
+  signature, even if a separate closed match also exists.
+- ELSE (all matches are closed): pick the match with the most recent
+  `closedAt` as `dup`, and continue to the **Closed-but-stale** check.
 
 **Closed-but-stale (auto-resolve):**
 IF dup.state == CLOSED AND Sentry lastSeen < dup.closedAt

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -60,13 +60,17 @@ Rule 2 — Stale single occurrence
   THEN: archive in Sentry. action = "archived:stale-single"
 
 Rule 3 — Known native-lib upstream noise
-  IF culprit matches any of:
+  IF (culprit OR title) matches any of:
      /margelo::nitro/, /folly::dynamic/,
      /_axDictionaryKeyReplacement/, /google::logging_fail/,
      /__pthread_kill/
   AND events <= 3
   THEN: file GH issue. labels = ["bug", "app:native-rd", "priority:low"]
         action = "filed:upstream"
+  NOTE: title is matched because Sentry sometimes places the upstream
+        frame in title only (e.g. NATIVE-RD-8 ax-dict 2026-05-16/27,
+        NATIVE-RD-4 margelo::nitro 2026-06-07) with culprit pointing at
+        the Swift `main` thunk. See memory `sentry-triage-rule3-drift`.
 
 Rule 4 — High signal
   IF seerActionability == "high" OR events >= 10 OR users >= 3
@@ -102,10 +106,34 @@ gh issue list \
   --repo rollercoaster-dev/Rollercoaster.dev-mobile \
   --state all \
   --search "in:body $shortId" \
-  --json number,title,state,url
+  --json number,title,state,closedAt,url
 ```
 
-If any match: skip create. Record action as `skipped:dup:<number>` and capture the existing issue URL for the summary.
+If any match: check the dup's state.
+
+**Closed-but-stale (auto-resolve):**
+  IF dup.state == CLOSED AND Sentry lastSeen < dup.closedAt
+  THEN: the Sentry issue is just a stale `unresolved` row — the GH fix
+        already landed and Sentry has been silent since before the close.
+        Resolve it in Sentry.
+
+```
+mcp__sentry__update_issue({
+  organizationSlug: "rollercoasterdev",
+  issueId: shortId,
+  regionUrl: "https://de.sentry.io",
+  status: "resolved",
+  reason: "Resolved via GH #<N> closed <closedAt>; lastSeen <lastSeen> (before close). Sentry status was stale."
+})
+```
+
+  Record action as `resolved:closed-dup:<N>`. If Sentry ever sees this
+  signature again, the resolved issue auto-reopens — so no information
+  is lost if the GH close was premature.
+
+**Plain dup:**
+  ELSE: skip create. Record action as `skipped:dup:<N>` and capture the
+        existing issue URL for the summary.
 
 If no match: create the issue.
 
@@ -163,6 +191,7 @@ Build a single message. Use markdown (`tg-send` supports it).
 Week of <ISO date>
 
 ✅ Archived: <count>
+✅ Resolved: <count> ([list as Sentry shortId → GH #num — closed-but-stale])
 🆕 Filed: <count> ([list as Sentry shortId → GH #num links])
 ♻️ Dedup-skipped: <count>
 ⚠️ Errors: <count if any>

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -123,7 +123,7 @@ mcp__sentry__update_issue({
   issueId: shortId,
   regionUrl: "https://de.sentry.io",
   status: "resolved",
-  reason: "Resolved via GH #<N> closed <closedAt>; lastSeen <lastSeen> (before close). Sentry status was stale."
+  reason: "Resolved via GH #$N closed $closedAt; lastSeen $lastSeen (before close). Sentry status was stale."
 })
 ```
 

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -112,10 +112,10 @@ gh issue list \
 If any match: check the dup's state.
 
 **Closed-but-stale (auto-resolve):**
-  IF dup.state == CLOSED AND Sentry lastSeen < dup.closedAt
-  THEN: the Sentry issue is just a stale `unresolved` row — the GH fix
-        already landed and Sentry has been silent since before the close.
-        Resolve it in Sentry.
+IF dup.state == CLOSED AND Sentry lastSeen < dup.closedAt
+THEN: the Sentry issue is just a stale `unresolved` row — the GH fix
+already landed and Sentry has been silent since before the close.
+Resolve it in Sentry.
 
 ```
 mcp__sentry__update_issue({
@@ -127,13 +127,13 @@ mcp__sentry__update_issue({
 })
 ```
 
-  Record action as `resolved:closed-dup:<N>`. If Sentry ever sees this
-  signature again, the resolved issue auto-reopens — so no information
-  is lost if the GH close was premature.
+Record action as `resolved:closed-dup:<N>`. If Sentry ever sees this
+signature again, the resolved issue auto-reopens — so no information
+is lost if the GH close was premature.
 
 **Plain dup:**
-  ELSE: skip create. Record action as `skipped:dup:<N>` and capture the
-        existing issue URL for the summary.
+ELSE: skip create. Record action as `skipped:dup:<N>` and capture the
+existing issue URL for the summary.
 
 If no match: create the issue.
 

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -109,7 +109,14 @@ gh issue list \
   --json number,title,state,closedAt,url
 ```
 
-If any match: check the dup's state.
+If matches exist, pick `dup` by precedence — open beats closed:
+
+- IF any match has `state == OPEN`: pick the most recently created open
+  match as `dup`, and treat it as a **Plain dup** below. Never
+  auto-resolve Sentry while an open GH issue is still tracking this
+  signature, even if a separate closed match also exists.
+- ELSE (all matches are closed): pick the match with the most recent
+  `closedAt` as `dup`, and continue to the **Closed-but-stale** check.
 
 **Closed-but-stale (auto-resolve):**
 IF dup.state == CLOSED AND Sentry lastSeen < dup.closedAt


### PR DESCRIPTION
## Summary
- **Rule 3** now matches `(culprit OR title)` — Sentry sometimes hides the upstream frame in `title` while `culprit` points at the Swift `main` thunk.
- **New dedup branch:** if a GH dup is CLOSED and Sentry `lastSeen < closedAt`, auto-resolve the Sentry row with a templated reason instead of silently skipping.
- Telegram template gains `✅ Resolved` line.

## Why now

Two distinct problems showed up in the 2026-06-07 triage run:

**Rule 3 title-only misses** — third distinct case observed (NATIVE-RD-4 / `margelo::nitro`), after two ax-dict misses on NATIVE-RD-8 (2026-05-16, 2026-05-27). The drift-watch memo's trigger condition has now fired; broadening to `(culprit OR title)` is safe because the existing `events <= 3` guard caps blast radius.

**Closed-but-stale Sentry rows** — NATIVE-RD-2 (#53) and NATIVE-RD-B (#93) both had GH issues closed weeks ago, but Sentry rows still showed `unresolved` with `lastSeen` *before* the GH close. The old dedup logic silently skipped them. The new branch resolves them with a reason comment linking the GH close. If the signature ever returns, Sentry auto-reopens the resolved issue, so worst case is a label flip.

## Test plan
- [ ] On next `/sentry-triage` run, a title-only Rule 3 candidate routes to `filed:upstream` (priority:low) instead of `filed:high-signal` or `filed:triage`.
- [ ] On next `/sentry-triage` run, a CLOSED GH dup with `lastSeen < closedAt` triggers auto-resolve, and the Telegram summary shows it under `✅ Resolved`.
- [ ] Plain dups (open GH issues, or closed with `lastSeen >= closedAt`) still route to `skipped:dup:<N>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)