### PR TITLE
refactor(native-rd): unify sub-step leaf-resolution + orphan-promotion into one helper (#337)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-337-leaf-resolver.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-337-leaf-resolver.md
@@ -1,0 +1,230 @@
+# Development Plan: Issue #337
+
+## Issue Summary
+
+**Title**: A-reading: unify sub-step leaf-resolution + orphan-promotion into one helper
+**Type**: refactor (tech-debt)
+**Complexity**: SMALL
+**Estimated Lines**: ~130 lines (helper ~40 + unit tests ~60 + consumer deltas ~30)
+
+## Intent Verification
+
+Observable criteria derived from the issue.
+
+- [x] `apps/native-rd/src/db/queries.ts` exports a single `resolveNextActionableStep` helper that encodes both leaf-resolution and orphan-promotion in one place.
+- [x] `findFirstPendingLeafIndex` in `FocusModeScreen.tsx` delegates to the helper; its own bucketing loop is deleted.
+- [x] `buildGoalCardGoal`'s bucketing loop in `GoalsScreen.tsx` is deleted and replaced by a call to the helper.
+- [x] All existing sub-step tests in `FocusModeScreen.test.tsx` (`describe("sub-steps (#292)")`) and `GoalsScreen.test.tsx` (`describe("sub-step next-step resolution")`) pass unmodified — no test fixtures or assertions change. (Each screen's `jest.mock("../../../db")` gained a faithful `resolveNextActionableStep` copy — a mock-setup addition, not a fixture/assertion change.)
+- [x] `bun run type-check` and `bun run lint` exit clean (lint: 0 errors; only pre-existing warnings in untouched files).
+- [x] No behaviour change: full suite green — 179 suites / 8968 tests; leaf / invite / flat / orphan / interleaved-query-order / completed-parent-pending-child all preserved.
+
+## Dependencies
+
+No dependencies. Issue body does not mention blockers. Parent epic #288 is the overarching sub-steps epic; #292 (which shipped the duplicated logic) is already merged.
+
+| Issue | Title                                             | Status | Type         |
+| ----- | ------------------------------------------------- | ------ | ------------ |
+| #292  | Goal card, FocusMode snap, MiniTimeline sub-spine | Merged | context only |
+| #288  | Epic: sub-steps (A: substructure)                 | Open   | parent epic  |
+
+**Status**: All dependencies met.
+
+## Objective
+
+Extract the "next actionable step" resolution logic (leaf / invite / flat / orphan-promotion) that is currently copy-pasted in `FocusModeScreen.tsx:findFirstPendingLeafIndex` (lines 104-148) and `GoalsScreen.tsx:buildGoalCardGoal` (lines 50-99) into a single exported helper in `src/db/queries.ts`. Both screens then delegate to it. No query changes; no behaviour changes.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                     | Alternatives Considered                                                                       | Rationale                                                                                                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Helper operates on a minimal `{ id, parentStepId, status }` shape, not `StepRowLike`                                                                         | Widen `stepsForActiveGoalsQuery` so GoalsScreen could call `groupStepsByParent` directly      | `stepsForActiveGoalsQuery` intentionally omits `ordinal`, `completedAt`, and `plannedEvidenceTypes` to prevent an N+1 on the home screen. There is no other pressure to widen it, so the issue's own preference ("minimal-shape resolver is PREFERRED") applies. |
+| D2  | Helper lives in `src/db/queries.ts` alongside `groupStepsByParent` / `flattenGroupedSteps`                                                                   | New file `src/db/stepResolver.ts`                                                             | The existing grouping helpers are already here and already exported from the `src/db/index.ts` barrel. A separate file buys no clarity at this size and adds an extra import path.                                                                               |
+| D3  | Helper returns a discriminated union `{ kind: 'leaf' \| 'invite' \| 'flat' \| 'none'; index: number; ... }` rather than two separate functions               | Return just the flat index (FocusMode need) or just the title/context pair (GoalsScreen need) | Both consumers can derive everything they need from one call. A discriminated return makes the three states explicit, eliminates the implicit "no pending child → check parent" chain, and makes tests easier to read.                                           |
+| D4  | FocusModeScreen's `findFirstPendingLeafIndex` is converted to a thin wrapper that calls the helper and extracts `index`, keeping its public signature intact | Rename the function at call sites                                                             | Only one call site (`useEffect` line 319); still, keeping the local wrapper name avoids touching the test mock comment that references it. The wrapper is a one-liner and will be a TODO-comment candidate for a later cleanup.                                  |
+
+## Affected Areas
+
+- `apps/native-rd/src/db/queries.ts`: add `resolveNextActionableStep` (and its input type `NextActionableInput`) + export via barrel
+- `apps/native-rd/src/db/index.ts`: add `resolveNextActionableStep` and `NextActionableInput` to the re-exports
+- `apps/native-rd/src/db/__tests__/queries.step.test.ts`: new `describe("resolveNextActionableStep")` block covering all six cases
+- `apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx`: replace the body of `findFirstPendingLeafIndex` with a delegate call
+- `apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx`: replace the bucketing block inside `buildGoalCardGoal` with a delegate call
+
+## Implementation Plan
+
+### Step 1: Add `resolveNextActionableStep` helper + unit tests
+
+**Files**:
+
+- `apps/native-rd/src/db/queries.ts`
+- `apps/native-rd/src/db/index.ts`
+- `apps/native-rd/src/db/__tests__/queries.step.test.ts`
+
+**Commit**: `refactor(db): add resolveNextActionableStep — single leaf/invite/flat/orphan resolver`
+
+**Changes**:
+
+- [ ] Define the minimal input type directly above the helper in `queries.ts`:
+
+  ```typescript
+  /** Minimal step shape that resolveNextActionableStep requires. */
+  export interface NextActionableInput {
+    id: string;
+    parentStepId: string | null;
+    status: string | null;
+  }
+  ```
+
+- [ ] Define the discriminated result type:
+
+  ```typescript
+  export type NextActionableResult =
+    | { kind: "leaf"; index: number; parentId: string }
+    | { kind: "invite"; index: number; childCount: number }
+    | { kind: "flat"; index: number }
+    | { kind: "none" };
+  ```
+
+- [ ] Implement `resolveNextActionableStep`:
+
+  ```typescript
+  /**
+   * Resolve the single next actionable step for a goal given a flat row array.
+   *
+   * Encodes the orphan-promotion rule (mirrors groupStepsByParent): a row whose
+   * parentStepId is not a present top-level step surfaces as top-level so its
+   * pending work stays reachable (#292).
+   *
+   * Handles four states:
+   *   leaf   — first pending child under a top-level step
+   *   invite — all children done, parent still pending
+   *   flat   — pending top-level step with no children
+   *   none   — nothing pending
+   *
+   * @param rows Flat, already-ordered rows (ordinal, createdAt).
+   */
+  export function resolveNextActionableStep(
+    rows: readonly NextActionableInput[],
+  ): NextActionableResult { ... }
+  ```
+
+  The body mirrors the logic currently in both consumers:
+  1. Build `rootIds` (rows where `parentStepId == null`).
+  2. Walk `rows` to bucket `childrenByParent` and `topLevel` using the same orphan-promotion rule both consumers already use.
+  3. Iterate `topLevel`; for each step find its first pending child. If found, return `{ kind: 'leaf', index: <flat index of child>, parentId: step.id }`. If no pending child and parent is completed, `continue`. If no pending child and parent is pending and has children, return `{ kind: 'invite', index: <flat index of step>, childCount: children.length }`. If no pending child and parent is pending and has no children, return `{ kind: 'flat', index: <flat index of step> }`.
+  4. Return `{ kind: 'none' }`.
+
+  The flat `index` values are the row's position in the original `rows` array (same semantics as `findFirstPendingLeafIndex` today).
+
+- [ ] Export from `src/db/index.ts`:
+
+  ```typescript
+  resolveNextActionableStep,
+  type NextActionableInput,
+  type NextActionableResult,
+  ```
+
+  (Add to the "Step" section of the existing barrel.)
+
+- [ ] Add `describe("resolveNextActionableStep")` block in `queries.step.test.ts` with `test.each` cases covering:
+  - empty rows → `{ kind: 'none' }`
+  - flat goal, all pending → `{ kind: 'flat', index: 0 }`
+  - flat goal, first step completed, second pending → `{ kind: 'flat', index: 1 }`
+  - leaf state (first pending child) → `{ kind: 'leaf', index: <child flat index>, parentId: ... }`
+  - partial leaf (earlier sibling completed) → `{ kind: 'leaf', index: <second child flat index> }`
+  - invite state (all children done, parent pending) → `{ kind: 'invite', index: <parent flat index>, childCount: N }`
+  - orphan (parent absent) → promotes to top-level, returns `{ kind: 'flat', index: <orphan flat index> }`
+  - interleaved-query-order (child ordinal before parent) → correct flat index after bucketing
+  - completed parent with pending child → `{ kind: 'leaf', ... }` (not skipped on parent status)
+  - all steps completed → `{ kind: 'none' }`
+
+  These mirror the named sub-step test fixtures in `FocusModeScreen.test.tsx` (`LEAF_STEPS`, `INVITE_STEPS`, `INTERLEAVED_STEPS`, `PARTIAL_LEAF_STEPS`, `ORPHAN_STEPS`, `COMPLETED_PARENT_PENDING_CHILD_STEPS`) so the unit tests are directly traceable to the existing screen integration tests.
+
+### Step 2: Refactor FocusModeScreen consumer
+
+**Files**: `apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx`
+
+**Commit**: `refactor(focus-mode): delegate findFirstPendingLeafIndex to resolveNextActionableStep`
+
+**Changes**:
+
+- [ ] Add `resolveNextActionableStep` to the import from `../../db` (line 44-56 import block).
+- [ ] Replace the body of `findFirstPendingLeafIndex` (lines 114-148, the entire `rootIds` / `childrenByParent` / `topLevel` walk) with:
+  ```typescript
+  function findFirstPendingLeafIndex(
+    rows: readonly {
+      id: string;
+      parentStepId: string | null;
+      status: string | null;
+    }[],
+  ): number {
+    const result = resolveNextActionableStep(rows);
+    return result.kind === "none" ? -1 : result.index;
+  }
+  ```
+  The function signature is unchanged; call site at line 319 (`findFirstPendingLeafIndex(stepRows)`) is unchanged.
+- [ ] Verify: `FocusModeScreen.tsx` no longer contains a `rootIds`/`childrenByParent`/`topLevel` bucketing loop.
+
+### Step 3: Refactor GoalsScreen consumer
+
+**Files**: `apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx`
+
+**Commit**: `refactor(goals-screen): delegate buildGoalCardGoal bucketing to resolveNextActionableStep`
+
+**Changes**:
+
+- [ ] Add `resolveNextActionableStep` to the `../../db` import (line 15-21 import block).
+- [ ] Delete the `rootIds` / `childrenByParent` / `topLevel` bucketing block (lines 50-63) and the `for (const step of topLevel)` resolution loop (lines 72-99) inside `buildGoalCardGoal`.
+- [ ] Replace with a call to `resolveNextActionableStep(steps)` and a `switch` (or `if/else`) on `result.kind`:
+
+  ```typescript
+  const result = resolveNextActionableStep(steps);
+  let nextStepTitle: string | null = null;
+  let nextStepContext: string | null = null;
+  if (result.kind === "leaf") {
+    const leaf = steps[result.index];
+    const parent = steps.find((s) => s.id === result.parentId);
+    nextStepTitle = leaf?.title ?? null;
+    nextStepContext = t("goals:card.nextStepContext", {
+      parent: parent?.title ?? "",
+    });
+  } else if (result.kind === "flat") {
+    nextStepTitle = steps[result.index]?.title ?? null;
+  } else if (result.kind === "invite") {
+    const parent = steps[result.index];
+    nextStepTitle = parent?.title ?? null;
+    nextStepContext = t("goals:card.allSubstepsDone", {
+      count: result.childCount,
+    });
+  }
+  // kind === 'none': both stay null
+  ```
+
+  Note: `buildGoalCardGoal` receives the per-goal slice (`steps: readonly StepRow[]`), so `steps.find` is still scoped to one goal. `result.parentId` is the id of the container parent (present in `steps` for the leaf case), so `steps.find` is O(n) over a small per-goal slice.
+
+- [ ] Verify: `GoalsScreen.tsx` no longer contains a `rootIds`/`childrenByParent`/`topLevel` bucketing loop.
+
+## Testing Strategy
+
+- [x] Unit tests for `resolveNextActionableStep` in `apps/native-rd/src/db/__tests__/queries.step.test.ts` — one `describe` block, `test.each` for nine named cases. No new file. (`bun test`'s native runner trips on RN Flow types here; ran via `npx jest --no-coverage` per `CLAUDE.md`.)
+- [x] Existing screen tests are the regression gate: `FocusModeScreen.test.tsx` (62 tests) and `GoalsScreen.test.tsx` (25 tests) pass unchanged — no fixture or assertion changes (only the faithful mock copy added).
+- [x] Ran the full native-rd suite via jest: **179 suites / 8968 tests, all green.**
+- [ ] Manual smoke check (NOT run — autonomous flow, no simulator): open FocusMode on a goal with sub-steps and confirm the carousel snaps to the first pending leaf; open GoalsScreen and confirm the next-step line reads the leaf title + parent context. Covered by the screen integration tests above; left for the reviewer / `/verify` if a device check is wanted.
+
+## Not in Scope
+
+| Item                                                                                                                                                                | Reason                                                                                                                       | Follow-up                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Widen `stepsForActiveGoalsQuery` to full `StepRowLike`                                                                                                              | Design tension in issue resolves to minimal-shape resolver (D1 above)                                                        | none                                                     |
+| Moving the FocusModeScreen test mock (`groupStepsByParent` / `flattenGroupedSteps` faithful copies in the `jest.mock('../../../db')` block) to use the real helpers | Out of scope; mock structure is load-bearing for other tests in that file                                                    | Could be a follow-up cleanup once the refactor is stable |
+| Removing the `findFirstPendingLeafIndex` wrapper function entirely                                                                                                  | Its one call site is trivial to update, but keeping the named function preserves the self-documenting intent at the use site | Future cleanup, track in PR review if desired            |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+
+- [2026-06-21] Type names: shipped as `NextActionableStepInput` / `NextActionableStep` (plan proposed `NextActionableInput` / `NextActionableResult`). The `…Step` suffix reads consistently with the `resolveNextActionableStep` function name. Behaviour identical.
+- [2026-06-21] Test-mock copies: both screen tests mock `../../../db` with faithful inline copies of the pure helpers (`groupStepsByParent`, `flattenGroupedSteps`). Because `findFirstPendingLeafIndex` / `buildGoalCardGoal` now call `resolveNextActionableStep` from that module, each mock gained a faithful `resolveNextActionableStep` copy too — otherwise the delegated call resolves to `undefined`. No fixture or assertion changed; this is the established mock pattern in those files.
+- [2026-06-21] Orphan-promotion "one place" scope: among the next-step resolvers it is now unified into `resolveNextActionableStep`. `groupStepsByParent` still independently encodes the rule for tree-building — unifying the two is out of scope per D1 (different output shapes; the minimal-query rows lack the full `StepRowLike` fields `groupStepsByParent` needs).

--- a/apps/native-rd/src/db/__tests__/queries.step.test.ts
+++ b/apps/native-rd/src/db/__tests__/queries.step.test.ts
@@ -16,6 +16,7 @@ import {
   reorderSubSteps,
   groupStepsByParent,
   flattenGroupedSteps,
+  resolveNextActionableStep,
   type GroupedStep,
 } from "../queries";
 import { evolu } from "../evolu";
@@ -284,6 +285,84 @@ describe("Step CRUD Operations", () => {
     test("flat goal round-trips unchanged", () => {
       const grouped = groupStepsByParent([row("a", null), row("b", null)]);
       expect(flattenGroupedSteps(grouped).map((s) => s.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("resolveNextActionableStep", () => {
+    // Cases mirror the named sub-step fixtures in FocusModeScreen.test.tsx and
+    // GoalsScreen.test.tsx so the unit-level resolver stays traceable to the
+    // #292 screen behaviour it now backs (#337). `index` is the position in the
+    // input array; the wiring (`s2a` shapes) matches those screen tests.
+    test.each([
+      ["empty goal → none", [], { kind: "none" }],
+      [
+        "flat goal, all pending → first step is the flat next action",
+        [row("a", null), row("b", null)],
+        { kind: "flat", index: 0 },
+      ],
+      [
+        "flat goal, first completed → next pending flat step",
+        [row("a", null, { status: "completed" }), row("b", null)],
+        { kind: "flat", index: 1 },
+      ],
+      [
+        "leaf state: first pending child (earlier sibling already done)",
+        [
+          row("s1", null, { status: "completed" }),
+          row("s2", null),
+          row("s2a", "s2", { status: "completed" }),
+          row("s2b", "s2"),
+          row("s2c", "s2"),
+          row("s3", null),
+        ],
+        { kind: "leaf", index: 3, parentId: "s2" },
+      ],
+      [
+        "invite state: all children done, parent still pending",
+        [
+          row("s1", null, { status: "completed" }),
+          row("s2", null),
+          row("s2a", "s2", { status: "completed" }),
+          row("s2b", "s2", { status: "completed" }),
+          row("s2c", "s2", { status: "completed" }),
+          row("s3", null),
+        ],
+        { kind: "invite", index: 1, childCount: 3 },
+      ],
+      [
+        "orphan (parent absent) is promoted and read as a flat step",
+        [row("s1", null, { status: "completed" }), row("s2a", "s2")],
+        { kind: "flat", index: 1 },
+      ],
+      [
+        "interleaved query order: child before parent still indexes the child",
+        [
+          row("s2a", "s2"),
+          row("s1", null, { status: "completed" }),
+          row("s2", null),
+        ],
+        { kind: "leaf", index: 0, parentId: "s2" },
+      ],
+      [
+        "pending leaf under a manually-completed parent still wins",
+        [
+          row("s1", null, { status: "completed" }),
+          row("s2", null, { status: "completed" }),
+          row("s2a", "s2"),
+        ],
+        { kind: "leaf", index: 2, parentId: "s2" },
+      ],
+      [
+        "all steps completed → none",
+        [
+          row("s1", null, { status: "completed" }),
+          row("s2", null, { status: "completed" }),
+          row("s2a", "s2", { status: "completed" }),
+        ],
+        { kind: "none" },
+      ],
+    ])("%s", (_label, rows, expected) => {
+      expect(resolveNextActionableStep(rows)).toEqual(expected);
     });
   });
 

--- a/apps/native-rd/src/db/__tests__/queries.step.test.ts
+++ b/apps/native-rd/src/db/__tests__/queries.step.test.ts
@@ -315,7 +315,7 @@ describe("Step CRUD Operations", () => {
           row("s2c", "s2"),
           row("s3", null),
         ],
-        { kind: "leaf", index: 3, parentId: "s2" },
+        { kind: "leaf", index: 3, parentIndex: 1 },
       ],
       [
         "invite state: all children done, parent still pending",
@@ -341,7 +341,7 @@ describe("Step CRUD Operations", () => {
           row("s1", null, { status: "completed" }),
           row("s2", null),
         ],
-        { kind: "leaf", index: 0, parentId: "s2" },
+        { kind: "leaf", index: 0, parentIndex: 2 },
       ],
       [
         "pending leaf under a manually-completed parent still wins",
@@ -350,7 +350,7 @@ describe("Step CRUD Operations", () => {
           row("s2", null, { status: "completed" }),
           row("s2a", "s2"),
         ],
-        { kind: "leaf", index: 2, parentId: "s2" },
+        { kind: "leaf", index: 2, parentIndex: 1 },
       ],
       [
         "all steps completed → none",

--- a/apps/native-rd/src/db/index.ts
+++ b/apps/native-rd/src/db/index.ts
@@ -25,6 +25,7 @@ export {
   stepsByGoalQuery,
   groupStepsByParent,
   flattenGroupedSteps,
+  resolveNextActionableStep,
   isPendingStep,
   findFirstPendingIndex,
   createStep,
@@ -62,4 +63,8 @@ export {
   clearUserSettingsKey,
   markWelcomeSeen,
 } from "./queries";
-export type { GroupedStep } from "./queries";
+export type {
+  GroupedStep,
+  NextActionableStep,
+  NextActionableStepInput,
+} from "./queries";

--- a/apps/native-rd/src/db/queries.ts
+++ b/apps/native-rd/src/db/queries.ts
@@ -446,9 +446,10 @@ export interface NextActionableStepInput {
 
 /**
  * The single next actionable step, tagged by which of the four states it is.
- * `index` is the position of the actionable row in the input `rows` array.
+ * Both `index` and `parentIndex` are positions in the input `rows` array, so a
+ * caller maps either straight back to a row via `rows[...]`.
  *
- * - `leaf`   — first pending child under a top-level step; `parentId` is the
+ * - `leaf`   — first pending child under a top-level step; `parentIndex` is the
  *              container step (use it for the "↳ in [parent]" context line).
  * - `invite` — all of a pending parent's children are done; `childCount` is how
  *              many are done (use it for the "all N substeps done" readout).
@@ -456,7 +457,7 @@ export interface NextActionableStepInput {
  * - `none`   — nothing is pending.
  */
 export type NextActionableStep =
-  | { kind: "leaf"; index: number; parentId: string }
+  | { kind: "leaf"; index: number; parentIndex: number }
   | { kind: "invite"; index: number; childCount: number }
   | { kind: "flat"; index: number }
   | { kind: "none" };
@@ -510,7 +511,7 @@ export function resolveNextActionableStep(
     );
     // A pending leaf wins even under a completed parent — its work isn't hidden.
     if (pendingChild) {
-      return { kind: "leaf", index: pendingChild.index, parentId: step.id };
+      return { kind: "leaf", index: pendingChild.index, parentIndex: step.index }; // prettier-ignore
     }
     // No pending child: skip once the step itself is complete (a flat step, or
     // a parent whose subtree is fully done). Otherwise it's the next action.

--- a/apps/native-rd/src/db/queries.ts
+++ b/apps/native-rd/src/db/queries.ts
@@ -437,6 +437,94 @@ export function flattenGroupedSteps(
   return out;
 }
 
+/** Minimal step shape {@link resolveNextActionableStep} reads. */
+export interface NextActionableStepInput {
+  id: string;
+  parentStepId: string | null;
+  status: string | null;
+}
+
+/**
+ * The single next actionable step, tagged by which of the four states it is.
+ * `index` is the position of the actionable row in the input `rows` array.
+ *
+ * - `leaf`   — first pending child under a top-level step; `parentId` is the
+ *              container step (use it for the "↳ in [parent]" context line).
+ * - `invite` — all of a pending parent's children are done; `childCount` is how
+ *              many are done (use it for the "all N substeps done" readout).
+ * - `flat`   — a pending top-level step with no children.
+ * - `none`   — nothing is pending.
+ */
+export type NextActionableStep =
+  | { kind: "leaf"; index: number; parentId: string }
+  | { kind: "invite"; index: number; childCount: number }
+  | { kind: "flat"; index: number }
+  | { kind: "none" };
+
+/**
+ * Resolve the single next actionable step for one goal from a flat row array.
+ * Pure — no Evolu calls. Shared by FocusModeScreen (which wants the carousel
+ * index) and GoalsScreen (which wants the next-step title + context), so the
+ * leaf/invite/flat bucketing and its orphan-promotion rule live in one place
+ * (#337) rather than being copy-pasted into each screen.
+ *
+ * Orphan promotion mirrors {@link groupStepsByParent}: a row whose
+ * `parentStepId` is not a present top-level step (parent null, soft-deleted, or
+ * itself a child) surfaces as top-level so its pending work stays reachable.
+ * Without it a deleted parent would hide its children (#292).
+ *
+ * A pending child wins *before* its parent's own status is checked, so a
+ * manually completed parent that still has pending sub-steps doesn't hide them
+ * — step completion is per-step, not cascaded (see {@link completeStep}). A
+ * completed top-level step with no pending child is skipped (subtree closed).
+ *
+ * @param rows Flat rows for a single goal, in the order callers want
+ *   "first pending" to mean (e.g. `(ordinal, createdAt)`-ordered).
+ */
+export function resolveNextActionableStep(
+  rows: readonly NextActionableStepInput[],
+): NextActionableStep {
+  const rootIds = new Set(
+    rows.filter((r) => r.parentStepId == null).map((r) => r.id),
+  );
+  const childrenByParent = new Map<
+    string,
+    { index: number; status: string | null }[]
+  >();
+  const topLevel: { id: string; index: number; status: string | null }[] = [];
+  rows.forEach((row, index) => {
+    if (row.parentStepId != null && rootIds.has(row.parentStepId)) {
+      const entry = { index, status: row.status };
+      const list = childrenByParent.get(row.parentStepId);
+      if (list) list.push(entry);
+      else childrenByParent.set(row.parentStepId, [entry]);
+    } else {
+      topLevel.push({ id: row.id, index, status: row.status });
+    }
+  });
+
+  for (const step of topLevel) {
+    const children = childrenByParent.get(step.id) ?? [];
+    const pendingChild = children.find(
+      (c) => c.status !== StepStatus.completed,
+    );
+    // A pending leaf wins even under a completed parent — its work isn't hidden.
+    if (pendingChild) {
+      return { kind: "leaf", index: pendingChild.index, parentId: step.id };
+    }
+    // No pending child: skip once the step itself is complete (a flat step, or
+    // a parent whose subtree is fully done). Otherwise it's the next action.
+    if (step.status === StepStatus.completed) continue;
+    // Still pending: a parent whose children are all done is the invite state;
+    // a step with no children is a flat pending step.
+    if (children.length > 0) {
+      return { kind: "invite", index: step.index, childCount: children.length };
+    }
+    return { kind: "flat", index: step.index };
+  }
+  return { kind: "none" };
+}
+
 /**
  * Create a new step for a goal
  * @param goalId - Goal ID

--- a/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/FocusModeScreen.tsx
@@ -51,6 +51,7 @@ import {
   isPendingStep,
   groupStepsByParent,
   flattenGroupedSteps,
+  resolveNextActionableStep,
   EvidenceType,
   StepStatus,
 } from "../../db";
@@ -91,15 +92,10 @@ const EVIDENCE_ROUTE_MAP: Partial<
 
 /**
  * Index (into the flat `stepRows`) of the first pending *leaf* to snap to on
- * mount (#292). Mirrors the goal card's resolution: walk top-level steps in
- * order and return the first pending child (a leaf) — or the parent itself when
- * it is a flat pending step or in the invite state (all children done, parent
- * still pending). Returns -1 when nothing is pending.
- *
- * Pending children are checked *before* the parent's own status, so a manually
- * completed parent that still has pending sub-steps doesn't hide them — step
- * completion is per-step, not cascaded (see completeStep), so this is reachable.
- * A completed parent whose children are all done is skipped (subtree closed).
+ * mount (#292), or -1 when nothing is pending. Thin adapter over the shared
+ * {@link resolveNextActionableStep}: leaf, invite, and flat all resolve to the
+ * actionable row's flat index, and the orphan-promotion rule lives in the
+ * resolver — so FocusMode and the goal card can't drift apart (#337).
  */
 function findFirstPendingLeafIndex(
   rows: readonly {
@@ -108,43 +104,8 @@ function findFirstPendingLeafIndex(
     status: string | null;
   }[],
 ): number {
-  // A row is a child only if its parent is a present top-level step. A null
-  // parent — or an orphan whose parent was soft-deleted — surfaces as top-level
-  // so its pending work stays reachable. Mirrors groupStepsByParent's orphan
-  // promotion (#292); without it a deleted parent would hide its children.
-  const rootIds = new Set(
-    rows.filter((r) => r.parentStepId == null).map((r) => r.id),
-  );
-  const childrenByParent = new Map<
-    string,
-    { index: number; status: string | null }[]
-  >();
-  const topLevel: { id: string; index: number; status: string | null }[] = [];
-  rows.forEach((row, index) => {
-    if (row.parentStepId != null && rootIds.has(row.parentStepId)) {
-      const entry = { index, status: row.status };
-      const list = childrenByParent.get(row.parentStepId);
-      if (list) list.push(entry);
-      else childrenByParent.set(row.parentStepId, [entry]);
-    } else {
-      topLevel.push({ id: row.id, index, status: row.status });
-    }
-  });
-
-  for (const step of topLevel) {
-    const children = childrenByParent.get(step.id) ?? [];
-    const pendingChild = children.find(
-      (c) => c.status !== StepStatus.completed,
-    );
-    // A pending leaf wins even under a completed parent — its work isn't hidden.
-    if (pendingChild) return pendingChild.index;
-    // No pending child: skip once the step itself is complete (a flat step, or a
-    // parent whose subtree is fully done). Otherwise it's the next action — a
-    // flat pending step, or the invite state (children all done, parent pending).
-    if (step.status === StepStatus.completed) continue;
-    return step.index;
-  }
-  return -1;
+  const result = resolveNextActionableStep(rows);
+  return result.kind === "none" ? -1 : result.index;
 }
 
 function FocusContent({ goalId }: { goalId: string }) {

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -181,7 +181,7 @@ jest.mock("../../../db", () => ({
       const children = childrenByParent.get(step.id) ?? [];
       const pendingChild = children.find((c) => c.status !== "completed");
       if (pendingChild) {
-        return { kind: "leaf", index: pendingChild.index, parentId: step.id };
+        return { kind: "leaf", index: pendingChild.index, parentIndex: step.index }; // prettier-ignore
       }
       if (step.status === "completed") continue;
       if (children.length > 0) {

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -149,6 +149,48 @@ jest.mock("../../../db", () => ({
     }
     return out;
   },
+  // Faithful copy of the real resolver (leaf/invite/flat/none + orphan
+  // promotion) so findFirstPendingLeafIndex's delegation is exercised, not
+  // stubbed — keeps the #292 snap behaviour under test after the #337 extract.
+  resolveNextActionableStep: (
+    rows: readonly {
+      id: string;
+      parentStepId: string | null;
+      status: string | null;
+    }[],
+  ) => {
+    const rootIds = new Set(
+      rows.filter((r) => r.parentStepId == null).map((r) => r.id),
+    );
+    const childrenByParent = new Map<
+      string,
+      { index: number; status: string | null }[]
+    >();
+    const topLevel: { id: string; index: number; status: string | null }[] = [];
+    rows.forEach((row, index) => {
+      if (row.parentStepId != null && rootIds.has(row.parentStepId)) {
+        const entry = { index, status: row.status };
+        const list = childrenByParent.get(row.parentStepId);
+        if (list) list.push(entry);
+        else childrenByParent.set(row.parentStepId, [entry]);
+      } else {
+        topLevel.push({ id: row.id, index, status: row.status });
+      }
+    });
+    for (const step of topLevel) {
+      const children = childrenByParent.get(step.id) ?? [];
+      const pendingChild = children.find((c) => c.status !== "completed");
+      if (pendingChild) {
+        return { kind: "leaf", index: pendingChild.index, parentId: step.id };
+      }
+      if (step.status === "completed") continue;
+      if (children.length > 0) {
+        return { kind: "invite", index: step.index, childCount: children.length }; // prettier-ignore
+      }
+      return { kind: "flat", index: step.index };
+    }
+    return { kind: "none" };
+  },
 }));
 
 const mockUseQuery = jest.fn();

--- a/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
+++ b/apps/native-rd/src/screens/FocusModeScreen/__tests__/FocusModeScreen.test.tsx
@@ -152,6 +152,7 @@ jest.mock("../../../db", () => ({
   // Faithful copy of the real resolver (leaf/invite/flat/none + orphan
   // promotion) so findFirstPendingLeafIndex's delegation is exercised, not
   // stubbed — keeps the #292 snap behaviour under test after the #337 extract.
+  // Keep in sync with resolveNextActionableStep in src/db/queries.ts.
   resolveNextActionableStep: (
     rows: readonly {
       id: string;

--- a/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx
@@ -56,9 +56,8 @@ function buildGoalCardGoal(
   let nextStepContext: string | null = null;
   if (next.kind === "leaf") {
     nextStepTitle = steps[next.index]?.title ?? null;
-    const parent = steps.find((s) => s.id === next.parentId);
     nextStepContext = t("goals:card.nextStepContext", {
-      parent: parent?.title ?? "",
+      parent: steps[next.parentIndex]?.title ?? "",
     });
   } else if (next.kind === "invite") {
     nextStepTitle = steps[next.index]?.title ?? null;

--- a/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/GoalsScreen.tsx
@@ -14,6 +14,7 @@ import { Logger } from "../../shims/rd-logger";
 import {
   activeGoalsQuery,
   stepsForActiveGoalsQuery,
+  resolveNextActionableStep,
   deleteGoal,
   GoalStatus,
   StepStatus,
@@ -40,63 +41,34 @@ function buildGoalCardGoal(
     (s) => s.status === StepStatus.completed,
   ).length;
 
-  // Reconstruct the parent → children hierarchy by bucketing on parentStepId.
-  // Flat query order is preserved within each bucket so "first pending" is
-  // stable; it is not relied on for hierarchy (child ordinals are
-  // sibling-scoped and can collide with top-level ordinals). A step counts as a
-  // child only when its parent is a present top-level step — a null parent or an
-  // orphan (parent soft-deleted) surfaces as top-level so its pending work stays
-  // reachable, mirroring groupStepsByParent's orphan promotion (#292).
-  const rootIds = new Set(
-    steps.filter((s) => s.parentStepId == null).map((s) => s.id),
-  );
-  const childrenByParent = new Map<string, StepRow[]>();
-  const topLevel: StepRow[] = [];
-  for (const step of steps) {
-    if (step.parentStepId != null && rootIds.has(step.parentStepId)) {
-      const list = childrenByParent.get(step.parentStepId);
-      if (list) list.push(step);
-      else childrenByParent.set(step.parentStepId, [step]);
-    } else {
-      topLevel.push(step);
-    }
-  }
-
-  // Resolve the single next-action line, mirroring the prototype's nextInfo():
-  // the first non-completed top-level step is a flat step (hero = its title),
-  // a pending leaf (hero = first pending child + "↳ in [parent]" context), or
-  // the invite state (all children done, parent still pending — hero = parent
-  // + "all N substeps done" readout, never a state change).
+  // Resolve the single next-action line via the shared resolver (#337), which
+  // owns the leaf/invite/flat bucketing and orphan promotion (a soft-deleted
+  // parent surfaces its child as top-level so its pending work stays reachable,
+  // mirroring groupStepsByParent, #292). The resolver returns an index into
+  // `steps`, so the per-goal slice maps the result straight back to titles:
+  //   leaf   → the pending child is the hero, the container parent is context
+  //   invite → the pending parent is the hero, "all N substeps done" is context
+  //   flat   → a pending top-level step is its own hero (no context)
+  // A pending leaf wins even under a manually completed parent — completion is
+  // per-step, not cascaded, so a done parent must not hide live sub-work.
+  const next = resolveNextActionableStep(steps);
   let nextStepTitle: string | null = null;
   let nextStepContext: string | null = null;
-  for (const step of topLevel) {
-    const children = childrenByParent.get(step.id) ?? [];
-    const pendingChild = children.find(
-      (c) => c.status !== StepStatus.completed,
-    );
-    // A pending leaf is the next action even under a manually completed parent
-    // — step completion is per-step, not cascaded, so a done parent must not
-    // hide pending sub-work.
-    if (pendingChild) {
-      nextStepTitle = pendingChild.title ?? null;
-      nextStepContext = t("goals:card.nextStepContext", {
-        parent: step.title ?? "",
-      });
-      break;
-    }
-    // No pending child: skip the step entirely once it's complete (a flat step,
-    // or a parent whose whole subtree is done).
-    if (step.status === StepStatus.completed) continue;
-    // Still pending: a flat step is its own hero (no context); a parent whose
-    // children are all done is the invite state.
-    nextStepTitle = step.title ?? null;
-    if (children.length > 0) {
-      nextStepContext = t("goals:card.allSubstepsDone", {
-        count: children.length,
-      });
-    }
-    break;
+  if (next.kind === "leaf") {
+    nextStepTitle = steps[next.index]?.title ?? null;
+    const parent = steps.find((s) => s.id === next.parentId);
+    nextStepContext = t("goals:card.nextStepContext", {
+      parent: parent?.title ?? "",
+    });
+  } else if (next.kind === "invite") {
+    nextStepTitle = steps[next.index]?.title ?? null;
+    nextStepContext = t("goals:card.allSubstepsDone", {
+      count: next.childCount,
+    });
+  } else if (next.kind === "flat") {
+    nextStepTitle = steps[next.index]?.title ?? null;
   }
+  // kind === "none": no pending work, both lines stay null.
 
   return {
     id: goalRow.id,

--- a/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
@@ -73,7 +73,7 @@ jest.mock("../../../db", () => ({
       const children = childrenByParent.get(step.id) ?? [];
       const pendingChild = children.find((c) => c.status !== "completed");
       if (pendingChild) {
-        return { kind: "leaf", index: pendingChild.index, parentId: step.id };
+        return { kind: "leaf", index: pendingChild.index, parentIndex: step.index }; // prettier-ignore
       }
       if (step.status === "completed") continue;
       if (children.length > 0) {

--- a/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
@@ -41,6 +41,48 @@ jest.mock("../../../db", () => ({
   isPendingStep: (s: { status: string | null }) => s.status === "pending",
   GoalStatus: { active: "active", completed: "completed" },
   StepStatus: { pending: "pending", completed: "completed" },
+  // Faithful copy of the real resolver (leaf/invite/flat/none + orphan
+  // promotion) so buildGoalCardGoal's next-step resolution is exercised, not
+  // stubbed — keeps the #292 sub-step cases under test after the #337 extract.
+  resolveNextActionableStep: (
+    rows: readonly {
+      id: string;
+      parentStepId: string | null;
+      status: string | null;
+    }[],
+  ) => {
+    const rootIds = new Set(
+      rows.filter((r) => r.parentStepId == null).map((r) => r.id),
+    );
+    const childrenByParent = new Map<
+      string,
+      { index: number; status: string | null }[]
+    >();
+    const topLevel: { id: string; index: number; status: string | null }[] = [];
+    rows.forEach((row, index) => {
+      if (row.parentStepId != null && rootIds.has(row.parentStepId)) {
+        const entry = { index, status: row.status };
+        const list = childrenByParent.get(row.parentStepId);
+        if (list) list.push(entry);
+        else childrenByParent.set(row.parentStepId, [entry]);
+      } else {
+        topLevel.push({ id: row.id, index, status: row.status });
+      }
+    });
+    for (const step of topLevel) {
+      const children = childrenByParent.get(step.id) ?? [];
+      const pendingChild = children.find((c) => c.status !== "completed");
+      if (pendingChild) {
+        return { kind: "leaf", index: pendingChild.index, parentId: step.id };
+      }
+      if (step.status === "completed") continue;
+      if (children.length > 0) {
+        return { kind: "invite", index: step.index, childCount: children.length }; // prettier-ignore
+      }
+      return { kind: "flat", index: step.index };
+    }
+    return { kind: "none" };
+  },
 }));
 
 const { deleteGoal } = require("../../../db");

--- a/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/__tests__/GoalsScreen.test.tsx
@@ -44,6 +44,7 @@ jest.mock("../../../db", () => ({
   // Faithful copy of the real resolver (leaf/invite/flat/none + orphan
   // promotion) so buildGoalCardGoal's next-step resolution is exercised, not
   // stubbed — keeps the #292 sub-step cases under test after the #337 extract.
+  // Keep in sync with resolveNextActionableStep in src/db/queries.ts.
   resolveNextActionableStep: (
     rows: readonly {
       id: string;


### PR DESCRIPTION
## Summary

- Pure refactor (#337): #292 copy-pasted the same "next actionable step + orphan-promotion" bucketing into two screens. This extracts it into one shared, pure helper and has both screens delegate to it.
- New `resolveNextActionableStep` in `src/db/queries.ts` (beside `groupStepsByParent`/`flattenGroupedSteps`) returns a tagged union `{ kind: 'leaf' | 'invite' | 'flat' | 'none', … }` with positions into the caller's input array.
- No behaviour change — leaf / invite / flat / orphan / interleaved-query-order / completed-parent-pending-leaf all produce identical results.

## Changes

- **`src/db/queries.ts`** — add `resolveNextActionableStep` + types `NextActionableStep` / `NextActionableStepInput` (minimal `{ id, parentStepId, status }` shape, so the home screen's minimal query feed needs no widening).
- **`src/db/index.ts`** — export the helper and its types via the barrel.
- **`FocusModeScreen.tsx`** — `findFirstPendingLeafIndex` is now a 2-line adapter (`none → -1`, else `result.index`); its inline bucketing loop is deleted.
- **`GoalsScreen.tsx`** — `buildGoalCardGoal` deletes its bucketing loop and maps the tagged result to `nextStepTitle`/`nextStepContext`.
- **Tests** — new `describe("resolveNextActionableStep")` unit block (9 `test.each` cases mirroring the named #292 screen fixtures); both screen test mocks gain a faithful resolver copy so delegation stays exercised, not stubbed.

## Intent Verification

- [x] `src/db/queries.ts` exports a single `resolveNextActionableStep` helper that encodes both leaf-resolution and orphan-promotion in one place.
- [x] `findFirstPendingLeafIndex` and `buildGoalCardGoal` both delegate to it; their duplicated bucketing loops are deleted.
- [x] Existing #292 behaviour preserved — full suite green (179 suites / 8968 tests); leaf / invite / flat / orphan / interleaved / completed-parent-pending-leaf all covered, no fixtures or assertions changed (each screen mock gained a faithful resolver copy — a mock-setup addition only).
- [x] Type-check + lint clean (0 errors; only pre-existing warnings in untouched files).

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Minimal `{ id, parentStepId, status }` input shape, not `StepRowLike` | `stepsForActiveGoalsQuery` deliberately omits `ordinal`/`completedAt`/`plannedEvidenceTypes` to avoid an N+1 on the home screen; the issue prefers the minimal-shape resolver. |
| Helper lives in `src/db/queries.ts` beside the other grouping helpers | Colocating with `groupStepsByParent` keeps the mirrored orphan-promotion rule from drifting; no new file/import path. |
| Discriminated union return (`leaf`/`invite`/`flat`/`none`) | Each consumer derives what it needs from one call; the three actionable states are explicit. |
| `leaf` carries `parentIndex: number` (not `parentId`) | The resolver already holds the parent's flat index while bucketing; returning it lets GoalsScreen read `steps[next.parentIndex]?.title` (O(1)) instead of an O(n) `steps.find(...)` re-scan per goal card. Uniformly position-based union. (Surfaced by the `/simplify` pass.) |
| `groupStepsByParent` retains its own orphan promotion | Unifying the two is out of scope — different output shapes (tree vs. index) and the minimal query rows lack the fields `groupStepsByParent` requires. Among the *next-step resolvers*, the rule is now in exactly one place. |

## Discovery Log

- [2026-06-21] Type names shipped as `NextActionableStepInput` / `NextActionableStep` (plan proposed `NextActionableInput` / `NextActionableResult`) — `…Step` reads consistently with the function name.
- [2026-06-21] Both screen tests mock `../../../db` with a literal factory, so each gained a faithful `resolveNextActionableStep` copy (a factory can't reference the real module); a sync-reminder comment points back to `queries.ts`. No fixture/assertion changed.
- [2026-06-21] `/simplify` pass (efficiency + altitude, unanimous): `leaf.parentId: string` → `parentIndex: number`, dropping the per-card `steps.find(...)` re-scan.

## Test Plan

- [x] Type-check passes
- [x] Lint passes (0 errors)
- [x] Tests pass (179 suites / 8968 tests; resolver unit block + #292 screen regression suites green)
- [x] Build script (no-op for native-rd) returns successfully

> Not run: manual simulator smoke check (autonomous flow). Behaviour is covered by the FocusMode/Goals integration suites; a device check can be done at review via `/verify` if wanted.

---

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)