### PR TITLE
fix(native-rd): high-contrast surface token + Phosphor reorder icons

### DIFF
--- a/apps/native-rd/src/components/StepList/DraggableStepItem.tsx
+++ b/apps/native-rd/src/components/StepList/DraggableStepItem.tsx
@@ -11,6 +11,12 @@ import Animated, {
   withTiming,
   runOnJS,
 } from "react-native-reanimated";
+import {
+  ArrowUp,
+  ArrowDown,
+  ArrowBendDownRight,
+  ArrowBendUpLeft,
+} from "phosphor-react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
 import { getTimingConfig } from "../../utils/animation";
 import { IconButton } from "../IconButton";
@@ -176,7 +182,7 @@ export function DraggableStepItem({
                 <View style={styles.reorderButtons}>
                   {onMoveUp && !isFirst && (
                     <IconButton
-                      icon={<Text variant="body">↑</Text>}
+                      icon={<ArrowUp size={18} weight="bold" />}
                       onPress={onMoveUp}
                       size="sm"
                       accessibilityLabel={`Move "${step.title}" up`}
@@ -184,7 +190,7 @@ export function DraggableStepItem({
                   )}
                   {onMoveDown && !isLast && (
                     <IconButton
-                      icon={<Text variant="body">↓</Text>}
+                      icon={<ArrowDown size={18} weight="bold" />}
                       onPress={onMoveDown}
                       size="sm"
                       accessibilityLabel={`Move "${step.title}" down`}
@@ -192,7 +198,7 @@ export function DraggableStepItem({
                   )}
                   {canNestUnder && onNestUnder && (
                     <IconButton
-                      icon={<Text variant="body">⤵</Text>}
+                      icon={<ArrowBendDownRight size={18} weight="bold" />}
                       onPress={() => setPickerOpen(true)}
                       size="sm"
                       accessibilityLabel={t(
@@ -203,7 +209,7 @@ export function DraggableStepItem({
                   )}
                   {canUnNest && onUnNest && (
                     <IconButton
-                      icon={<Text variant="body">⤴</Text>}
+                      icon={<ArrowBendUpLeft size={18} weight="bold" />}
                       onPress={onUnNest}
                       size="sm"
                       accessibilityLabel={t(

--- a/packages/design-tokens/src/themes/high-contrast.json
+++ b/packages/design-tokens/src/themes/high-contrast.json
@@ -38,7 +38,12 @@
       "warning": { "$value": "#cc5500" },
       "warning-light": { "$value": "#ffe0cc" },
       "info": { "$value": "#0055cc" },
-      "info-light": { "$value": "#cce0ff" }
+      "info-light": { "$value": "#cce0ff" },
+      "gray": {
+        "100": { "$value": "#eeeeee" },
+        "200": { "$value": "#e0e0e0" },
+        "300": { "$value": "#cccccc" }
+      }
     },
     "narrative": {
       "climb": {


### PR DESCRIPTION
## Summary

Two visual fixes for the goal editor in the **high-contrast** theme, found while debugging the steplist drag/drop UI. The progress bars and "pending" status badges were rendering as solid black blobs in high contrast, and the sub-step reorder controls used a color-emoji arrow that clashed with the other icons.

## Changes

- **design-tokens:** `high-contrast.json` was the only theme missing a `color.gray` block, so the Unistyles build resolved `backgroundTertiary` through its `?? form.border` fallback to `#000000`. Every component using `backgroundTertiary` as a surface (ProgressBar track, locked StatusBadge, BrutalistSlider track, …) then rendered black-on-black in high contrast — progress bars looked 100% full regardless of progress, and pending badges were unreadable. Added a light gray ramp (`200 → #e0e0e0`) so the surface is light and dark fills/text stay visible. Fixes the whole class in one token change; no component edits needed.
- **steplist:** Replaced the four `DraggableStepItem` reorder controls (unicode glyphs `↑ ↓ ⤵ ⤴`; iOS promoted `⤴/⤵` to color-emoji) with matching Phosphor icons — `ArrowUp`, `ArrowDown`, `ArrowBendDownRight` (nest-under), `ArrowBendUpLeft` (un-nest) — so they read as one consistent monochrome set and tone per theme via `IconButton`.

## Dependencies

- [ ] None

## Test Plan

- [x] Type check passes (`bun run type-check`)
- [x] Lint passes (`bun run lint`)
- [x] Format check passes (Prettier, via pre-commit)
- [x] StepList unit tests pass — `jest` 58/58 (note: `bun run test` segfaults on this machine — a Bun crash, unrelated; ran via `npx jest`)
- [x] a11y audit passes — `cd apps/native-rd && bun run test:a11y` → 15/15
- [x] Manually verified on device in high-contrast: progress bars + status badges now legible; reorder icons render as a consistent set

## Related Issues

- None

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s1hVoqRmfAiu2xx3YTR1U
