### PR TITLE
fix(useDensity): validate DB density value, route to Sentry (closes #126)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-126-density-unsafe-cast.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-126-density-unsafe-cast.md
@@ -1,0 +1,121 @@
+# Development Plan: Issue #126
+
+## Issue Summary
+
+**Title**: useDensity unsafe DensityLevel cast on DB read
+**Type**: bug
+**Complexity**: SMALL
+**Estimated Lines**: ~80 lines
+
+## Intent Verification
+
+Observable criteria derived from the issue.
+
+- [ ] When `useDensity` reads a `null` density from DB, `densityLevel` is `"default"` and no log is emitted.
+- [ ] When `useDensity` reads a valid `DensityLevel` string from DB (`"compact"`, `"default"`, `"comfortable"`), it is used as-is.
+- [ ] When `useDensity` reads an unrecognised string from DB (e.g. `"cozy"`, `"large"`, any arbitrary value), `densityLevel` falls back to `"default"` AND a `logger.error` call is made with an `Error` instance carrying the bad value, so the rd-logger shim forwards it to Sentry.
+- [ ] The `as DensityLevel` cast is gone from `useDensity.ts`; TypeScript compilation passes with no suppressions.
+- [ ] A new unit test in `src/hooks/__tests__/useDensity.test.ts` passes a bogus string via `mockUseQuery` and asserts both the fallback and the error log emission.
+
+## Dependencies
+
+No upstream dependencies.
+
+**Status**: All dependencies met.
+
+## Objective
+
+Replace the unsafe `as DensityLevel` cast in `useDensity.ts` with a proper runtime type guard that narrows DB values to `DensityLevel`, falls back to `"default"` for anything unrecognised, and emits a `logger.error` (carrying an `Error` instance) so corrupted rows reach Sentry via the rd-logger shim.
+
+## Decisions
+
+| ID  | Decision                                                                             | Alternatives Considered                                                    | Rationale                                                                                                                                                                                                                                                                                                         |
+| --- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Add `isDensityLevel` type guard and `narrowDensity` helper to `src/utils/density.ts` | Inline ternary or IIFE in `useDensity.ts`; guard in a separate `guards.ts` | `density.ts` already owns the union and `densityOptions` array; co-locating the guard keeps the module self-contained and matches the `isValidThemeName` pattern in `useTheme.ts`. A named `narrowDensity` helper (user decision 2026-06-11) makes the unknown-value path directly testable in `density.test.ts`. |
+| D2  | Use `logger.error` with an `Error` instance for unknown DB value                     | `logger.warn` (console-only)                                               | User decision 2026-06-11: corrupted density rows must reach Sentry. The `rd-logger` shim's `reportLoggerError` only forwards calls when at least one arg is an `Error`, so we pass a constructed `Error("Unknown density value: " + raw)` plus a metadata object.                                                 |
+| D3  | Do not auto-write the fallback back to Evolu                                         | Auto-correct the stored value                                              | Consistent with `useThemePersistence`'s rationale: the user might restore the row on the next sync or upgrade; silently clobbering it loses intent. Confirmed by user 2026-06-11.                                                                                                                                 |
+| D4  | Export `isDensityLevel` and `narrowDensity` from `density.ts`                        | Keep them unexported / internal to the hook                                | Both are testable directly in `density.test.ts`. `narrowDensity` encapsulates the fallback + logging policy so the hook stays a thin consumer.                                                                                                                                                                    |
+
+## Affected Areas
+
+- `apps/native-rd/src/utils/density.ts`: add `DENSITY_LEVELS` set, `isDensityLevel(value: unknown): value is DensityLevel` type guard, and `narrowDensity(raw: unknown, logger: Logger): DensityLevel` helper that handles `null`/valid/invalid branches and emits the Sentry-reaching `logger.error` for the invalid branch. Export all three.
+- `apps/native-rd/src/hooks/useDensity.ts`: import `narrowDensity` and `Logger`, replace the unsafe cast with a single `narrowDensity(settings?.density, logger)` call, add a module-level `const logger = new Logger("useDensity")`.
+- `apps/native-rd/src/hooks/__tests__/useDensity.test.ts`: add `describe("unknown DB value fallback")` with two cases: bogus string falls back to `"default"`, `logger.error` is called once with an `Error` instance.
+- `apps/native-rd/src/utils/__tests__/density.test.ts`: add `isDensityLevel` guard tests (valid values, invalid strings, non-strings) and `narrowDensity` tests (null → "default" no log, valid → passthrough no log, invalid → "default" with `logger.error` called with an `Error`).
+
+## Implementation Plan
+
+### Step 1: Add `isDensityLevel` guard and `narrowDensity` helper to density utilities
+
+**Files**: `apps/native-rd/src/utils/density.ts`, `apps/native-rd/src/utils/__tests__/density.test.ts`
+**Commit**: `fix(density): add isDensityLevel guard and narrowDensity helper`
+**Changes**:
+
+- [ ] Export `DENSITY_LEVELS: ReadonlySet<DensityLevel>` built from the keys of `DENSITY_MULTIPLIERS` (no separate string array needed — the Record already has the canonical list).
+- [ ] Export `isDensityLevel(value: unknown): value is DensityLevel` that checks `typeof value === "string"` then `DENSITY_LEVELS.has(value as DensityLevel)`.
+- [ ] Export `narrowDensity(raw: unknown, logger: Logger): DensityLevel` with this contract:
+  ```ts
+  export function narrowDensity(raw: unknown, logger: Logger): DensityLevel {
+    if (raw === null || raw === undefined) return "default";
+    if (isDensityLevel(raw)) return raw;
+    logger.error(new Error(`Unknown density value in DB: ${String(raw)}`), {
+      rawDensity: raw,
+    });
+    return "default";
+  }
+  ```
+  The `Error` instance is required — the `rd-logger` shim's `reportLoggerError` only forwards to Sentry when at least one arg is an `Error`. Import `Logger` from `../shims/rd-logger`.
+- [ ] In `density.test.ts`:
+  - `describe("isDensityLevel")` block using `test.each` for all three valid values, a sample of invalid strings, and non-string inputs (`null`, `42`, `undefined`).
+  - `describe("narrowDensity")` block: pass a stub logger (`{ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }`-shaped) and assert (a) `null` → `"default"` with no logger calls, (b) `undefined` → `"default"` with no logger calls, (c) valid `"compact"` → `"compact"` with no logger calls, (d) bogus `"cozy"` → `"default"` AND `logger.error` called once with first arg `instanceof Error`.
+
+### Step 2: Fix unsafe cast in `useDensity` by delegating to `narrowDensity`
+
+**Files**: `apps/native-rd/src/hooks/useDensity.ts`
+**Commit**: `fix(useDensity): replace unsafe DensityLevel cast with validated narrowing`
+**Changes**:
+
+- [ ] Import `narrowDensity` from `../utils/density`.
+- [ ] Import `Logger` from `../shims/rd-logger`.
+- [ ] Add module-level `const logger = new Logger("useDensity")` (matches `useThemePersistence` pattern).
+- [ ] Replace lines 23-24:
+  ```ts
+  const densityLevel: DensityLevel =
+    (settings?.density as DensityLevel) || "default";
+  ```
+  with:
+  ```ts
+  const densityLevel: DensityLevel = narrowDensity(settings?.density, logger);
+  ```
+
+### Step 3: Add unit tests for the hook's fallback path
+
+**Files**: `apps/native-rd/src/hooks/__tests__/useDensity.test.ts`
+**Commit**: `test(useDensity): cover unknown DB value fallback and error emission`
+**Changes**:
+
+- [ ] Mock `../shims/rd-logger` at the top of the test file (same pattern as `../../db` mock already present); expose `mockLoggerError` spy on the `Logger` class's `error` method.
+- [ ] Add `describe("unknown DB value fallback")`:
+  - `it("falls back to 'default' when density is an unrecognised string")` — feeds `{ density: "cozy" }` via `makeSettings`, asserts `densityLevel === "default"` from hook result, asserts `mockLoggerError` called once with first arg `instanceof Error`.
+  - `it("does not log when density is null")` — feeds `{ density: null }`, asserts fallback `"default"` and `mockLoggerError` NOT called.
+
+## Testing Strategy
+
+- [ ] Unit tests for `isDensityLevel` guard and `narrowDensity` helper in `src/utils/__tests__/density.test.ts` using `test.each` for all valid values + invalid samples.
+- [ ] Unit tests for the hook's fallback path in `src/hooks/__tests__/useDensity.test.ts` with a mocked `Logger` asserting `error` is called with an `Error` instance.
+- [ ] Test file paths mirror `src/` under `src/__tests__/` (already the case for both files).
+- [ ] No new screen-level test required — `SettingsScreen` renders `densityLevel` via `DensityPicker`, and the guard lives entirely in the hook.
+- [ ] Run: `bun test --testPathPatterns "useDensity|density"` to validate both test files.
+
+## Not in Scope
+
+| Item                                                                        | Reason                                                                         | Follow-up |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------- |
+| Auto-correcting the corrupted DB row                                        | Consistent with `useThemePersistence` policy; recovery via sync/upgrade        | none      |
+| SettingsScreen snapshot/integration test for the literal-key render symptom | The guard prevents the symptom entirely; symptom-level test would be redundant | none      |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/src/hooks/__tests__/useDensity.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useDensity.test.ts
@@ -5,6 +5,25 @@ import { UnistylesRuntime } from "react-native-unistyles";
 import { useDensity } from "../useDensity";
 import { themeNames } from "../../themes/compose";
 import { __resetUserSettingsRowInitForTests } from "../useUserSettingsRow";
+import { Logger } from "../../shims/rd-logger";
+
+// jest.config.js maps "../shims/rd-logger" to a mock that returns a fresh
+// `{ error, warn, info, debug }` instance per `new Logger(...)`. useDensity
+// instantiates one logger at module load — capture it here so
+// `beforeEach(jest.clearAllMocks)` can wipe the call history without losing
+// the reference.
+const MockLogger = Logger as unknown as jest.Mock;
+const useDensityLoggerIdx = MockLogger.mock.calls.findIndex(
+  (call: unknown[]) => call[0] === "useDensity",
+);
+if (useDensityLoggerIdx < 0) {
+  throw new Error(
+    "useDensity did not instantiate a Logger at module load — did the import order change?",
+  );
+}
+const useDensityLogger = MockLogger.mock.results[useDensityLoggerIdx].value as {
+  error: jest.Mock;
+};
 
 type ChangeListener = (status: AppStateStatus) => void;
 type MutableAppState = { currentState: AppStateStatus | unknown };
@@ -105,6 +124,27 @@ describe("useDensity", () => {
       expect(mockUpdateUserSettings).toHaveBeenCalledWith("settings-1", {
         density: "compact",
       });
+    });
+  });
+
+  describe("unknown DB value fallback", () => {
+    it("falls back to 'default' when density is an unrecognised string and logs an Error", () => {
+      mockUseQuery.mockReturnValue([
+        makeSettings({ density: "cozy" as unknown as null }),
+      ]);
+      const { result } = renderHook(() => useDensity());
+      expect(result.current.densityLevel).toBe("default");
+      expect(useDensityLogger.error).toHaveBeenCalledTimes(1);
+      const firstArg = useDensityLogger.error.mock.calls[0][0];
+      expect(firstArg).toBeInstanceOf(Error);
+      expect((firstArg as Error).message).toContain("cozy");
+    });
+
+    it("does not log when density is null", () => {
+      mockUseQuery.mockReturnValue([makeSettings({ density: null })]);
+      const { result } = renderHook(() => useDensity());
+      expect(result.current.densityLevel).toBe("default");
+      expect(useDensityLogger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/native-rd/src/hooks/__tests__/useDensity.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useDensity.test.ts
@@ -156,15 +156,26 @@ describe("useDensity", () => {
 
   describe("unknown DB value fallback", () => {
     it("falls back to 'default' when density is an unrecognised string and logs an Error", () => {
-      mockUseQuery.mockReturnValue([
-        makeSettings({ density: "cozy" as unknown as null }),
-      ]);
+      mockUseQuery.mockReturnValue([makeSettings({ density: "cozy" })]);
       const { result } = renderHook(() => useDensity());
       expect(result.current.densityLevel).toBe("default");
       expect(getLoggerForScope("useDensity").error).toHaveBeenCalledTimes(1);
       const firstArg = getLoggerForScope("useDensity").error.mock.calls[0][0];
       expect(firstArg).toBeInstanceOf(Error);
       expect((firstArg as Error).message).toContain("cozy");
+    });
+
+    it("preserves the raw shape in the Error message for non-string corruption", () => {
+      // The rd-logger shim drops meta args at the Sentry boundary — the
+      // raw shape has to live in the Error message itself or it's lost.
+      // String(obj) would produce "[object Object]"; JSON.stringify keeps
+      // the shape recognisable.
+      mockUseQuery.mockReturnValue([
+        makeSettings({ density: { broken: true } }),
+      ]);
+      renderHook(() => useDensity());
+      const firstArg = getLoggerForScope("useDensity").error.mock.calls[0][0];
+      expect((firstArg as Error).message).toContain('{"broken":true}');
     });
 
     it("does not log when density is null", () => {

--- a/apps/native-rd/src/hooks/__tests__/useDensity.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useDensity.test.ts
@@ -5,25 +5,52 @@ import { UnistylesRuntime } from "react-native-unistyles";
 import { useDensity } from "../useDensity";
 import { themeNames } from "../../themes/compose";
 import { __resetUserSettingsRowInitForTests } from "../useUserSettingsRow";
-import { Logger } from "../../shims/rd-logger";
 
-// jest.config.js maps "../shims/rd-logger" to a mock that returns a fresh
-// `{ error, warn, info, debug }` instance per `new Logger(...)`. useDensity
-// instantiates one logger at module load — capture it here so
-// `beforeEach(jest.clearAllMocks)` can wipe the call history without losing
-// the reference.
-const MockLogger = Logger as unknown as jest.Mock;
-const useDensityLoggerIdx = MockLogger.mock.calls.findIndex(
-  (call: unknown[]) => call[0] === "useDensity",
-);
-if (useDensityLoggerIdx < 0) {
-  throw new Error(
-    "useDensity did not instantiate a Logger at module load — did the import order change?",
-  );
-}
-const useDensityLogger = MockLogger.mock.results[useDensityLoggerIdx].value as {
+// Replace the global rd-logger mock for this file so we can look up Logger
+// instances by scope regardless of when they're constructed (module load
+// vs. inside the hook body). The registry survives jest.clearAllMocks() —
+// only each instance's child mocks get reset, the entries themselves stay.
+//
+// `var` (not `const`) is deliberate: jest.mock is hoisted above all other
+// code AND `import { useDensity }` is also hoisted as a require, which
+// fires `new Logger("useDensity")` BEFORE any const body code runs. `var`
+// hoists the binding (as undefined) so the factory can lazy-init it; a
+// const would hit TDZ.
+type ScopedMockLogger = {
   error: jest.Mock;
+  warn: jest.Mock;
+  info: jest.Mock;
+  debug: jest.Mock;
 };
+// eslint-disable-next-line no-var
+var mockLoggersByScope: Map<string, ScopedMockLogger> | undefined;
+
+jest.mock("../../shims/rd-logger", () => ({
+  Logger: jest.fn().mockImplementation((scope: string) => {
+    mockLoggersByScope ??= new Map<string, ScopedMockLogger>();
+    let logger = mockLoggersByScope.get(scope);
+    if (!logger) {
+      logger = {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+      };
+      mockLoggersByScope.set(scope, logger);
+    }
+    return logger;
+  }),
+}));
+
+function getLoggerForScope(scope: string): ScopedMockLogger {
+  const logger = mockLoggersByScope?.get(scope);
+  if (!logger) {
+    throw new Error(
+      `No Logger constructed with scope "${scope}" yet. Did renderHook fail, or has the scope been renamed?`,
+    );
+  }
+  return logger;
+}
 
 type ChangeListener = (status: AppStateStatus) => void;
 type MutableAppState = { currentState: AppStateStatus | unknown };
@@ -134,8 +161,8 @@ describe("useDensity", () => {
       ]);
       const { result } = renderHook(() => useDensity());
       expect(result.current.densityLevel).toBe("default");
-      expect(useDensityLogger.error).toHaveBeenCalledTimes(1);
-      const firstArg = useDensityLogger.error.mock.calls[0][0];
+      expect(getLoggerForScope("useDensity").error).toHaveBeenCalledTimes(1);
+      const firstArg = getLoggerForScope("useDensity").error.mock.calls[0][0];
       expect(firstArg).toBeInstanceOf(Error);
       expect((firstArg as Error).message).toContain("cozy");
     });
@@ -144,7 +171,7 @@ describe("useDensity", () => {
       mockUseQuery.mockReturnValue([makeSettings({ density: null })]);
       const { result } = renderHook(() => useDensity());
       expect(result.current.densityLevel).toBe("default");
-      expect(useDensityLogger.error).not.toHaveBeenCalled();
+      expect(getLoggerForScope("useDensity").error).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/native-rd/src/hooks/useDensity.ts
+++ b/apps/native-rd/src/hooks/useDensity.ts
@@ -3,9 +3,16 @@ import { UnistylesRuntime } from "react-native-unistyles";
 import { updateUserSettings } from "../db";
 import { useUserSettingsRow } from "./useUserSettingsRow";
 import { useAppStateGuard } from "./useAppStateGuard";
-import { scaleSpacing, type DensityLevel } from "../utils/density";
+import {
+  narrowDensity,
+  scaleSpacing,
+  type DensityLevel,
+} from "../utils/density";
 import { space as baseSpace } from "../themes/tokens";
 import { themeNames } from "../themes/compose";
+import { Logger } from "../shims/rd-logger";
+
+const logger = new Logger("useDensity");
 
 function applyDensityToAllThemes(level: DensityLevel) {
   const scaled = scaleSpacing(baseSpace, level);
@@ -22,8 +29,7 @@ export function useDensity() {
   const appliedLevel = useRef<DensityLevel>("default");
   const { runWhenActive } = useAppStateGuard();
 
-  const densityLevel: DensityLevel =
-    (settings?.density as DensityLevel) || "default";
+  const densityLevel: DensityLevel = narrowDensity(settings?.density, logger);
 
   // Apply density to Unistyles themes when level changes. The updateTheme
   // loop touches all 7 themes in tight succession, which is the same

--- a/apps/native-rd/src/hooks/useDensity.ts
+++ b/apps/native-rd/src/hooks/useDensity.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { UnistylesRuntime } from "react-native-unistyles";
 import { updateUserSettings } from "../db";
 import { useUserSettingsRow } from "./useUserSettingsRow";
@@ -29,7 +29,21 @@ export function useDensity() {
   const appliedLevel = useRef<DensityLevel>("default");
   const { runWhenActive } = useAppStateGuard();
 
-  const densityLevel: DensityLevel = narrowDensity(settings?.density, logger);
+  const rawDensity = settings?.density;
+  const narrowed = useMemo(() => narrowDensity(rawDensity), [rawDensity]);
+  const densityLevel: DensityLevel = narrowed.value;
+
+  // Log corruption once per distinct unknown value, not once per render. The
+  // narrowed memo is stable across re-renders that don't touch rawDensity,
+  // so a steady bad row produces exactly one Sentry event.
+  useEffect(() => {
+    if (narrowed.isUnknown) {
+      logger.error(
+        new Error(`Unknown density value in DB: ${String(narrowed.raw)}`),
+        { rawDensity: narrowed.raw },
+      );
+    }
+  }, [narrowed]);
 
   // Apply density to Unistyles themes when level changes. The updateTheme
   // loop touches all 7 themes in tight succession, which is the same

--- a/apps/native-rd/src/hooks/useDensity.ts
+++ b/apps/native-rd/src/hooks/useDensity.ts
@@ -36,12 +36,16 @@ export function useDensity() {
   // Log corruption once per distinct unknown value, not once per render. The
   // narrowed memo is stable across re-renders that don't touch rawDensity,
   // so a steady bad row produces exactly one Sentry event.
+  //
+  // The raw shape goes in the Error message because the rd-logger shim only
+  // forwards the Error to Sentry — meta args are dropped. JSON.stringify keeps
+  // object/array/empty-string shapes legible (`{}`, `[]`, `""`); the typeof
+  // fallback catches values JSON can't serialise (undefined, functions, BigInt).
   useEffect(() => {
     if (narrowed.isUnknown) {
-      logger.error(
-        new Error(`Unknown density value in DB: ${String(narrowed.raw)}`),
-        { rawDensity: narrowed.raw },
-      );
+      const serialized =
+        JSON.stringify(narrowed.raw) ?? `<${typeof narrowed.raw}>`;
+      logger.error(new Error(`Unknown density value in DB: ${serialized}`));
     }
   }, [narrowed]);
 

--- a/apps/native-rd/src/services/__tests__/sentry-report.test.ts
+++ b/apps/native-rd/src/services/__tests__/sentry-report.test.ts
@@ -5,6 +5,13 @@
  * the SDK without pulling the real native module. Per Jest's hoisting rules,
  * variables referenced inside `jest.mock` factories must be prefixed `mock*`.
  */
+import {
+  breadcrumb,
+  reportError,
+  reportLoggerError,
+  type ReportContext,
+} from "../sentry-report";
+
 type CapturedScope = {
   tags: Record<string, string>;
   extras: Record<string, unknown>;
@@ -65,13 +72,6 @@ jest.mock("@sentry/react-native", () => ({
     mockState.setUserCalls += 1;
   },
 }));
-
-import {
-  breadcrumb,
-  reportError,
-  reportLoggerError,
-  type ReportContext,
-} from "../sentry-report";
 
 beforeEach(() => {
   mockState.captured = [];
@@ -229,6 +229,14 @@ describe("reportLoggerError", () => {
       expect(mockState.captured[0].scope.tags).toEqual({
         area: "evidence.view",
         kind,
+      });
+    });
+
+    it("routes useDensity to settings.density", () => {
+      reportLoggerError("useDensity", new Error("boom"));
+      expect(mockState.captured).toHaveLength(1);
+      expect(mockState.captured[0].scope.tags).toEqual({
+        area: "settings.density",
       });
     });
 

--- a/apps/native-rd/src/services/sentry-report.ts
+++ b/apps/native-rd/src/services/sentry-report.ts
@@ -55,6 +55,7 @@ export type ReportContext =
   | { area: "audio.playback" }
   | { area: "navigation" }
   | { area: "db.write" }
+  | { area: "settings.density" }
   | { area: "render" };
 
 // No-op in dev — `initSentry()` returns early before any client is installed,
@@ -94,6 +95,9 @@ const SCOPE_TO_AREA: Record<string, ReportContext> = {
   PhotoContent: { area: "evidence.view", kind: "photo" },
   LinkContent: { area: "evidence.view", kind: "link" },
   FileContent: { area: "evidence.view", kind: "file" },
+  // Error.message is `Unknown density value in DB: <raw>` — raw is the DB
+  // column value, an enum candidate, never user free-text.
+  useDensity: { area: "settings.density" },
 };
 
 // `map` parameter exists as a test seam — production callers always omit it.

--- a/apps/native-rd/src/utils/__tests__/density.test.ts
+++ b/apps/native-rd/src/utils/__tests__/density.test.ts
@@ -10,20 +10,6 @@ import {
   type DensityLevel,
 } from "../density";
 
-type StubLogger = {
-  error: jest.Mock;
-  warn: jest.Mock;
-  info: jest.Mock;
-  debug: jest.Mock;
-};
-
-const makeStubLogger = (): StubLogger => ({
-  error: jest.fn(),
-  warn: jest.fn(),
-  info: jest.fn(),
-  debug: jest.fn(),
-});
-
 const mockSpace = {
   "0": 0,
   "1": 4,
@@ -117,44 +103,44 @@ describe("density utilities", () => {
   });
 
   describe("narrowDensity", () => {
-    test("returns 'default' for null without logging", () => {
-      const logger = makeStubLogger();
-      expect(narrowDensity(null, logger as never)).toBe("default");
-      expect(logger.error).not.toHaveBeenCalled();
+    test("returns known='default' for null", () => {
+      expect(narrowDensity(null)).toEqual({
+        isUnknown: false,
+        value: "default",
+      });
     });
 
-    test("returns 'default' for undefined without logging", () => {
-      const logger = makeStubLogger();
-      expect(narrowDensity(undefined, logger as never)).toBe("default");
-      expect(logger.error).not.toHaveBeenCalled();
+    test("returns known='default' for undefined", () => {
+      expect(narrowDensity(undefined)).toEqual({
+        isUnknown: false,
+        value: "default",
+      });
     });
 
     test.each(["compact", "default", "comfortable"] as const)(
-      "returns valid level '%s' as-is without logging",
+      "returns known='%s' for valid level",
       (level) => {
-        const logger = makeStubLogger();
-        expect(narrowDensity(level, logger as never)).toBe(level);
-        expect(logger.error).not.toHaveBeenCalled();
+        expect(narrowDensity(level)).toEqual({
+          isUnknown: false,
+          value: level,
+        });
       },
     );
 
-    test("falls back to 'default' and logs an Error for an unrecognised string", () => {
-      const logger = makeStubLogger();
-      expect(narrowDensity("cozy", logger as never)).toBe("default");
-      expect(logger.error).toHaveBeenCalledTimes(1);
-      const [firstArg, meta] = logger.error.mock.calls[0];
-      expect(firstArg).toBeInstanceOf(Error);
-      expect((firstArg as Error).message).toContain("cozy");
-      expect(meta).toEqual({ rawDensity: "cozy" });
+    test("returns unknown with raw='cozy' for an unrecognised string", () => {
+      expect(narrowDensity("cozy")).toEqual({
+        isUnknown: true,
+        value: "default",
+        raw: "cozy",
+      });
     });
 
-    test("falls back to 'default' and logs an Error for a non-string value", () => {
-      const logger = makeStubLogger();
-      expect(narrowDensity(42, logger as never)).toBe("default");
-      expect(logger.error).toHaveBeenCalledTimes(1);
-      const [firstArg, meta] = logger.error.mock.calls[0];
-      expect(firstArg).toBeInstanceOf(Error);
-      expect(meta).toEqual({ rawDensity: 42 });
+    test("returns unknown with raw=42 for a non-string value", () => {
+      expect(narrowDensity(42)).toEqual({
+        isUnknown: true,
+        value: "default",
+        raw: 42,
+      });
     });
   });
 });

--- a/apps/native-rd/src/utils/__tests__/density.test.ts
+++ b/apps/native-rd/src/utils/__tests__/density.test.ts
@@ -4,8 +4,25 @@ import {
   scaleSpacing,
   densityOptions,
   DENSITY_MULTIPLIERS,
+  DENSITY_LEVELS,
+  isDensityLevel,
+  narrowDensity,
   type DensityLevel,
 } from "../density";
+
+type StubLogger = {
+  error: jest.Mock;
+  warn: jest.Mock;
+  info: jest.Mock;
+  debug: jest.Mock;
+};
+
+const makeStubLogger = (): StubLogger => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+});
 
 const mockSpace = {
   "0": 0,
@@ -68,5 +85,76 @@ describe("density utilities", () => {
     for (const level of levels) {
       expect(DENSITY_MULTIPLIERS[level]).toBeGreaterThan(0);
     }
+  });
+
+  describe("isDensityLevel", () => {
+    test.each(["compact", "default", "comfortable"] as const)(
+      "returns true for valid level '%s'",
+      (level) => {
+        expect(isDensityLevel(level)).toBe(true);
+      },
+    );
+
+    test.each(["cozy", "large", "", "Default", " compact "])(
+      "returns false for invalid string '%s'",
+      (value) => {
+        expect(isDensityLevel(value)).toBe(false);
+      },
+    );
+
+    test.each([null, undefined, 42, 0, {}, []] as const)(
+      "returns false for non-string %p",
+      (value) => {
+        expect(isDensityLevel(value)).toBe(false);
+      },
+    );
+
+    test("DENSITY_LEVELS contains exactly the three canonical levels", () => {
+      expect([...DENSITY_LEVELS].sort()).toEqual(
+        ["comfortable", "compact", "default"].sort(),
+      );
+    });
+  });
+
+  describe("narrowDensity", () => {
+    test("returns 'default' for null without logging", () => {
+      const logger = makeStubLogger();
+      expect(narrowDensity(null, logger as never)).toBe("default");
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test("returns 'default' for undefined without logging", () => {
+      const logger = makeStubLogger();
+      expect(narrowDensity(undefined, logger as never)).toBe("default");
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test.each(["compact", "default", "comfortable"] as const)(
+      "returns valid level '%s' as-is without logging",
+      (level) => {
+        const logger = makeStubLogger();
+        expect(narrowDensity(level, logger as never)).toBe(level);
+        expect(logger.error).not.toHaveBeenCalled();
+      },
+    );
+
+    test("falls back to 'default' and logs an Error for an unrecognised string", () => {
+      const logger = makeStubLogger();
+      expect(narrowDensity("cozy", logger as never)).toBe("default");
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      const [firstArg, meta] = logger.error.mock.calls[0];
+      expect(firstArg).toBeInstanceOf(Error);
+      expect((firstArg as Error).message).toContain("cozy");
+      expect(meta).toEqual({ rawDensity: "cozy" });
+    });
+
+    test("falls back to 'default' and logs an Error for a non-string value", () => {
+      const logger = makeStubLogger();
+      expect(narrowDensity(42, logger as never)).toBe("default");
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      const [firstArg, meta] = logger.error.mock.calls[0];
+      expect(firstArg).toBeInstanceOf(Error);
+      expect(meta).toEqual({ rawDensity: 42 });
+    });
   });
 });

--- a/apps/native-rd/src/utils/__tests__/density.test.ts
+++ b/apps/native-rd/src/utils/__tests__/density.test.ts
@@ -127,19 +127,37 @@ describe("density utilities", () => {
       },
     );
 
-    test("returns unknown with raw='cozy' for an unrecognised string", () => {
-      expect(narrowDensity("cozy")).toEqual({
-        isUnknown: true,
-        value: "default",
-        raw: "cozy",
-      });
-    });
+    // Plausible DB-rot shapes — an empty string from a partial write, a
+    // trimmed/cased value from a migration that normalised the column the
+    // wrong way, or a JSON-typed cell that was accidentally written object
+    // or array. All should land in the "isUnknown" branch with raw intact
+    // so Sentry sees the exact shape.
+    test.each([
+      ["cozy", "cozy"],
+      ["", ""],
+      [" compact ", " compact "],
+      ["Default", "Default"],
+    ])(
+      "returns unknown with raw=%p for unrecognised string",
+      (input, expectedRaw) => {
+        expect(narrowDensity(input)).toEqual({
+          isUnknown: true,
+          value: "default",
+          raw: expectedRaw,
+        });
+      },
+    );
 
-    test("returns unknown with raw=42 for a non-string value", () => {
-      expect(narrowDensity(42)).toEqual({
+    test.each([
+      [42, 42],
+      [0, 0],
+      [{}, {}],
+      [[], []],
+    ])("returns unknown with raw=%p for non-string", (input, expectedRaw) => {
+      expect(narrowDensity(input)).toEqual({
         isUnknown: true,
         value: "default",
-        raw: 42,
+        raw: expectedRaw,
       });
     });
   });

--- a/apps/native-rd/src/utils/density.ts
+++ b/apps/native-rd/src/utils/density.ts
@@ -1,4 +1,5 @@
 import type { Space } from "../themes/tokens";
+import { Logger } from "../shims/rd-logger";
 
 export type DensityLevel = "compact" | "default" | "comfortable";
 
@@ -7,6 +8,23 @@ export const DENSITY_MULTIPLIERS: Record<DensityLevel, number> = {
   default: 1.0,
   comfortable: 1.25,
 } as const;
+
+export const DENSITY_LEVELS: ReadonlySet<DensityLevel> = new Set(
+  Object.keys(DENSITY_MULTIPLIERS) as DensityLevel[],
+);
+
+export function isDensityLevel(value: unknown): value is DensityLevel {
+  return typeof value === "string" && DENSITY_LEVELS.has(value as DensityLevel);
+}
+
+export function narrowDensity(raw: unknown, logger: Logger): DensityLevel {
+  if (raw === null || raw === undefined) return "default";
+  if (isDensityLevel(raw)) return raw;
+  logger.error(new Error(`Unknown density value in DB: ${String(raw)}`), {
+    rawDensity: raw,
+  });
+  return "default";
+}
 
 /**
  * Display strings live in `settings:density.options.<id>` — consumers look them

--- a/apps/native-rd/src/utils/density.ts
+++ b/apps/native-rd/src/utils/density.ts
@@ -1,5 +1,4 @@
 import type { Space } from "../themes/tokens";
-import { Logger } from "../shims/rd-logger";
 
 export type DensityLevel = "compact" | "default" | "comfortable";
 
@@ -17,13 +16,26 @@ export function isDensityLevel(value: unknown): value is DensityLevel {
   return typeof value === "string" && DENSITY_LEVELS.has(value as DensityLevel);
 }
 
-export function narrowDensity(raw: unknown, logger: Logger): DensityLevel {
-  if (raw === null || raw === undefined) return "default";
-  if (isDensityLevel(raw)) return raw;
-  logger.error(new Error(`Unknown density value in DB: ${String(raw)}`), {
-    rawDensity: raw,
-  });
-  return "default";
+/**
+ * Result of narrowing an arbitrary DB column value to a DensityLevel.
+ *
+ * `isUnknown: false` covers both the valid-enum case and the expected-null
+ * case (fresh row before settings have ever been written, or a missing
+ * column on an old schema). Callers fall back to "default" without alarm.
+ *
+ * `isUnknown: true` is the corruption case — an unrecognised string or a
+ * non-string value. Callers should report `raw` so the operator can trace
+ * which migration or write path produced it; the helper itself stays pure.
+ */
+export type NarrowedDensity =
+  | { isUnknown: false; value: DensityLevel }
+  | { isUnknown: true; value: "default"; raw: unknown };
+
+export function narrowDensity(raw: unknown): NarrowedDensity {
+  if (raw === null || raw === undefined)
+    return { isUnknown: false, value: "default" };
+  if (isDensityLevel(raw)) return { isUnknown: false, value: raw };
+  return { isUnknown: true, value: "default", raw };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #126.

- Replace the unsafe `as DensityLevel` cast in `useDensity` with a validating narrow. `narrowDensity(raw)` returns a discriminated union `{ isUnknown, value, raw? }` — corrupted DB strings (`"cozy"`, `""`, `" compact "`, objects, etc.) fall through to `"default"` instead of lying to TypeScript.
- Wire the corruption-report path to Sentry: `useDensity` was already calling `logger.error(...)`, but the rd-logger shim drops any scope that isn't in `SCOPE_TO_AREA` — and `useDensity` wasn't there. Add `useDensity → settings.density` and extend the closed `ReportContext` enum to match.
- Avoid Sentry-spam on the render loop: narrowing moved into `useMemo`, with a `useEffect` that logs exactly once per distinct unknown raw value rather than once per render.

## Test plan

- [x] `npx jest --no-coverage --testPathPatterns "SettingsScreen|Theme|useUserSettingsRow|useDensity|density|sentry-report"` — **150 tests, 10 suites green**.
- [x] `bun run type-check` — clean across the workspace (runs on every commit via husky).
- [ ] Manual: plant a corrupted `density` value in the local Evolu DB, launch the app, confirm the row falls back to "default" UI and the Sentry event lands under `area=settings.density` (deferred — needs a running app session).

## Notes for reviewers

- `narrowDensity` no longer takes a logger — that's intentional. Logging moved into the consumer so the helper stays pure and the render-loop noise goes away.
- The `useDensity.test.ts` mock-registry hardening (commit `838c5ed`) protects the test against a future refactor that constructs the Logger inside the hook body instead of at module load.
- Dev plan with options considered: `apps/native-rd/docs/plans/dev-plans/issue-126-density-unsafe-cast.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)