### PR TITLE
fix(native-rd): vendor unistyles PR #1191 patch for shadow-tree double-free

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/native-rd": {
       "name": "native-rd",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@evolu/common": "^7.4.1",
         "@evolu/react": "^10.4.0",
@@ -142,6 +142,7 @@
     },
   },
   "patchedDependencies": {
+    "react-native-unistyles@3.2.5": "patches/react-native-unistyles@3.2.5.patch",
     "ajv-formats@3.0.1": "patches/ajv-formats@3.0.1.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "bun": ">=1.3.7"
   },
   "patchedDependencies": {
-    "ajv-formats@3.0.1": "patches/ajv-formats@3.0.1.patch"
+    "ajv-formats@3.0.1": "patches/ajv-formats@3.0.1.patch",
+    "react-native-unistyles@3.2.5": "patches/react-native-unistyles@3.2.5.patch"
   }
 }

--- a/patches/react-native-unistyles@3.2.5.patch
+++ b/patches/react-native-unistyles@3.2.5.patch
@@ -1,0 +1,92 @@
+diff --git a/cxx/core/UnistylesRegistry.cpp b/cxx/core/UnistylesRegistry.cpp
+index 7960fd72c580a526ed52cba3d1fc7505cb45c7e0..795072cfdeb3989a834568d3975113826f20fb4f 100644
+--- a/cxx/core/UnistylesRegistry.cpp
++++ b/cxx/core/UnistylesRegistry.cpp
+@@ -122,6 +122,7 @@ void core::UnistylesRegistry::suspendShadowNode(const ShadowNodeFamily* shadowNo
+     this->trafficController.withLock([this, shadowNodeFamily](){
+         if (this->_shadowRegistry.contains(shadowNodeFamily)) {
+             this->_suspendedFamilies.insert(shadowNodeFamily);
++            this->trafficController.removeShadowNode(shadowNodeFamily);
+         }
+     });
+ }
+@@ -130,6 +131,10 @@ bool core::UnistylesRegistry::isSuspended(const ShadowNodeFamily* family) const
+     return _suspendedFamilies.count(family) > 0;
+ }
+ 
++bool core::UnistylesRegistry::isActiveUnistylesFamily(const ShadowNodeFamily* family) const noexcept {
++    return _shadowRegistry.count(family) > 0 && _suspendedFamilies.count(family) == 0;
++}
++
+ std::shared_ptr<core::StyleSheet> core::UnistylesRegistry::addStyleSheet(jsi::Runtime& rt, core::StyleSheetType type, jsi::Object&& rawValue) {
+     int tag = _nextStyleSheetTag.fetch_add(1);
+ 
+@@ -145,6 +150,10 @@ core::DependencyMap core::UnistylesRegistry::buildDependencyMap(std::vector<Unis
+     std::unordered_set<UnistyleDependency> uniqueDependencies(deps.begin(), deps.end());
+ 
+     for (const auto& [family, unistyles] : this->_shadowRegistry) {
++        if (this->_suspendedFamilies.count(family) > 0) {
++            continue;
++        }
++
+         bool hasAnyOfDependencies = false;
+ 
+         // Check if any dependency matches
+diff --git a/cxx/core/UnistylesRegistry.h b/cxx/core/UnistylesRegistry.h
+index f501232918f26154836965dc3130dd6c119e3365..fd0eb332c1fd24eaa57051395c2d08e55e0b04d8 100644
+--- a/cxx/core/UnistylesRegistry.h
++++ b/cxx/core/UnistylesRegistry.h
+@@ -44,6 +44,8 @@ struct UnistylesRegistry: public StyleSheetRegistry {
+     void unlinkShadowNodeWithUnistyles(const ShadowNodeFamily*);
+     void suspendShadowNode(const ShadowNodeFamily*);
+     bool isSuspended(const ShadowNodeFamily*) const noexcept;
++    // Caller must hold trafficController's lock when link/unlink/suspend may race.
++    bool isActiveUnistylesFamily(const ShadowNodeFamily*) const noexcept;
+     std::shared_ptr<core::StyleSheet> addStyleSheet(jsi::Runtime& rt, core::StyleSheetType type, jsi::Object&& rawValue);
+     DependencyMap buildDependencyMap(std::vector<UnistyleDependency>& deps);
+     void shadowLeafUpdateFromUnistyle(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Value& maybePressableId);
+diff --git a/cxx/shadowTree/ShadowTrafficController.h b/cxx/shadowTree/ShadowTrafficController.h
+index aafbecedd3a209c25dcb6055acad19bf377cb2f3..2c952a566ccf40f006883e52431fad6f697122b8 100644
+--- a/cxx/shadowTree/ShadowTrafficController.h
++++ b/cxx/shadowTree/ShadowTrafficController.h
+@@ -20,9 +20,13 @@ struct ShadowTrafficController {
+         this->_canCommit = true;
+     }
+ 
+-    inline shadow::ShadowLeafUpdates& getUpdates() {
++    inline shadow::ShadowLeafUpdates takeUpdates() {
+         // call it only within withLock!
+-        return _unistylesUpdates;
++        auto updates = std::move(_unistylesUpdates);
++        _unistylesUpdates = {};
++        _canCommit = false;
++
++        return updates;
+     }
+ 
+     inline void setUpdates(shadow::ShadowLeafUpdates& newUpdates) {
+diff --git a/cxx/shadowTree/ShadowTreeManager.cpp b/cxx/shadowTree/ShadowTreeManager.cpp
+index 01026dc5751b00473ae878804cdae1b283fdbc57..f4e5cff69107c4e64b97ee8464654e53dbeb4af9 100644
+--- a/cxx/shadowTree/ShadowTreeManager.cpp
++++ b/cxx/shadowTree/ShadowTreeManager.cpp
+@@ -10,7 +10,19 @@ void shadow::ShadowTreeManager::updateShadowTree(jsi::Runtime& rt) {
+     auto& registry = core::UnistylesRegistry::get();
+ 
+     registry.trafficController.withLock([&](){
+-        auto updates = registry.trafficController.getUpdates();
++        auto updates = registry.trafficController.takeUpdates();
++
++        if (updates.empty()) {
++            return;
++        }
++
++        for (auto it = updates.begin(); it != updates.end();) {
++            if (!registry.isActiveUnistylesFamily(it->first)) {
++                it = updates.erase(it);
++            } else {
++                ++it;
++            }
++        }
+ 
+         if (updates.empty()) {
+             return;


### PR DESCRIPTION
## Summary

Vendors [react-native-unistyles PR #1191](https://github.com/jpudysz/react-native-unistyles/pull/1191) via Bun's `patchedDependencies` to close a shadow-tree use-after-free window that crashed the app on theme changes (Sentry NATIVE-RD-4 / NATIVE-RD-9).

The upstream patch replaces `ShadowTrafficController::getUpdates()` with `takeUpdates()` (drain-by-move + clear + `_canCommit=false`), filters stale shadow node families through a new `UnistylesRegistry::isActiveUnistylesFamily()` guard, and hooks `suspendShadowNode` to `trafficController.removeShadowNode` so pending updates against a suspended family are dropped before they reach `nativeProps_DEPRECATED`.

## Changes

- `patches/react-native-unistyles@3.2.5.patch` — 92-line vendored patch, byte-equivalent to upstream PR #1191 modulo path translation (`packages/unistyles/cxx/` → `cxx/` after npm tarball flattening)
- `package.json` — `patchedDependencies` entry for `react-native-unistyles@3.2.5`
- `bun.lock` — lockfile update

No app source under `apps/native-rd/src/` is touched.

## Dependencies

- [ ] None

## Test Plan

Verification was the gating step for this PR — no automated suite exists for C++ shadow-tree behavior.

- [x] Patched symbols present in `node_modules/react-native-unistyles/cxx/` after `bun install` — `takeUpdates` / `isActiveUnistylesFamily` counts match expected `1 1 1 2` across the four target files
- [x] iOS dev client rebuild succeeded on iPhone 17 simulator (iOS 26.1, Xcode 26) — unistyles C++ translation units compiled cleanly, no link errors
- [x] App launches and reaches the Goals screen on the patched binary
- [x] Stress test: 10× rapid toggle `light-default` ↔ `dark-default` (qutrek's documented repro pattern from upstream issue #1179) survived without SIGABRT — final theme applied correctly, tab navigation Goals↔Settings post-stress still works
- [x] Simulator system log contains no abort/exception/unistyles errors during the toggle storm

What this PR does NOT cover (deferred to post-merge):
- Real iPhone 11 hardware (most reliable upstream repro device) — local debug-tether to legacy iOS hardware is blocked on Xcode 26 + iOS 16 pairing (see native-rd-build skill, Gotcha 12); will be exercised via TestFlight after merge
- Production EAS build — by project rule, agents do not run EAS builds; needs human-driven `eas build`

## Related Issues

Closes #270

Upstream:
- Issue: https://github.com/jpudysz/react-native-unistyles/issues/1179
- PR: https://github.com/jpudysz/react-native-unistyles/pull/1191