### PR TITLE
feat(native-rd): name saved & exported badge files after the goal title

### DIFF
--- a/apps/native-rd/src/badges/__tests__/badgeFilename.test.ts
+++ b/apps/native-rd/src/badges/__tests__/badgeFilename.test.ts
@@ -1,0 +1,33 @@
+import { slugifyBadgeName } from "../badgeFilename";
+
+describe("slugifyBadgeName", () => {
+  it.each([
+    ["Learn TypeScript", "Learn-TypeScript"],
+    ["  trim me  ", "trim-me"],
+    ["Read 3 books!!!", "Read-3-books"],
+    ["a/b\\c:d*e", "a-b-c-d-e"],
+    ["keep_underscores-and-dashes", "keep_underscores-and-dashes"],
+    ["multiple    spaces", "multiple-spaces"],
+  ])("slugifies %p to %p", (input, expected) => {
+    expect(slugifyBadgeName(input)).toBe(expected);
+  });
+
+  it.each([
+    ["", "empty string"],
+    ["   ", "whitespace only"],
+    ["🎉🎉🎉", "emoji only"],
+    ["日本語", "non-Latin script"],
+    [null, "null"],
+    [undefined, "undefined"],
+  ])("falls back to 'badge' for %p (%s)", (input, _label) => {
+    expect(slugifyBadgeName(input)).toBe("badge");
+  });
+
+  it("caps the slug length and trims a trailing dash left by the cut", () => {
+    const slug = slugifyBadgeName(
+      "this is an extremely long badge title that should be truncated well before the end",
+    );
+    expect(slug.length).toBeLessThanOrEqual(40);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+});

--- a/apps/native-rd/src/badges/__tests__/badgeStorage.test.ts
+++ b/apps/native-rd/src/badges/__tests__/badgeStorage.test.ts
@@ -6,6 +6,8 @@
 
 import { Buffer } from "buffer";
 
+import { saveBadgePNG, readBadgePNG } from "../badgeStorage";
+
 jest.mock("expo-file-system/legacy", () => ({
   documentDirectory: "file:///data/user/0/app/files/",
   EncodingType: { Base64: "base64" },
@@ -17,8 +19,6 @@ jest.mock("expo-file-system/legacy", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockFS = require("expo-file-system/legacy");
-
-import { saveBadgePNG, readBadgePNG } from "../badgeStorage";
 
 const MINIMAL_PNG = new Uint8Array([
   137, 80, 78, 71, 13, 10, 26, 10, 0, 1, 2, 3,
@@ -121,6 +121,17 @@ describe("saveBadgePNG", () => {
         /Failed to write badge PNG to file:.*\.png.*No space left on device/,
       );
     });
+  });
+
+  it("names the file after the badge title", async () => {
+    const uri = await saveBadgePNG(MINIMAL_PNG, "Learn TypeScript");
+    // Slug, then a uniqueness suffix, then .png.
+    expect(uri).toMatch(/\/badges\/Learn-TypeScript-[a-z0-9]+-[a-z0-9]+\.png$/);
+  });
+
+  it("falls back to a generic name when the title yields no usable slug", async () => {
+    const uri = await saveBadgePNG(MINIMAL_PNG, "🎉🎉🎉");
+    expect(uri).toMatch(/\/badges\/badge-[a-z0-9]+-[a-z0-9]+\.png$/);
   });
 
   it("each call generates a unique URI", async () => {

--- a/apps/native-rd/src/badges/badgeFilename.ts
+++ b/apps/native-rd/src/badges/badgeFilename.ts
@@ -12,9 +12,11 @@ const MAX_SLUG_LENGTH = 40;
 /**
  * Turn a badge/goal title into a filesystem- and share-sheet-safe slug.
  *
- * - Strips characters outside `[a-zA-Z0-9-_]` (so non-Latin scripts, emoji,
- *   and punctuation can't produce invalid filenames).
- * - Collapses runs of separators and trims leading/trailing dashes.
+ * - Replaces runs of characters outside `[a-zA-Z0-9-_]` with a single dash
+ *   (so non-Latin scripts, emoji, and punctuation can't produce invalid
+ *   filenames).
+ * - Collapses runs of dashes and trims leading/trailing dashes. Underscores
+ *   are valid filename characters and are kept as-is.
  * - Caps length so the full filename (slug + suffix + extension) stays short.
  * - Falls back to `"badge"` when nothing usable remains (e.g. emoji-only title).
  */

--- a/apps/native-rd/src/badges/badgeFilename.ts
+++ b/apps/native-rd/src/badges/badgeFilename.ts
@@ -1,0 +1,30 @@
+/**
+ * Badge filename helpers.
+ *
+ * Saved/exported badge files are named after the goal they represent so the
+ * user recognises them in the share sheet, Files app, or download folder —
+ * instead of an opaque `{timestamp}-{random}.png`.
+ */
+
+const FALLBACK_SLUG = "badge";
+const MAX_SLUG_LENGTH = 40;
+
+/**
+ * Turn a badge/goal title into a filesystem- and share-sheet-safe slug.
+ *
+ * - Strips characters outside `[a-zA-Z0-9-_]` (so non-Latin scripts, emoji,
+ *   and punctuation can't produce invalid filenames).
+ * - Collapses runs of separators and trims leading/trailing dashes.
+ * - Caps length so the full filename (slug + suffix + extension) stays short.
+ * - Falls back to `"badge"` when nothing usable remains (e.g. emoji-only title).
+ */
+export function slugifyBadgeName(name: string | null | undefined): string {
+  const slug = (name ?? "")
+    .replace(/[^a-zA-Z0-9-_]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+
+  return slug || FALLBACK_SLUG;
+}

--- a/apps/native-rd/src/badges/badgeStorage.ts
+++ b/apps/native-rd/src/badges/badgeStorage.ts
@@ -12,16 +12,22 @@
 import { Buffer } from "buffer";
 import * as FileSystem from "expo-file-system/legacy";
 
+import { slugifyBadgeName } from "./badgeFilename";
+
 const BADGES_SUBDIR = "badges";
 
 function getBadgesDirectory(): string {
   return `${FileSystem.documentDirectory}${BADGES_SUBDIR}/`;
 }
 
-function generateBadgeFilename(): string {
+// Name files after the badge so they're recognisable in the share sheet / Files
+// app, while keeping a short timestamp+random suffix to guarantee uniqueness
+// (multiple badges can share a title; re-bakes shouldn't collide).
+function generateBadgeFilename(badgeName?: string): string {
+  const slug = slugifyBadgeName(badgeName);
   const timestamp = Date.now().toString(36);
   const random = Math.random().toString(36).slice(2, 8);
-  return `${timestamp}-${random}.png`;
+  return `${slug}-${timestamp}-${random}.png`;
 }
 
 /**
@@ -30,9 +36,14 @@ function generateBadgeFilename(): string {
  * Creates the directory if it does not exist.
  *
  * @param data - PNG image bytes
+ * @param badgeName - Badge/goal title used to name the file (sanitised to a
+ *   slug). Omit to fall back to a generic name.
  * @returns Local file URI that can be stored in the badge row's imageUri field
  */
-export async function saveBadgePNG(data: Uint8Array): Promise<string> {
+export async function saveBadgePNG(
+  data: Uint8Array,
+  badgeName?: string,
+): Promise<string> {
   const badgesDir = getBadgesDirectory();
 
   try {
@@ -46,7 +57,7 @@ export async function saveBadgePNG(data: Uint8Array): Promise<string> {
     );
   }
 
-  const uri = `${badgesDir}${generateBadgeFilename()}`;
+  const uri = `${badgesDir}${generateBadgeFilename(badgeName)}`;
   try {
     await FileSystem.writeAsStringAsync(
       uri,

--- a/apps/native-rd/src/hooks/__tests__/useBadgeExport.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useBadgeExport.test.ts
@@ -95,7 +95,10 @@ describe("useBadgeExport", () => {
       const { result } = renderHook(() => useBadgeExport());
 
       await act(async () => {
-        await result.current.exportVerifiableBadge("file:///badges/badge.png");
+        await result.current.exportVerifiableBadge(
+          "file:///badges/badge.png",
+          "Learn TypeScript",
+        );
       });
 
       expect(
@@ -105,11 +108,12 @@ describe("useBadgeExport", () => {
         "file:///badges/badge.png",
         { encoding: FileSystem.EncodingType.Base64 },
       );
+      // File is named after the badge so it's recognisable in the picked folder.
       expect(
         FileSystem.StorageAccessFramework.createFileAsync,
       ).toHaveBeenCalledWith(
         "content:///picked",
-        expect.stringMatching(/^badge-\d+\.png$/),
+        "Learn-TypeScript.png",
         "image/png",
       );
       expect(FileSystem.writeAsStringAsync).toHaveBeenCalledWith(
@@ -320,7 +324,7 @@ describe("useBadgeExport", () => {
       });
 
       expect(FileSystem.writeAsStringAsync).toHaveBeenCalledWith(
-        expect.stringContaining("badge-Learn-TypeScript-"),
+        expect.stringContaining("Learn-TypeScript-"),
         credential,
         { encoding: FileSystem.EncodingType.UTF8 },
       );

--- a/apps/native-rd/src/hooks/useBadgeExport.ts
+++ b/apps/native-rd/src/hooks/useBadgeExport.ts
@@ -3,6 +3,7 @@ import { Alert, Platform } from "react-native";
 import * as Sharing from "expo-sharing";
 import * as FileSystem from "expo-file-system/legacy";
 import { PLACEHOLDER_IMAGE_URI } from "./useCreateBadge";
+import { slugifyBadgeName } from "../badges/badgeFilename";
 
 // expo-sharing's `shareAsync` rejects with a generic Error when the user
 // dismisses the system share sheet on Android (iOS currently resolves
@@ -31,79 +32,85 @@ export function useBadgeExport() {
    *   byte-for-byte. This avoids the dominant Android failure mode where
    *   messengers re-encode "photo" attachments and strip ancillary chunks.
    */
-  const exportVerifiableBadge = useCallback(async (imageUri: string | null) => {
-    if (!imageUri || imageUri === PLACEHOLDER_IMAGE_URI) {
-      Alert.alert(
-        "No image available",
-        "This badge does not have a baked image yet.",
-      );
-      return;
-    }
-
-    setIsExportingImage(true);
-    try {
-      if (Platform.OS === "android") {
-        const perm =
-          await FileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync();
-        if (!perm.granted) {
-          // User cancelled the folder picker — not an error.
-          return;
-        }
-        const base64 = await FileSystem.readAsStringAsync(imageUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-        const filename = `badge-${Date.now()}.png`;
-        const destUri = await FileSystem.StorageAccessFramework.createFileAsync(
-          perm.directoryUri,
-          filename,
-          "image/png",
+  const exportVerifiableBadge = useCallback(
+    async (imageUri: string | null, badgeName?: string) => {
+      if (!imageUri || imageUri === PLACEHOLDER_IMAGE_URI) {
+        Alert.alert(
+          "No image available",
+          "This badge does not have a baked image yet.",
         );
-        await FileSystem.writeAsStringAsync(destUri, base64, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
         return;
       }
 
-      if (Platform.OS === "ios") {
-        const canShare = await Sharing.isAvailableAsync();
-        if (!canShare) {
-          Alert.alert(
-            "Sharing unavailable",
-            "Sharing is not available on this device.",
-          );
+      setIsExportingImage(true);
+      try {
+        if (Platform.OS === "android") {
+          const perm =
+            await FileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync();
+          if (!perm.granted) {
+            // User cancelled the folder picker — not an error.
+            return;
+          }
+          const base64 = await FileSystem.readAsStringAsync(imageUri, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
+          // SAF copies the bytes into a brand-new file, so we name it after the
+          // badge here rather than inheriting the on-disk filename.
+          const filename = `${slugifyBadgeName(badgeName)}.png`;
+          const destUri =
+            await FileSystem.StorageAccessFramework.createFileAsync(
+              perm.directoryUri,
+              filename,
+              "image/png",
+            );
+          await FileSystem.writeAsStringAsync(destUri, base64, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
           return;
         }
-        await Sharing.shareAsync(imageUri, {
-          UTI: "public.png",
-          mimeType: "image/png",
-          dialogTitle: "Export Verifiable Badge",
-        });
-        return;
-      }
 
-      // Web / macOS / windows / unknown — fall through to a clear alert
-      // rather than silently using the iOS share-sheet path.
-      console.error("[useBadgeExport] Unsupported platform", {
-        os: Platform.OS,
-      });
-      Alert.alert(
-        "Export unavailable",
-        "Badge export is only supported on iOS and Android.",
-      );
-    } catch (error) {
-      if (isShareCancellation(error)) return;
-      console.error("[useBadgeExport] Failed to export verifiable badge", {
-        imageUri,
-        error,
-      });
-      Alert.alert(
-        "Export failed",
-        "Something went wrong exporting the verifiable badge.",
-      );
-    } finally {
-      setIsExportingImage(false);
-    }
-  }, []);
+        if (Platform.OS === "ios") {
+          const canShare = await Sharing.isAvailableAsync();
+          if (!canShare) {
+            Alert.alert(
+              "Sharing unavailable",
+              "Sharing is not available on this device.",
+            );
+            return;
+          }
+          await Sharing.shareAsync(imageUri, {
+            UTI: "public.png",
+            mimeType: "image/png",
+            dialogTitle: "Export Verifiable Badge",
+          });
+          return;
+        }
+
+        // Web / macOS / windows / unknown — fall through to a clear alert
+        // rather than silently using the iOS share-sheet path.
+        console.error("[useBadgeExport] Unsupported platform", {
+          os: Platform.OS,
+        });
+        Alert.alert(
+          "Export unavailable",
+          "Badge export is only supported on iOS and Android.",
+        );
+      } catch (error) {
+        if (isShareCancellation(error)) return;
+        console.error("[useBadgeExport] Failed to export verifiable badge", {
+          imageUri,
+          error,
+        });
+        Alert.alert(
+          "Export failed",
+          "Something went wrong exporting the verifiable badge.",
+        );
+      } finally {
+        setIsExportingImage(false);
+      }
+    },
+    [],
+  );
 
   const exportImage = useCallback(async (imageUri: string | null) => {
     if (!imageUri || imageUri === PLACEHOLDER_IMAGE_URI) {
@@ -164,8 +171,8 @@ export function useBadgeExport() {
       }
 
       setIsExportingJSON(true);
-      const safeName = goalTitle.replace(/[^a-zA-Z0-9-_]/g, "-").slice(0, 40);
-      const tempUri = `${cacheDir}badge-${safeName}-${Date.now()}.json`;
+      const safeName = slugifyBadgeName(goalTitle);
+      const tempUri = `${cacheDir}${safeName}-${Date.now()}.json`;
       try {
         const canShare = await Sharing.isAvailableAsync();
         if (!canShare) {

--- a/apps/native-rd/src/hooks/useCreateBadge.ts
+++ b/apps/native-rd/src/hooks/useCreateBadge.ts
@@ -319,7 +319,7 @@ export function useCreateBadge(
         // to placeholder so badge creation still succeeds without a baked image.
         let imageUri = PLACEHOLDER_IMAGE_URI;
         try {
-          imageUri = await saveBadgePNG(bakedPng);
+          imageUri = await saveBadgePNG(bakedPng, goalTitle);
         } catch (imageErr) {
           logger.error("Badge image save failed, using placeholder", {
             goalId,

--- a/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
@@ -437,7 +437,7 @@ function BadgeDetailContent({
             <Button
               label={t("badgeDetail:actions.exportVerifiable")}
               variant="primary"
-              onPress={() => exportVerifiableBadge(imageUri)}
+              onPress={() => exportVerifiableBadge(imageUri, goalTitle)}
               loading={isExportingImage}
               disabled={!hasRealImage}
             />

--- a/apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx
@@ -292,6 +292,7 @@ describe("BadgeDetailScreen", () => {
       fireEvent.press(screen.getByLabelText("Export Verifiable Badge"));
       expect(mockExportVerifiableBadge).toHaveBeenCalledWith(
         "file:///badges/badge.png",
+        "Learn TypeScript",
       );
     });
 
@@ -331,6 +332,7 @@ describe("BadgeDetailScreen", () => {
       expect(mockExportVerifiableBadge).toHaveBeenCalledTimes(1);
       expect(mockExportVerifiableBadge).toHaveBeenCalledWith(
         "file:///badges/badge.png",
+        "Learn TypeScript",
       );
     });
 


### PR DESCRIPTION
## Summary

- Saved and exported badge PNGs are now named after the goal title (e.g. `learn-typescript-….png`) instead of an opaque `{timestamp}-{random}.png`, so the filename users see in the iOS share sheet / Android file picker is meaningful.
- Adds a shared `slugifyBadgeName` helper and routes both the on-disk save path and the Android SAF export through it.

## Changes

- **`src/badges/badgeFilename.ts`** (new) — `slugifyBadgeName`: turns a title into a filesystem- and share-sheet-safe slug. Strips characters outside `[a-zA-Z0-9-_]`, collapses separators, caps length, and falls back to `"badge"` when nothing usable remains (emoji-only, non-Latin scripts, empty).
- **`src/badges/badgeStorage.ts`** — `saveBadgePNG` accepts the badge name and writes `{slug}-{timestamp}-{random}.png`. The timestamp+random suffix is retained so re-bakes and same-titled badges can't collide or overwrite each other. Because iOS shares the on-disk file directly, this also fixes the iOS export filename.
- **`src/hooks/useCreateBadge.ts`** — passes the goal title through to `saveBadgePNG`.
- **`src/hooks/useBadgeExport.ts`** — Android verifiable-badge export writes a fresh file via SAF and can't inherit the on-disk name, so the goal title is threaded through `exportVerifiableBadge` and the copy is named `{slug}.png`. Also swaps the JSON credential export's inline sanitiser for the shared `slugifyBadgeName` helper.
- **`src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx`** — passes the `goalTitle` already in scope to `exportVerifiableBadge`.

## Test Plan

- [x] Type-check passes (`bun run type-check`)
- [x] Lint passes (`bun run lint`)
- [x] Tests pass (`bun test` — 180 suites / 8974 tests)
- [x] Build script (no-op for native-rd) — N/A

---

Generated with [Claude Code](https://claude.ai/code)