### PR TITLE
fix(native-rd): make Goals screen scroll when content overflows

### DIFF
--- a/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.styles.ts
+++ b/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.styles.ts
@@ -5,13 +5,11 @@ export const styles = StyleSheet.create((theme) => ({
     flex: 1,
     backgroundColor: theme.colors.background,
   },
-  scrollContent: {
+  list: {
     flex: 1,
-    backgroundColor: theme.colors.background,
-    padding: theme.space[4],
-    gap: theme.space[4],
   },
   listContent: {
+    padding: theme.space[4],
     gap: theme.space[3],
   },
   loadingIndicator: {

--- a/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx
@@ -45,7 +45,11 @@ function buildGoalCardGoal(
   };
 }
 
-function GoalList() {
+function GoalList({
+  contentInset,
+}: {
+  contentInset: { paddingBottom: number };
+}) {
   const { t } = useTranslation(["goals", "common"]);
   const navigation = useNavigation<Nav>();
   const rows = useQuery(activeGoalsQuery);
@@ -99,10 +103,9 @@ function GoalList() {
     <>
       <FlatList
         data={rows}
-        scrollEnabled={false}
         keyExtractor={(item) => item.id}
-        style={{ overflow: "visible" }}
-        contentContainerStyle={styles.listContent}
+        style={styles.list}
+        contentContainerStyle={[styles.listContent, contentInset]}
         renderItem={({ item }) => (
           <GoalCard
             goal={buildGoalCardGoal(item, stepsByGoalId.get(item.id) ?? [])}
@@ -137,17 +140,15 @@ export function GoalsScreen() {
   return (
     <View style={styles.screen}>
       <ScreenHeader title={t("goals:title")} />
-      <View style={[styles.scrollContent, tabInset]}>
-        <ErrorBoundary>
-          <Suspense
-            fallback={
-              <ActivityIndicator style={styles.loadingIndicator} size="large" />
-            }
-          >
-            <GoalList />
-          </Suspense>
-        </ErrorBoundary>
-      </View>
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <ActivityIndicator style={styles.loadingIndicator} size="large" />
+          }
+        >
+          <GoalList contentInset={tabInset} />
+        </Suspense>
+      </ErrorBoundary>
     </View>
   );
 }


### PR DESCRIPTION
## What & why

The Goals screen didn't scroll once goals exceeded the viewport height — the extra cards were clipped with no way to reach them.

Root cause: the `FlatList` was rendered with `scrollEnabled={false}` inside a `flex: 1` wrapper, and a no-op `overflow: "visible"` style (a web-ism that doesn't enable scrolling on native). Nothing in the tree was a scroll region.

## Changes (Option 2 — adjust layout structure)

- Make the `FlatList` the scroll region: drop `scrollEnabled={false}` and the `overflow: "visible"` style; give it `flex: 1` so it fills the space below the fixed header and scrolls within it.
- Move `padding`, `gap`, and the tab-bar content inset onto the FlatList's `contentContainerStyle` so the **content** carries them — the last card now clears the tab bar when scrolled to the bottom.
- Remove the intermediate padded `flex: 1` wrapper `View`; `GoalList` now renders directly under the fixed `ScreenHeader` and takes a `contentInset` prop.

`EmptyState` and the loading indicator are unaffected — `EmptyState` brings its own padding and centering.

## Test plan

- [x] `bun run type-check` passes
- [x] `bun run lint` passes (0 errors)
- [x] 18 GoalsScreen tests pass
- [ ] Visual check on-device/sim: with a goals list taller than the screen, the list scrolls beneath the fixed header and the last card clears the tab bar. (The test renderer has no real viewport, so scroll behaviour itself isn't unit-covered.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)