### PR TITLE
fix(native-rd): handle changeLanguage rejection in dev LanguagePicker (#125)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-125-language-picker-catch.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-125-language-picker-catch.md
@@ -1,0 +1,90 @@
+# Development Plan: Issue #125
+
+## Issue Summary
+
+**Title**: void i18n.changeLanguage(...) swallows promise rejection in LanguagePicker
+**Type**: tech-debt
+**Complexity**: TRIVIAL
+**Estimated Lines**: ~15 lines (implementation + test additions)
+
+## Intent Verification
+
+Observable criteria derived from the issue:
+
+- [x] When `i18n.changeLanguage` rejects, the error is logged via `logger.error(...)` rather than silently discarded.
+- [x] The toggle's displayed state is driven by `i18n.language` (reactive read), so a failed language switch leaves the toggle at its pre-change value — no explicit revert needed.
+- [x] The existing test "switches language to pseudo and back when the toggle changes" continues to pass.
+- [x] A new test asserts that when `changeLanguage` rejects, `logger.error` is called with the error.
+
+_Write criteria that a reviewer could verify by running the tests or reading the implementation._
+
+## Dependencies
+
+No upstream dependencies. Issue #67 (i18n migration) is already closed; this issue was surfaced during that review but is standalone.
+
+| Issue | Title                                            | Status | Type         |
+| ----- | ------------------------------------------------ | ------ | ------------ |
+| #67   | i18n: migrate Welcome, NewGoal, Settings screens | Closed | Context only |
+
+**Status**: All dependencies met.
+
+## Objective
+
+Replace `void i18n.changeLanguage(...)` in `LanguagePicker` with a `.catch` handler that logs the rejection via the project's standard `Logger` primitive. This eliminates the UnhandledPromiseRejection silent-fail and aligns the handler with the app-wide error-logging convention.
+
+## Decisions
+
+| ID  | Decision                                                                                                       | Alternatives Considered                                       | Rationale                                                                                                                                                                                                                                                                                                                                                                  |
+| --- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Use `Logger` from `../../shims/rd-logger` (same shim used by `src/i18n/index.ts` and all screen-level loggers) | `console.error` directly; Sentry directly                     | `Logger.error` is the single logging primitive in this codebase. It wraps `console.error`, extracts `Error` instances, and routes them to `reportLoggerError` (Sentry bridge). Using it directly gives free Sentry capture without extra code.                                                                                                                             |
+| D2  | No explicit toggle-state revert                                                                                | Explicit `setState` call to undo the visual toggle            | `isPseudo` is derived from `i18n.language` via `useTranslation`, which re-renders when the language changes. If `changeLanguage` rejects, `i18n.language` stays unchanged, so the toggle re-renders back to the pre-change value on the next render. No manual revert needed.                                                                                              |
+| D3  | Scope the logger name to `"SettingsScreen"`                                                                    | `"LanguagePicker"`, `"i18n"`                                  | Matches the convention every other screen uses (e.g. `new Logger("BadgeDesignerScreen")`). The i18n module already has its own `new Logger("i18n")` instance.                                                                                                                                                                                                              |
+| D4  | Single commit — no split                                                                                       | Two commits (impl + test)                                     | The implementation change is one expression in one file; the test update is in the co-located test file. Both are small enough to land atomically. Splitting would produce a red-CI commit (unhandled rejection, but no test yet).                                                                                                                                         |
+| D5  | Wrap non-Error rejections before logging                                                                       | Pass `err` through as-is (relying on rd-logger's `findError`) | rd-logger's Sentry bridge only fires when an `Error` instance is detected. If `changeLanguage` ever rejects with a non-Error (string, plain object), bypassing the bridge would silently drop the Sentry breadcrumb. One-line wrap (`err instanceof Error ? err : new Error(String(err))`) closes that gap with zero downside. User-driven decision during implementation. |
+
+## Affected Areas
+
+- `apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx`: add `Logger` import, instantiate module-level `logger`, attach `.catch` to `changeLanguage` call.
+- `apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx`: add a test asserting `logger.error` is called when `changeLanguage` rejects.
+
+## Implementation Plan
+
+### Step 1: Attach `.catch` to `changeLanguage` and add rejection test
+
+**Files**:
+
+- `apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx`
+- `apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx`
+
+**Commit**: `fix(settings): handle changeLanguage rejection in LanguagePicker`
+
+**Changes**:
+
+- [x] Add `import { Logger } from "../../shims/rd-logger";` near the top of `SettingsScreen.tsx` (group with other local imports).
+- [x] Add `const logger = new Logger("SettingsScreen");` as a module-level constant (after imports, before the component functions).
+- [x] Replace `void i18n.changeLanguage(next ? "pseudo" : "en");` with the `.catch` handler (including the D5 non-Error wrap).
+- [x] In `SettingsScreen.test.tsx`, within the `LanguagePicker (dev-only)` describe block, add a test that captures the SettingsScreen logger instance (via `Logger.mock.results` at module load — see Discovery Log) and asserts `logger.error` is called when `changeLanguage` rejects.
+
+## Testing Strategy
+
+- [ ] Unit test: `changeLanguage` rejection calls `logger.error` (Jest 30, `@testing-library/react-native` v13)
+- [ ] Test file: `src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx` (co-located, already exists)
+- [ ] Existing tests must stay green — the spy approach must not mutate i18n state for sibling tests
+- [ ] Manual: flip the pseudo toggle in the dev client; observe no console errors for the happy path; observe a logged error if `changeLanguage` is forced to throw
+
+## Not in Scope
+
+| Item                                        | Reason                                                                                                           | Follow-up  |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------- |
+| Lazy-load translation protection            | Issue explicitly scopes this to "if we ever lazy-load" — that's a future concern                                 | none filed |
+| Sentry breadcrumb / alert for the rejection | Dev-only UI; `logger.error` already routes to Sentry via `reportLoggerError` if the error is an `Error` instance | none       |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+
+- [2026-06-07] **jest globally mocks `rd-logger`** via `moduleNameMapper` in `jest.config.js` (maps `../shims/rd-logger` → `src/db/__tests__/mocks/rd-logger.ts`). The mock returns a fresh `{ error, warn, info, debug }` per `new Logger(...)`. To assert on logger behaviour, the test has to reach the mocked instance — `console.error` spies don't fire because the real shim is never loaded under jest.
+- [2026-06-07] **Capturing the SettingsScreen logger instance**: the existing `beforeEach(() => jest.clearAllMocks())` wipes `Logger.mock.calls` and `Logger.mock.results`, so the instance can't be looked up inside a test. Captured once at module-load time at the top of the test file (after imports but before describe blocks). The instance reference persists; its `error` jest.fn() call history still gets cleared per-test, which is the desired behaviour.
+- [2026-06-07] **Used `waitFor` instead of microtask-drain pattern**: `.catch` fires asynchronously after `fireEvent`; `await Promise.resolve()` twice was insufficient in this environment. `waitFor` from `@testing-library/react-native` retries the assertion until it passes or times out, which is the canonical RN-testing pattern for async-handler side effects.

--- a/apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -21,7 +21,10 @@ import { SettingsRow } from "../../components/SettingsRow";
 import { ThemeSwitcher } from "../../components/ThemeSwitcher";
 import { useDensity } from "../../hooks/useDensity";
 import { densityOptions } from "../../utils/density";
+import { Logger } from "../../shims/rd-logger";
 import { styles } from "./SettingsScreen.styles";
+
+const logger = new Logger("SettingsScreen");
 
 export function isSentryDebugToolsEnabled(value: string | undefined): boolean {
   return value === "true";
@@ -78,7 +81,13 @@ function LanguagePicker() {
         toggle={{
           value: isPseudo,
           onValueChange: (next) => {
-            void i18n.changeLanguage(next ? "pseudo" : "en");
+            i18n
+              .changeLanguage(next ? "pseudo" : "en")
+              .catch((err: unknown) => {
+                const error =
+                  err instanceof Error ? err : new Error(String(err));
+                logger.error("changeLanguage failed", { error });
+              });
           },
         }}
       />

--- a/apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
+++ b/apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
@@ -5,10 +5,29 @@ import {
   renderWithProviders,
   screen,
   fireEvent,
+  waitFor,
 } from "../../../__tests__/test-utils";
 import { i18n } from "../../../i18n";
+import { Logger } from "../../../shims/rd-logger";
 
 import { isSentryDebugToolsEnabled, SettingsScreen } from "../SettingsScreen";
+
+// jest.config.js maps "../shims/rd-logger" to a mock that returns a fresh
+// `{ error, warn, info, debug }` instance per `new Logger(...)`. SettingsScreen
+// instantiates exactly one logger at module load. Capture that instance now —
+// `beforeEach(jest.clearAllMocks)` wipes the constructor's call history, but the
+// instance reference (and its `error` jest.fn() call history, also cleared) lives on.
+const MockLogger = Logger as unknown as jest.Mock;
+const settingsScreenLoggerIdx = MockLogger.mock.calls.findIndex(
+  (call: unknown[]) => call[0] === "SettingsScreen",
+);
+if (settingsScreenLoggerIdx < 0) {
+  throw new Error(
+    "SettingsScreen did not instantiate a Logger at module load — did the import order change?",
+  );
+}
+const settingsScreenLogger = MockLogger.mock.results[settingsScreenLoggerIdx]
+  .value as { error: jest.Mock };
 
 // RN's jest setup sets __DEV__ as a runtime global; TS doesn't see it here.
 const devGlobal = global as unknown as { __DEV__: boolean };
@@ -312,6 +331,28 @@ describe("SettingsScreen", () => {
 
       fireEvent(toggle, "valueChange", false);
       expect(changeSpy).toHaveBeenLastCalledWith("en");
+
+      changeSpy.mockRestore();
+    });
+
+    it("logs an error via the SettingsScreen logger when changeLanguage rejects", async () => {
+      devGlobal.__DEV__ = true;
+      const boom = new Error("loader exploded");
+      const changeSpy = jest
+        .spyOn(i18n, "changeLanguage")
+        .mockRejectedValueOnce(boom);
+
+      renderWithProviders(<SettingsScreen />);
+      const toggle = screen.getByLabelText(i18n.t("settings:language.pseudo"));
+
+      fireEvent(toggle, "valueChange", true);
+
+      await waitFor(() => {
+        expect(settingsScreenLogger.error).toHaveBeenCalledWith(
+          "changeLanguage failed",
+          { error: boom },
+        );
+      });
 
       changeSpy.mockRestore();
     });


### PR DESCRIPTION
## Summary

- Replaces `void i18n.changeLanguage(...)` in the dev-only `LanguagePicker` with a `.catch` handler that routes rejections through the `Logger`/Sentry bridge instead of becoming a silent `UnhandledPromiseRejection`.
- Non-`Error` rejection values are wrapped (`err instanceof Error ? err : new Error(String(err))`) before logging so the rd-logger shim's Error-detection always fires and Sentry never misses an event.
- No UI revert needed: the toggle's value is read from `i18n.language` via `useTranslation`, so a rejected switch re-renders the toggle to its pre-change state automatically.

## Changes

- `apps/native-rd/src/screens/SettingsScreen/SettingsScreen.tsx` — add `Logger` import, module-level `logger` instance, replace `void` with `.catch` + wrap.
- `apps/native-rd/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx` — new test capturing the mocked Logger instance at module load and asserting `logger.error("changeLanguage failed", { error })` fires on rejection.
- `apps/native-rd/docs/plans/dev-plans/issue-125-language-picker-catch.md` — dev plan with decisions and discovery log.

## Intent Verification

- [x] When `i18n.changeLanguage` rejects, the error is logged via `logger.error(...)` rather than silently discarded.
- [x] The toggle's displayed state is driven by `i18n.language` (reactive read), so a failed language switch leaves the toggle at its pre-change value — no explicit revert needed.
- [x] The existing test "switches language to pseudo and back when the toggle changes" continues to pass.
- [x] A new test asserts that when `changeLanguage` rejects, `logger.error` is called with the error.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Use `Logger` from `../../shims/rd-logger` | Single logging primitive in the codebase. `Logger.error` wraps `console.error` AND extracts `Error` instances into `reportLoggerError` (Sentry bridge). Free Sentry capture, dev-console output retained. |
| No explicit toggle-state revert | `isPseudo = i18n.language === "pseudo"` via `useTranslation` re-renders when language changes. A rejected `changeLanguage` leaves `i18n.language` untouched → toggle re-renders to prior state automatically. |
| Logger scope `"SettingsScreen"` | Matches every other screen's convention (`new Logger("BadgeDesignerScreen")` etc.). |
| Single commit | ~15 lines total across one production file + one co-located test file. Splitting would land a red-CI intermediate. |
| Wrap non-Error rejections | rd-logger's `findError` bridge only fires for `Error` instances. Wrapping closes the gap if `changeLanguage` ever rejects with a non-Error (string, plain object). One line, zero downside. |

## Discovery Log

- [2026-06-07] **jest globally mocks `rd-logger`** via `moduleNameMapper` in `jest.config.js` (maps `../shims/rd-logger` → `src/db/__tests__/mocks/rd-logger.ts`). Mock returns a fresh `{ error, warn, info, debug }` per `new Logger(...)`. Spying on `console.error` from tests doesn't work — the real shim is never loaded.
- [2026-06-07] **Capturing the SettingsScreen logger instance**: existing `beforeEach(() => jest.clearAllMocks())` wipes `Logger.mock.calls`/`mock.results`, so the instance can't be looked up inside a test. Captured once at module-load time at the top of the test file. The instance reference persists; its `error` jest.fn() call history still gets cleared per-test, which is the desired behaviour.
- [2026-06-07] **Used `waitFor` instead of microtask-drain pattern**: `.catch` fires asynchronously after `fireEvent`; `await Promise.resolve()` twice was insufficient. `waitFor` from `@testing-library/react-native` retries the assertion until it passes — the canonical RN-testing pattern for async-handler side effects.

## Test Plan

- [x] Type-check passes (`bun run type-check`)
- [x] Lint passes (`bun run lint` — 0 errors)
- [x] Tests pass (`npx jest --no-coverage` — 176 suites, 8760 tests including the new rejection test)
- [x] Build script no-op for native-rd

---

Closes #125

Generated with [Claude Code](https://claude.ai/code)