### PR TITLE
docs(native-rd): vision note on habit formation as recurring practice

### DIFF
--- a/apps/native-rd/docs/vision/habit-formation.md
+++ b/apps/native-rd/docs/vision/habit-formation.md
@@ -1,0 +1,134 @@
+# Habit Formation — the recurring practice
+
+**Date:** 2026-06-20
+**Status:** Draft — thinking note, not a committed feature
+**Owner:** Joe
+
+---
+
+## Why this exists
+
+This is, honestly, a big part of why the app exists. Tracking goals and earning
+badges is the visible loop. The quieter motivation underneath it is: **help a
+person who is bad at routine build a routine that improves their life** — without
+the guilt, the rabbit-holes, and the all-or-nothing collapse that make ordinary
+habit apps fail for neurodivergent people.
+
+The seed case is a real one: a daily mobility-and-strength routine, where the goal
+isn't to become a "yoga person" but to give the body a daily reminder that it
+moves. No pain, better mobility, more strength — but the part that actually
+matters, and the part that's hardest, is **making it a habit at all.**
+
+---
+
+## The honest mechanism
+
+The habit never forms inside the app.
+
+It forms at the toothbrush, at the kettlebell left where you almost trip over it,
+at the sticky note on the monitor. By the time someone would open the app to "do
+their habit," they've already lost — because opening the app is itself a routine
+they don't have yet. **Any habit app that needs you to show up to it is competing
+with the very thing it's trying to build.**
+
+So "help people build habits" is not "build a better tracker." It decomposes into
+three jobs, and only one of them happens in-app at the moment of action.
+
+### 1. Help design the cue — this is the real feature
+
+Most apps let you set a _time_ ("9am: stretch"). Time-based reminders are the wrong
+system for ADHD. The thing that works is an **anchor**: attach the new action to
+something already load-bearing in your day.
+
+- After brushing teeth → one hip drill.
+- While the coffee brews → 90/90 switches.
+- After the work laptop closes → a carry.
+
+The app's job is to walk you through _finding_ that anchor — "what do you already
+do every single day without fail?" — and binding the tiny new action to it. This is
+a thinking task, not a doing task, which is exactly what a phone is good for. No
+other habit app does this part well.
+
+### 2. Make the reward immediate and identity-shaped
+
+"You're 14% toward better mobility" is useless — the payoff is months away, and the
+brain we're designing for doesn't wait. What works is reflecting back an identity:
+_you showed up; that's two days running; you're becoming someone who does this._
+
+For recovery-shaped users especially, the right register is **"I am a person who
+shows up,"** not a score climbing toward a prize. This is where the app's badge
+instinct can serve the goal — but only if the badge says _you're consistent_, not
+_you're winning_.
+
+### 3. Own the failure moment — this is the whole moat
+
+Everyone can start a habit. The product that actually helps is the one that handles
+day 4, when you miss. The rules, borrowed from how this works in practice:
+
+- **Never miss twice.** Missing once is invisible. The only thing the app ever
+  nudges on is the second miss.
+- **No catch-up, by design.** The app should make "making up for it" _impossible_,
+  not merely discouraged. The compensation workout is the failure mode, not the
+  recovery.
+- **Shrink the ask on restart.** After a miss, the next action becomes "do one
+  minute / three reps," then grows back. The unit of progress is "I showed up,"
+  not "I completed the set."
+- **Zero guilt.** A broken streak is a shrug and a one-tap restart, never a small
+  death. Most apps make the broken streak punishing; for the abstinence-violation
+  effect, that's actively harmful.
+
+---
+
+## The primitive question
+
+This is the fork worth deciding before any of the above gets built.
+
+**Journeys end. Habits don't.**
+
+The current vision models everything as a journey: steps → completion → badge →
+done. A habit's success isn't _completion_ — a daily mobility drill never
+"completes." Its success is _recurrence over time, forgivingly measured._ If the
+app only knows finish-line goals, habits will always feel bolted on.
+
+So: does native-rd need a first-class **practice** (or ritual) concept, sitting
+alongside the journey — something whose progress is "how consistently, how kindly"
+rather than "how far along"?
+
+My read: this practice concept may be closer to what the app is _for_ than the
+journey-and-badge machinery is. The badges are one expression of the underlying
+promise — help me become someone who does the thing. They are not the promise
+itself.
+
+---
+
+## How this sits with the rest of the vision
+
+- **Reinforces "the journey is the product."** A practice has no destination at all
+  — it's pure journey. It's the strongest possible version of that principle.
+- **Extends the task view.** "One next step per active goal" already points here.
+  A practice's next step is just "the anchor fired; do the tiny thing."
+- **Tension with the skill tree / badge loop.** The sharpest line in the seed
+  material is _"track with a stupid checkbox, not an app rabbit-hole."_ The reward
+  architecture that makes Iteration C fun is the exact dopamine-spiral that makes
+  routine apps fail for this use. A practice mode may need to deliberately run
+  _under-gamified_, against the app's default reward loop. That's a real design
+  decision, not a detail.
+
+---
+
+## Open questions (story altitude — no schema yet)
+
+- Is "practice" a distinct primitive, or a journey with a recurrence flag and
+  different surfacing? (Deliberately not answering with data-model shapes here.)
+- What does the _anchor-design_ flow feel like as a screen? This is the one piece
+  that genuinely belongs on the phone and is worth prototyping first.
+- How does a practice show up in the task view next to finish-line goals without
+  the two collapsing into the same "checkbox" feel?
+- Where does this land in the A–D iteration strategy — a thread inside B, or its
+  own thing?
+
+---
+
+_Draft created 2026-06-20. Seeded from Joe's own mobility/strength routine and the
+recurring-habit motivation behind the app. Not a committed feature — input for the
+vision and for whenever the Iteration B feature list gets opened._

--- a/apps/native-rd/docs/vision/index.md
+++ b/apps/native-rd/docs/vision/index.md
@@ -2,8 +2,9 @@
 
 Documents defining what the app is, who it's for, and how it should feel.
 
-| Document                                       | Summary                                                   | Last Verified |
-| ---------------------------------------------- | --------------------------------------------------------- | ------------- |
-| [product-vision.md](./product-vision.md)       | What the app is, iterations A-D, relationship to monorepo | 2026-02-24    |
-| [design-principles.md](./design-principles.md) | ND-first design rules, visual identity, 7 themes          | 2026-02-24    |
-| [user-stories.md](./user-stories.md)           | Lina, Sam, Ava, Eva — real scenarios driving design       | 2026-02-24    |
+| Document                                       | Summary                                                                   | Last Verified |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | ------------- |
+| [product-vision.md](./product-vision.md)       | What the app is, iterations A-D, relationship to monorepo                 | 2026-02-24    |
+| [design-principles.md](./design-principles.md) | ND-first design rules, visual identity, 7 themes                          | 2026-02-24    |
+| [user-stories.md](./user-stories.md)           | Lina, Sam, Ava, Eva — real scenarios driving design                       | 2026-02-24    |
+| [habit-formation.md](./habit-formation.md)     | Recurring practice vs finish-line goal; how to help ND users build habits | 2026-06-20    |


### PR DESCRIPTION
## What

Adds a story-altitude vision note, `apps/native-rd/docs/vision/habit-formation.md`, capturing the habit-building motivation behind the app, and links it from the vision index.

## Why

Helping a person who struggles with routine build a routine that improves their life is a core reason the app exists, but the current vision models everything as a **finish-line journey** (steps → completion → badge). A habit never completes — its success is *recurrence over time, forgivingly measured*. The existing vision has no first-class concept for that.

## What the note records

- **The honest mechanism** — the habit forms at the toothbrush / the kettlebell / the sticky note, not in the app. The app's three jobs: design the cue (anchors, not time-based reminders), give an identity-shaped reward, and own the failure moment.
- **The failure-handling rules as the moat** — never-miss-twice, no-catch-up by design, shrink-the-ask on restart, zero guilt (with the abstinence-violation note kept in for recovery-shaped users).
- **The primitive fork** — *journeys end, habits don't.* Whether native-rd needs a first-class **practice** concept alongside the journey is left explicitly as Joe's call.
- **The tension** — the skill-tree reward loop (Iteration C) is the same dopamine-spiral that makes routine apps fail for this use; a practice mode may need to run deliberately under-gamified.

Story altitude only — no fields, enums, or tables. Marked a **draft thinking note**, not a committed feature. Input for the vision and for whenever the Iteration B feature list gets opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fCc3GYWcCk7xCkEBC1j85
