### PR TITLE
fix(native-rd): smooth focus step navigation

### DIFF
--- a/apps/native-rd/docs/plans/2026-06-14-focus-view-step-jitter.md
+++ b/apps/native-rd/docs/plans/2026-06-14-focus-view-step-jitter.md
@@ -84,7 +84,7 @@ right as the slide starts:
 Bottom-up; each commit leaves the tree green (type-check + lint + tests).
 
 - [x] Commit 1 — Stable callbacks + memoized cards
-- [ ] Commit 2 — Remove the redundant per-step evidence query
+- [x] Commit 2 — Remove the redundant per-step evidence query
 
 ### Commit 1 — Stable callbacks + memoized cards (highest leverage)
 
@@ -192,3 +192,6 @@ fix. First capture a before/after profile after commits 1-2.
 - [2026-06-14] Used `useFlashOnIncrease` as the render probe in the Focus-mode
   regression test. It runs once per card render and avoids altering production
   component APIs solely for instrumentation.
+- [2026-06-14] Confirmed `stepEvidenceByGoalQuery` selects every evidence
+  column, so filtered drawer rows retain `uri` and `metadata` for view and
+  delayed file deletion behavior.

--- a/apps/native-rd/docs/plans/2026-06-14-focus-view-step-jitter.md
+++ b/apps/native-rd/docs/plans/2026-06-14-focus-view-step-jitter.md
@@ -1,0 +1,194 @@
+# 2026-06-14 — Focus view step-navigation jitter
+
+## Goal
+
+Remove the visible stutter that occurs when moving between cards in Focus
+mode (arrow tap, swipe, dot/timeline tap, and auto-advance after a step
+completes). The carousel slide is already a UI-thread Reanimated animation
+and should be able to run smoothly, but navigation also triggers substantial
+JS rendering and query work in the same commit that starts the slide. Reduce
+that work first, then profile to confirm whether it accounts for the dropped
+frames before changing carousel behavior.
+
+No behaviour, schema, or visual changes — same cards, same animation, same
+evidence gating. This is a performance-only change.
+
+## Why
+
+A single `handleIndexChange` (`FocusModeScreen.tsx:293`) sets
+`currentCardIndex`, which fans out into a synchronous burst on the JS thread
+right as the slide starts:
+
+1. **Every card re-renders on every navigation.** `uiSteps` depends on
+   `currentCardIndex` (`FocusModeScreen.tsx:140-154`), so `stepsWithEvidence`
+   recomputes and the children array (`:576-606`) is rebuilt with fresh prop
+   objects for _all_ cards. `StepCard` (`StepCard.tsx:72`), `GoalEvidenceCard`,
+   and the `AnimatedCard` wrapper are plain function components — none are
+   `React.memo`. So N steps + the goal card all re-render per move, each
+   re-running `useTranslation`, the `useFlashOnIncrease` Reanimated hook
+   (`StepCard.tsx:83`), the evidence-option builders, and a full `ScrollView`
+   subtree. Memo alone won't help because the per-card handlers
+   (`onToggleComplete`, `onQuickEvidence`, `onEvidenceTap`) are re-created
+   inline every render (`:590-592`) and the handler functions themselves
+   aren't `useCallback`'d.
+
+2. **A fresh DB query fires on every step change — even with the drawer
+   closed.** `currentStepId` changes each navigation, so
+   `useQuery(evidenceByStepQuery(currentStepId))` (`FocusModeScreen.tsx:206-211`)
+   re-subscribes and runs new SQL on every move. But navigation _closes_ the
+   drawer (`:295`), so this result usually isn't even shown — it's an Evolu
+   re-subscription mid-slide for data nothing is displaying. (Card evidence
+   badges already read the goal-wide `allStepEvidenceRows`, which also contains
+   the complete rows needed by the drawer.)
+
+3. **The carousel keeps all cards mounted.** This increases the retained native
+   view tree, but it is not yet established as transition-time work:
+   `AnimatedCard`'s effect depends on `position`, so cards that remain hidden do
+   not dispatch new `withTiming` calls on every navigation
+   (`CardCarousel.tsx:58-85`). Profile before changing carousel mounting; windowing
+   has correctness risks for non-adjacent dot/timeline and auto-advance jumps.
+
+4. **Step completion adds mutation work.** `handleToggleStep` does a DB write
+   (`completeStep`) and requests navigation in the same handler; the write then
+   causes reactive query emissions and further renders. The current branches do
+   not issue two index updates for one completion: an intermediate completion
+   advances to another pending step, while final completion has no pending
+   `nextIndex` and lets the all-steps-complete effect move to the goal card.
+   Treat any further completion-path optimization as profiling-led follow-up.
+
+## Acceptance criteria
+
+- Moving between cards (arrow / swipe / dot / timeline / auto-advance) is
+  visibly smooth on a goal with ≥5 steps on a mid-tier device.
+- Re-render scope per navigation is bounded to the cards whose state actually
+  changed (the outgoing in-progress card → pending and the incoming →
+  in-progress), not every card.
+- Step navigation does not create or subscribe to a new per-step evidence
+  query. Drawer rows are selected from the already-loaded goal-wide step
+  evidence result.
+- No change to evidence gating, completion flow, snap-to-pending / snap-to-goal
+  behaviour, a11y announcements, or the look of the cards/animation.
+- `bun run type-check`, `bun run lint`, and the Focus-mode test suite pass.
+
+## Out of scope
+
+- Replacing `CardCarousel` with FlashList/Reanimated-Carousel or any new dep.
+- Windowing/unmounting carousel cards without profiling evidence that retained
+  hidden cards are still a material source of transition-time work.
+- Reworking `EvidenceDrawer` open/close animation.
+- Changing the auto-advance / snap lifecycle semantics.
+- Evolu query shape or schema changes.
+
+## Atomic commits
+
+Bottom-up; each commit leaves the tree green (type-check + lint + tests).
+
+- [x] Commit 1 — Stable callbacks + memoized cards
+- [ ] Commit 2 — Remove the redundant per-step evidence query
+
+### Commit 1 — Stable callbacks + memoized cards (highest leverage)
+
+Stops unchanged/off-screen cards re-rendering on every navigation.
+
+**Files**
+
+- `apps/native-rd/src/components/StepCard/StepCard.tsx`
+- `apps/native-rd/src/components/GoalEvidenceCard/GoalEvidenceCard.tsx`
+- `apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx`
+
+**Changes**
+
+- Wrap `StepCard` and `GoalEvidenceCard` in `React.memo`. Because the per-step
+  derived arrays (`plannedEvidenceTypes`, `capturedEvidenceTypes`) get new
+  identity each render, give `StepCard` a small `areEqual` comparator that
+  compares those arrays by content (or memoize per-step view-models so unchanged
+  steps keep identity — pick whichever reads cleaner; comparator is simpler).
+- Change `StepCard`'s callback contract so the parent can pass stable refs:
+  `onToggleComplete(id)` and `onQuickEvidence(id, type)` (StepCard already has
+  `step.id`). Update `StepCard.stories.tsx` / tests to the new signatures.
+- In `FocusContent`, define every `useCallback` before the `if (!goal)` early
+  return so hook order is identical while the goal query moves between loading,
+  missing, and populated states.
+- Stabilize `handleIndexChange` without reading `isDrawerOpen` or
+  `isFABMenuOpen`: call `setCurrentCardIndex(index)`, `setIsDrawerOpen(false)`,
+  and `setIsFABMenuOpen(false)` unconditionally. React ignores no-op state
+  updates, and this keeps the callback independent of navigation-time UI state.
+- `useCallback` `handleToggleStep`, `handleEvidenceTap`,
+  `handleQuickEvidence`, `handleMarkComplete`, and `handleBadgePress`. Give
+  `handleToggleStep` only the data dependencies required for completion and
+  call the stable `handleIndexChange`; do not capture `currentCardIndex` merely
+  to skip an idempotent index update.
+- Pass stable callback refs directly instead of inline arrows.
+
+### Commit 2 — Remove the redundant per-step evidence query
+
+Removes the mid-navigation Evolu load/subscription from the hot path without
+adding a drawer-open Suspense boundary.
+
+**Files**
+
+- `apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx`
+
+**Changes**
+
+- Delete the `useQuery(evidenceByStepQuery(...))` call from `FocusContent`.
+- Derive `currentStepEvidenceRows` with `useMemo` by filtering the already
+  subscribed `allStepEvidenceRows` for `currentStepId`. This avoids new SQL,
+  subscription churn, and a possible Suspense load when the drawer opens.
+- Keep goal-card rows sourced from the existing `goalEvidenceRows` query.
+- Confirm `drawerEvidence`, delete, and view handlers resolve the same complete
+  evidence row, including `uri` and `metadata`, from the filtered rows.
+
+## Conditional follow-ups
+
+Do not change carousel mounting or completion semantics as part of the initial
+fix. First capture a before/after profile after commits 1-2.
+
+### Carousel mounting
+
+- If hidden mounted cards remain material, write a separate follow-up plan that
+  preserves outgoing and destination cards until transition completion.
+  Rendering only the new left/center/right window and seeding directly at target
+  positions is not acceptable because long jumps would pop rather than animate.
+- A future implementation must also use stable child keys and cover adjacent
+  navigation, long jumps, wrapped auto-advance, keyboard navigation, a11y
+  visibility, and preview-peek visuals.
+
+### Completion path
+
+- If profiles still show completion-specific dropped frames, isolate whether
+  the cost is the mutation, reactive query emission, accessibility announcement,
+  or card render before proposing a change.
+- Preserve the current mutually exclusive navigation behavior: advance to
+  another pending step when one exists; otherwise let the pending-to-complete
+  effect snap to the goal card and announce completion.
+
+## Verification
+
+- Manual baseline and comparison: use the same physical device, build mode,
+  goal, and animation preference before and after the change. Record the device
+  model and test a goal with ≥5 steps.
+- Exercise adjacent arrow/swipe navigation, non-adjacent dot/timeline jumps,
+  wrapped auto-advance across completed steps, final-step snap-to-goal, and
+  navigation while the evidence drawer is open.
+- Capture React DevTools render evidence for one navigation before and after.
+  The after profile must show unchanged `StepCard` and `GoalEvidenceCard`
+  instances skipping renders.
+- Use the React Native performance monitor or profiler available in the local
+  development build to compare JS/UI frame drops. Treat visual inspection as a
+  supporting check, not the only performance evidence.
+- Optionally add temporary render-count logging to `StepCard` to confirm only
+  changed cards re-render per navigation (remove before commit).
+- Tests: extend the Focus-mode suite to assert that `evidenceByStepQuery` is
+  never invoked, including after navigation and drawer opening, and that drawer
+  view/delete behavior still uses the correct current-step row.
+- Add a focused memoization regression test using a render spy or instrumented
+  child to assert an unrelated card does not re-render when only
+  `currentCardIndex` changes. Do not infer this from card presence, since all
+  cards intentionally remain mounted.
+
+## Discovery log
+
+- [2026-06-14] Used `useFlashOnIncrease` as the render probe in the Focus-mode
+  regression test. It runs once per card render and avoids altering production
+  component APIs solely for instrumentation.

--- a/apps/native-rd/src/components/GoalEvidenceCard/GoalEvidenceCard.tsx
+++ b/apps/native-rd/src/components/GoalEvidenceCard/GoalEvidenceCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import { View, Text, Pressable, PixelRatio } from "react-native";
 import * as Haptics from "expo-haptics";
 import { useTranslation } from "react-i18next";
@@ -33,7 +33,7 @@ export interface GoalEvidenceCardProps {
   onMarkComplete?: () => void;
 }
 
-export function GoalEvidenceCard({
+export const GoalEvidenceCard = memo(function GoalEvidenceCard({
   goalTitle,
   goalDescription,
   goalColor,
@@ -176,4 +176,4 @@ export function GoalEvidenceCard({
       </Card>
     </View>
   );
-}
+});

--- a/apps/native-rd/src/components/StepCard/StepCard.tsx
+++ b/apps/native-rd/src/components/StepCard/StepCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { View, Text, Pressable, ScrollView } from "react-native";
 import Animated from "react-native-reanimated";
 import { useTranslation } from "react-i18next";
@@ -34,9 +34,9 @@ export interface StepCardProps {
   step: StepCardStep;
   stepIndex: number;
   totalSteps: number;
-  onToggleComplete: () => void;
+  onToggleComplete: (stepId: string) => void;
   onEvidenceTap: () => void;
-  onQuickEvidence?: (type: QuickEvidenceType) => void;
+  onQuickEvidence?: (stepId: string, type: QuickEvidenceType) => void;
 }
 
 const statusToVariant: Record<StepCardStatus, StatusBadgeVariant> = {
@@ -69,7 +69,7 @@ function getMissingQuickEvidenceOptions(
   );
 }
 
-export function StepCard({
+function StepCardComponent({
   step,
   stepIndex,
   totalSteps,
@@ -142,7 +142,7 @@ export function StepCard({
               return (
                 <Pressable
                   key={option.type}
-                  onPress={() => onQuickEvidence(option.type)}
+                  onPress={() => onQuickEvidence(step.id, option.type)}
                   style={styles.quickActionButton}
                   testID={`step-card-quick-evidence-${option.type}`}
                   accessible
@@ -182,7 +182,7 @@ export function StepCard({
           <View style={styles.checkboxRow}>
             <Checkbox
               checked={isCompleted}
-              onToggle={onToggleComplete}
+              onToggle={() => onToggleComplete(step.id)}
               label={checkboxLabel}
             />
           </View>
@@ -213,3 +213,42 @@ export function StepCard({
     </Card>
   );
 }
+
+function equalStringArrays(
+  previous: readonly string[] | null | undefined,
+  next: readonly string[] | null | undefined,
+): boolean {
+  const previousValues = previous ?? [];
+  const nextValues = next ?? [];
+  return (
+    previousValues.length === nextValues.length &&
+    previousValues.every((value, index) => value === nextValues[index])
+  );
+}
+
+function areStepCardPropsEqual(
+  previous: StepCardProps,
+  next: StepCardProps,
+): boolean {
+  return (
+    previous.step.id === next.step.id &&
+    previous.step.title === next.step.title &&
+    previous.step.status === next.step.status &&
+    previous.step.evidenceCount === next.step.evidenceCount &&
+    equalStringArrays(
+      previous.step.plannedEvidenceTypes,
+      next.step.plannedEvidenceTypes,
+    ) &&
+    equalStringArrays(
+      previous.step.capturedEvidenceTypes,
+      next.step.capturedEvidenceTypes,
+    ) &&
+    previous.stepIndex === next.stepIndex &&
+    previous.totalSteps === next.totalSteps &&
+    previous.onToggleComplete === next.onToggleComplete &&
+    previous.onEvidenceTap === next.onEvidenceTap &&
+    previous.onQuickEvidence === next.onQuickEvidence
+  );
+}
+
+export const StepCard = memo(StepCardComponent, areStepCardPropsEqual);

--- a/apps/native-rd/src/components/StepCard/__tests__/StepCard.test.tsx
+++ b/apps/native-rd/src/components/StepCard/__tests__/StepCard.test.tsx
@@ -98,7 +98,7 @@ describe("StepCard", () => {
       />,
     );
     fireEvent.press(screen.getByRole("checkbox"));
-    expect(onToggleComplete).toHaveBeenCalledTimes(1);
+    expect(onToggleComplete).toHaveBeenCalledWith("step-1");
   });
 
   it("calls onEvidenceTap when evidence badge is pressed", () => {
@@ -299,7 +299,7 @@ describe("StepCard", () => {
       />,
     );
     fireEvent.press(screen.getByLabelText("Add File evidence"));
-    expect(onQuickEvidence).toHaveBeenCalledWith("file");
+    expect(onQuickEvidence).toHaveBeenCalledWith("step-1", "file");
   });
 
   it("calls onQuickEvidence with 'text' when the Note quick action is pressed", () => {
@@ -315,7 +315,7 @@ describe("StepCard", () => {
       />,
     );
     fireEvent.press(screen.getByLabelText("Add Note evidence"));
-    expect(onQuickEvidence).toHaveBeenCalledWith("text");
+    expect(onQuickEvidence).toHaveBeenCalledWith("step-1", "text");
   });
 
   it("hides quick evidence actions when onQuickEvidence callback is not provided", () => {

--- a/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
@@ -280,162 +280,163 @@ function FocusContent({ goalId }: { goalId: string }) {
     hideToast();
   }, [hideToast]);
 
-  if (!goal) {
-    return (
-      <View style={styles.centered}>
-        <Text variant="body">{t("focusMode:errors.goalNotFound")}</Text>
-      </View>
-    );
-  }
-
   // --- Event Handlers ---
 
-  const handleIndexChange = (index: number) => {
+  const handleIndexChange = useCallback((index: number) => {
     setCurrentCardIndex(index);
-    if (isDrawerOpen) setIsDrawerOpen(false);
-    if (isFABMenuOpen) setIsFABMenuOpen(false);
-  };
+    setIsDrawerOpen(false);
+    setIsFABMenuOpen(false);
+  }, []);
 
-  const handleMarkComplete = () => {
+  const handleMarkComplete = useCallback(() => {
     navigation.navigate("CompletionFlow", { goalId });
-  };
+  }, [goalId, navigation]);
 
-  const handleBadgePress = () => {
+  const handleBadgePress = useCallback(() => {
     navigation.navigate("BadgeDesigner", {
       mode: "new-goal",
       goalId,
       returnVia: "back",
     });
-  };
+  }, [goalId, navigation]);
 
-  const handleToggleStep = (stepId: string) => {
-    const step = stepRows.find((s) => s.id === stepId);
-    if (!step) {
-      console.warn(
-        `[FocusModeScreen] handleToggleStep: step not found for id "${stepId}"`,
-      );
-      return;
-    }
-
-    try {
-      if (step.status === StepStatus.completed) {
-        uncompleteStep(stepId as StepId);
-        AccessibilityInfo.announceForAccessibility(
-          t("focusMode:a11y.stepUncompleted", { title: step.title }),
+  const handleToggleStep = useCallback(
+    (stepId: string) => {
+      const step = stepRows.find((s) => s.id === stepId);
+      if (!step) {
+        console.warn(
+          `[FocusModeScreen] handleToggleStep: step not found for id "${stepId}"`,
         );
-      } else {
-        const stepEvidence = allStepEvidenceRows
-          .filter((e) => e.stepId === stepId)
-          .map((e) => ({ type: (e.type as string | null) ?? null }));
-        const plannedTypes =
-          (step.plannedEvidenceTypes as string | null) ?? null;
-
-        if (!canCompleteStep(plannedTypes, stepEvidence)) {
-          showToast({
-            message: t("focusMode:toast.evidenceRequired"),
-            duration: 3000,
-          });
-          return;
-        }
-
-        completeStep(stepId as StepId, plannedTypes, stepEvidence);
-        AccessibilityInfo.announceForAccessibility(
-          t("focusMode:a11y.stepCompleted", { title: step.title }),
-        );
-        // Advance past the just-completed step to the next pending one.
-        // stepRows is the pre-completion snapshot, so skip stepId explicitly.
-        // Forward first, then wrap; if nothing remains pending, the
-        // all-steps-complete effect navigates to CompletionFlow.
-        const isOtherPending = (s: (typeof stepRows)[number]): boolean =>
-          s.id !== stepId && isPendingStep(s);
-        const completedIndex = stepRows.findIndex((s) => s.id === stepId);
-        const forwardIndex = stepRows.findIndex(
-          (s, i) => i > completedIndex && isOtherPending(s),
-        );
-        const nextIndex =
-          forwardIndex !== -1
-            ? forwardIndex
-            : stepRows.findIndex(isOtherPending);
-        if (nextIndex !== -1 && nextIndex !== currentCardIndex) {
-          // Use handleIndexChange (not setCurrentCardIndex) so the evidence
-          // drawer / FAB menu close — otherwise an open overlay would persist
-          // over the new step's content.
-          handleIndexChange(nextIndex);
-        }
+        return;
       }
-    } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : t("focusMode:errors.somethingWrong");
-      console.error("[FocusModeScreen] Failed to toggle step completion", {
-        stepId,
-        error,
-      });
-      reportError(error, { area: "focus.mode", kind: "step-toggle" });
-      showToast({
-        message: t("focusMode:errors.couldNotUpdateStep", { message }),
-        duration: 3000,
-      });
-    }
-  };
 
-  const handleEvidenceTap = () => {
+      try {
+        if (step.status === StepStatus.completed) {
+          uncompleteStep(stepId as StepId);
+          AccessibilityInfo.announceForAccessibility(
+            t("focusMode:a11y.stepUncompleted", { title: step.title }),
+          );
+        } else {
+          const stepEvidence = allStepEvidenceRows
+            .filter((e) => e.stepId === stepId)
+            .map((e) => ({ type: (e.type as string | null) ?? null }));
+          const plannedTypes =
+            (step.plannedEvidenceTypes as string | null) ?? null;
+
+          if (!canCompleteStep(plannedTypes, stepEvidence)) {
+            showToast({
+              message: t("focusMode:toast.evidenceRequired"),
+              duration: 3000,
+            });
+            return;
+          }
+
+          completeStep(stepId as StepId, plannedTypes, stepEvidence);
+          AccessibilityInfo.announceForAccessibility(
+            t("focusMode:a11y.stepCompleted", { title: step.title }),
+          );
+          // Advance past the just-completed step to the next pending one.
+          // stepRows is the pre-completion snapshot, so skip stepId explicitly.
+          // Forward first, then wrap; if nothing remains pending, the
+          // all-steps-complete effect navigates to CompletionFlow.
+          const isOtherPending = (s: (typeof stepRows)[number]): boolean =>
+            s.id !== stepId && isPendingStep(s);
+          const completedIndex = stepRows.findIndex((s) => s.id === stepId);
+          const forwardIndex = stepRows.findIndex(
+            (s, i) => i > completedIndex && isOtherPending(s),
+          );
+          const nextIndex =
+            forwardIndex !== -1
+              ? forwardIndex
+              : stepRows.findIndex(isOtherPending);
+          if (nextIndex !== -1) {
+            // Use handleIndexChange (not setCurrentCardIndex) so the evidence
+            // drawer / FAB menu close — otherwise an open overlay would persist
+            // over the new step's content.
+            handleIndexChange(nextIndex);
+          }
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : t("focusMode:errors.somethingWrong");
+        console.error("[FocusModeScreen] Failed to toggle step completion", {
+          stepId,
+          error,
+        });
+        reportError(error, { area: "focus.mode", kind: "step-toggle" });
+        showToast({
+          message: t("focusMode:errors.couldNotUpdateStep", { message }),
+          duration: 3000,
+        });
+      }
+    },
+    [allStepEvidenceRows, handleIndexChange, showToast, stepRows, t],
+  );
+
+  const handleEvidenceTap = useCallback(() => {
     setIsDrawerOpen(true);
-  };
+  }, []);
 
-  const handleToggleDrawer = () => {
+  const handleToggleDrawer = useCallback(() => {
     setIsDrawerOpen((prev) => !prev);
-  };
+  }, []);
 
-  const handleToggleFABMenu = () => {
+  const handleToggleFABMenu = useCallback(() => {
     setIsFABMenuOpen((prev) => !prev);
     if (!isDrawerOpen) setIsDrawerOpen(true);
-  };
+  }, [isDrawerOpen]);
 
-  const handleSelectEvidenceType = (type: EvidenceTypeValue) => {
-    setIsFABMenuOpen(false);
-    const routeName = EVIDENCE_ROUTE_MAP[type];
-    if (!routeName) {
-      logger.error("No capture route mapped for evidence type", { type });
-      const label = evidenceShortLabel(t, type);
-      showToast({
-        message: t("focusMode:errors.couldNotOpenCapture", { label }),
-        duration: 3000,
+  const handleSelectEvidenceType = useCallback(
+    (type: EvidenceTypeValue) => {
+      setIsFABMenuOpen(false);
+      const routeName = EVIDENCE_ROUTE_MAP[type];
+      if (!routeName) {
+        logger.error("No capture route mapped for evidence type", { type });
+        const label = evidenceShortLabel(t, type);
+        showToast({
+          message: t("focusMode:errors.couldNotOpenCapture", { label }),
+          duration: 3000,
+        });
+        return;
+      }
+
+      navigation.navigate(routeName, {
+        goalId,
+        stepId: isGoalCard ? undefined : stepRows[currentCardIndex]?.id,
       });
-      return;
-    }
+    },
+    [currentCardIndex, goalId, isGoalCard, navigation, showToast, stepRows, t],
+  );
 
-    navigation.navigate(routeName, {
-      goalId,
-      stepId: isGoalCard ? undefined : stepRows[currentCardIndex]?.id,
-    });
-  };
+  const handleQuickEvidence = useCallback(
+    (stepId: string, type: QuickEvidenceType) => {
+      setIsFABMenuOpen(false);
+      const routeName = EVIDENCE_ROUTE_MAP[type];
+      if (!routeName) {
+        logger.error("No capture route mapped for evidence type", { type });
+        const label = evidenceShortLabel(t, type);
+        showToast({
+          message: t("focusMode:errors.couldNotOpenCapture", { label }),
+          duration: 3000,
+        });
+        return;
+      }
 
-  const handleQuickEvidence = (stepId: string, type: QuickEvidenceType) => {
-    setIsFABMenuOpen(false);
-    const routeName = EVIDENCE_ROUTE_MAP[type];
-    if (!routeName) {
-      logger.error("No capture route mapped for evidence type", { type });
-      const label = evidenceShortLabel(t, type);
-      showToast({
-        message: t("focusMode:errors.couldNotOpenCapture", { label }),
-        duration: 3000,
+      navigation.navigate(routeName, {
+        goalId,
+        stepId,
       });
-      return;
-    }
+    },
+    [goalId, navigation, showToast, t],
+  );
 
-    navigation.navigate(routeName, {
-      goalId,
-      stepId,
-    });
-  };
-
-  const handleRequestDeleteEvidence = (id: string) => {
+  const handleRequestDeleteEvidence = useCallback((id: string) => {
     setPendingDeleteId(id);
-  };
+  }, []);
 
-  const handleConfirmDeleteEvidence = () => {
+  const handleConfirmDeleteEvidence = useCallback(() => {
     if (!pendingDeleteId) return;
     const id = pendingDeleteId;
     setPendingDeleteId(null);
@@ -479,29 +480,52 @@ function FocusContent({ goalId }: { goalId: string }) {
         t("focusMode:errors.somethingWrong"),
       );
     }
-  };
+  }, [
+    currentStepEvidenceRows,
+    goalEvidenceRows,
+    handleUndoDelete,
+    pendingDeleteId,
+    showToast,
+    t,
+  ]);
 
-  const handleViewEvidence = (id: string) => {
-    const row =
-      currentStepEvidenceRows.find((r) => r.id === id) ??
-      goalEvidenceRows.find((r) => r.id === id);
-    if (!row) return;
-    viewEvidence({
-      id: row.id,
-      title: row.description ?? row.type ?? evidenceFallbackLabel,
-      type: validateEvidenceType(row.type ?? "file"),
-      uri: row.uri ?? undefined,
-      metadata: row.metadata ?? undefined,
-    });
-  };
+  const handleViewEvidence = useCallback(
+    (id: string) => {
+      const row =
+        currentStepEvidenceRows.find((r) => r.id === id) ??
+        goalEvidenceRows.find((r) => r.id === id);
+      if (!row) return;
+      viewEvidence({
+        id: row.id,
+        title: row.description ?? row.type ?? evidenceFallbackLabel,
+        type: validateEvidenceType(row.type ?? "file"),
+        uri: row.uri ?? undefined,
+        metadata: row.metadata ?? undefined,
+      });
+    },
+    [
+      currentStepEvidenceRows,
+      evidenceFallbackLabel,
+      goalEvidenceRows,
+      viewEvidence,
+    ],
+  );
 
-  const handleTimelineTap = () => {
+  const handleTimelineTap = useCallback(() => {
     navigation.navigate("TimelineJourney", { goalId });
-  };
+  }, [goalId, navigation]);
 
-  const handleEditPress = () => {
+  const handleEditPress = useCallback(() => {
     navigation.navigate("EditMode", { goalId, cameFromFocus: true });
-  };
+  }, [goalId, navigation]);
+
+  if (!goal) {
+    return (
+      <View style={styles.centered}>
+        <Text variant="body">{t("focusMode:errors.goalNotFound")}</Text>
+      </View>
+    );
+  }
 
   // --- Render ---
 
@@ -587,9 +611,9 @@ function FocusContent({ goalId }: { goalId: string }) {
                 }}
                 stepIndex={index}
                 totalSteps={stepRows.length}
-                onToggleComplete={() => handleToggleStep(step.id)}
+                onToggleComplete={handleToggleStep}
                 onEvidenceTap={handleEvidenceTap}
-                onQuickEvidence={(type) => handleQuickEvidence(step.id, type)}
+                onQuickEvidence={handleQuickEvidence}
               />
             )),
             <GoalEvidenceCard

--- a/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
@@ -43,7 +43,6 @@ import {
   goalsQuery,
   stepsByGoalQuery,
   evidenceByGoalQuery,
-  evidenceByStepQuery,
   stepEvidenceByGoalQuery,
   completeStep,
   uncompleteStep,
@@ -204,10 +203,12 @@ function FocusContent({ goalId }: { goalId: string }) {
 
   // Current evidence for the drawer
   const currentStepId = isGoalCard ? null : stepRows[currentCardIndex]?.id;
-  const currentStepEvidenceRows = useQuery(
-    currentStepId
-      ? evidenceByStepQuery(currentStepId as StepId)
-      : evidenceByGoalQuery(goalId as GoalId),
+  const currentStepEvidenceRows = useMemo(
+    () =>
+      currentStepId
+        ? allStepEvidenceRows.filter((row) => row.stepId === currentStepId)
+        : [],
+    [allStepEvidenceRows, currentStepId],
   );
 
   const evidenceFallbackLabel = t("focusMode:evidenceFallback");

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -13,13 +13,17 @@ const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("../../../__tests__/mocks/navigation");
+  let navigation: ReturnType<typeof actual.useNavigation> | undefined;
   return {
     ...actual,
-    useNavigation: jest.fn(() => ({
-      ...actual.useNavigation(),
-      goBack: mockGoBack,
-      navigate: mockNavigate,
-    })),
+    useNavigation: jest.fn(() => {
+      navigation ??= {
+        ...actual.useNavigation(),
+        goBack: mockGoBack,
+        navigate: mockNavigate,
+      };
+      return navigation;
+    }),
   };
 });
 
@@ -48,6 +52,11 @@ jest.mock("../../../hooks/useAnimationPref", () => ({
     shouldReduceMotion: false,
     setAnimationPref: jest.fn(),
   }),
+}));
+
+const mockUseFlashOnIncrease = jest.fn((_count: number) => ({}));
+jest.mock("../../../hooks/useFlashOnIncrease", () => ({
+  useFlashOnIncrease: (count: number) => mockUseFlashOnIncrease(count),
 }));
 
 const mockCompleteStep = jest.fn();
@@ -244,6 +253,25 @@ describe("FocusModeScreen", () => {
       ),
     ).toBeOnTheScreen();
     expect(screen.getByText("Read docs")).toBeOnTheScreen();
+  });
+
+  it("only re-renders the outgoing and incoming cards during navigation", () => {
+    setupQueries({
+      steps: [
+        { id: "step-1", title: "Read docs", status: "pending", ordinal: 0 },
+        { id: "step-2", title: "Practice", status: "pending", ordinal: 1 },
+        { id: "step-3", title: "Build it", status: "pending", ordinal: 2 },
+      ],
+      stepEvidence: [],
+    });
+    renderWithProviders(<FocusModeScreen {...routeProps} />);
+
+    mockUseFlashOnIncrease.mockClear();
+    fireEvent.press(screen.getByLabelText("Next card"));
+
+    // useFlashOnIncrease runs during each StepCard/GoalEvidenceCard render.
+    // Only the two StepCards whose derived status changed should render.
+    expect(mockUseFlashOnIncrease).toHaveBeenCalledTimes(2);
   });
 
   it("advances the carousel to the next pending step after completing one", () => {

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
 } from "../../../__tests__/test-utils";
 import { i18n } from "../../../i18n";
+import { evidenceByStepQuery } from "../../../db";
 import { FocusModeScreen } from "../FocusModeScreen";
 
 // --- Mocks ---
@@ -66,13 +67,23 @@ const mockRestoreEvidence = jest.fn();
 const mockCreateEvidence = jest.fn();
 const mockCanCompleteStep = jest.fn().mockReturnValue(true);
 
+const mockDeleteEvidenceFile = jest.fn((_uri: string, _type: string) => {});
 jest.mock("../../../utils/evidenceCleanup", () => ({
-  deleteEvidenceFile: jest.fn(),
+  deleteEvidenceFile: (uri: string, type: string) =>
+    mockDeleteEvidenceFile(uri, type),
 }));
 
 jest.mock("../../../services/sentry-report", () => ({
   reportError: jest.fn(),
   breadcrumb: jest.fn(),
+}));
+
+const mockViewEvidence = jest.fn();
+jest.mock("../../../utils/evidenceViewers", () => ({
+  useEvidenceViewer: () => ({
+    viewEvidence: mockViewEvidence,
+    viewerModals: null,
+  }),
 }));
 
 jest.mock("../../../db", () => ({
@@ -253,6 +264,16 @@ describe("FocusModeScreen", () => {
       ),
     ).toBeOnTheScreen();
     expect(screen.getByText("Read docs")).toBeOnTheScreen();
+  });
+
+  it("never creates a per-step evidence query while navigating or opening the drawer", () => {
+    setupQueries();
+    renderWithProviders(<FocusModeScreen {...routeProps} />);
+
+    fireEvent.press(screen.getByLabelText("Next card"));
+    fireEvent.press(screen.getByLabelText("Toggle evidence drawer"));
+
+    expect(evidenceByStepQuery).not.toHaveBeenCalled();
   });
 
   it("only re-renders the outgoing and incoming cards during navigation", () => {
@@ -820,6 +841,63 @@ describe("FocusModeScreen", () => {
       screen.getByRole("button", { name: i18n.t("common:actions.delete") }),
     );
     expect(mockDeleteEvidence).toHaveBeenCalledWith("ev-s1");
+  });
+
+  it("uses the current step's goal-wide evidence row for view and delete", () => {
+    jest.useFakeTimers();
+    setupQueries({
+      steps: [
+        { id: "step-1", title: "Read docs", status: "pending", ordinal: 0 },
+        { id: "step-2", title: "Practice", status: "pending", ordinal: 1 },
+      ],
+      stepEvidence: [
+        {
+          id: "ev-s1",
+          type: "text",
+          uri: "content:text;First",
+          description: "First step note",
+          stepId: "step-1",
+        },
+        {
+          id: "ev-s2",
+          type: "photo",
+          uri: "/step-2.jpg",
+          description: "Second step photo",
+          metadata: '{"width":1200}',
+          stepId: "step-2",
+        },
+      ],
+    });
+    renderWithProviders(<FocusModeScreen {...routeProps} />);
+
+    fireEvent.press(screen.getByLabelText("Next card"));
+    fireEvent.press(screen.getByLabelText("Toggle evidence drawer"));
+
+    const evidenceItem = screen.getByLabelText(
+      "photo evidence: Second step photo",
+    );
+    expect(
+      screen.queryByLabelText(/text evidence: First step note/),
+    ).toBeNull();
+
+    fireEvent.press(evidenceItem);
+    expect(mockViewEvidence).toHaveBeenCalledWith({
+      id: "ev-s2",
+      title: "Second step photo",
+      type: "photo",
+      uri: "/step-2.jpg",
+      metadata: '{"width":1200}',
+    });
+
+    fireEvent(evidenceItem, "longPress");
+    fireEvent.press(
+      screen.getByRole("button", { name: i18n.t("common:actions.delete") }),
+    );
+    expect(mockDeleteEvidence).toHaveBeenCalledWith("ev-s2");
+
+    jest.advanceTimersByTime(5000);
+    expect(mockDeleteEvidenceFile).toHaveBeenCalledWith("/step-2.jpg", "photo");
+    jest.useRealTimers();
   });
 
   it("cancels evidence deletion when cancel is pressed", () => {


### PR DESCRIPTION
## Summary

- Memoize Focus mode step and goal cards so navigation only re-renders cards whose state changes.
- Stabilize card callbacks and preserve existing completion, evidence-gating, and accessibility behavior.
- Reuse the goal-wide step-evidence subscription for the drawer instead of creating a new query on every step change.

## Root cause

Changing the current card rebuilt every card with fresh callback props and also replaced the active per-step Evolu query. That JS render and subscription work occurred as the Reanimated carousel transition started, causing visible dropped frames.

## Validation

- `bun run type-check`
- `bun run lint` (passes with existing repository warnings)
- `bun run test`: 177 suites, 8,835 tests passed
- `bun run build`: passed; native-rd build task is a no-op
- Focus component suite: 100 tests passed after callback/memoization changes
- Focus screen suite: 55 tests passed after query reuse changes

## Manual verification

Physical-device profiling with a goal containing at least five steps remains required to compare frame drops before and after this change.

## Plan

See `apps/native-rd/docs/plans/2026-06-14-focus-view-step-jitter.md` for the reviewed implementation plan and profiling checklist.