### PR TITLE
docs(native-rd): test command is `bun run test`, not `bun test`

### DIFF
--- a/apps/native-rd/AGENTS.md
+++ b/apps/native-rd/AGENTS.md
@@ -49,13 +49,13 @@ src/
 
 ## Development Commands
 
-| Command              | Purpose                                       |
-| -------------------- | --------------------------------------------- |
-| `bun run type-check` | TypeScript type checking                      |
-| `bun run lint`       | ESLint                                        |
-| `bun test`           | Run Jest test suite                           |
-| `bun run test:ci`    | CI test run                                   |
-| `npx expo run:ios`   | Build and run on iOS (NEVER use `expo start`) |
+| Command              | Purpose                                              |
+| -------------------- | ---------------------------------------------------- |
+| `bun run type-check` | TypeScript type checking                             |
+| `bun run lint`       | ESLint                                               |
+| `bun run test`       | Run Jest test suite (Node-wrapped; never `bun test`) |
+| `bun run test:ci`    | CI test run                                          |
+| `npx expo run:ios`   | Build and run on iOS (NEVER use `expo start`)        |
 
 ## App Legibility Commands
 

--- a/apps/native-rd/CLAUDE.md
+++ b/apps/native-rd/CLAUDE.md
@@ -17,7 +17,7 @@ This is the native rollercoaster.dev app — a personal learning/goal tracker fo
 | --------- | -------------------------------------------------------------------------------- |
 | Typecheck | `bun run type-check`                                                             |
 | Lint      | `bun run lint`                                                                   |
-| Test      | `npx jest --no-coverage` or `bun test --testPathPatterns <pattern>`              |
+| Test      | `bun run test` (scope with `--testPathPatterns <pattern>`) — never `bun test`    |
 | CI test   | `bun run test:ci`                                                                |
 | Build iOS | `npx expo run:ios` (sim) or `bun run ios` (uses `.env.local` for device default) |
 
@@ -28,6 +28,7 @@ This is the native rollercoaster.dev app — a personal learning/goal tracker fo
 ## Tests
 
 - Jest 30, `@testing-library/react-native` v13
+- **Run with `bun run test`** — it goes through `scripts/jest-node.sh`, which runs Jest under real Node. Plain `jest`/`npx jest` and `bun test` (Bun's own runner) both reintroduce Bun/Jest runtime failures. See `README.md`.
 - Use `--testPathPatterns` (plural, not `--testPathPattern`)
 - Test files live in `src/__tests__/` mirroring `src/` structure
 - Use `test.each` instead of duplicating tests that follow the same pattern
@@ -106,8 +107,8 @@ Badge logic lives in `@rollercoaster-dev/openbadges-core` (workspace package at 
 
 ## After Making Changes
 
-| Changed           | Run                                     |
-| ----------------- | --------------------------------------- |
-| React Native code | `npx expo run:ios` (native build)       |
-| Test files        | `bun test --testPathPatterns <pattern>` |
-| Theme/style files | Build + visually verify on device       |
+| Changed           | Run                                         |
+| ----------------- | ------------------------------------------- |
+| React Native code | `npx expo run:ios` (native build)           |
+| Test files        | `bun run test --testPathPatterns <pattern>` |
+| Theme/style files | Build + visually verify on device           |


### PR DESCRIPTION
## What

Three places in the native-rd agent docs listed `bun test` as the test command, contradicting the authoritative `README.md:65-68`:

- `apps/native-rd/CLAUDE.md:20` (Commands table)
- `apps/native-rd/CLAUDE.md:112` (After Making Changes table)
- `apps/native-rd/AGENTS.md:56` (Development Commands table)

## Why

`README.md` is explicit: native-rd uses Jest, not Bun's test runner. The package test script runs `scripts/jest-node.sh` so Jest executes under **real Node** even though the repo sets `[run] bun = true` for other CLIs. Both `bun test` (Bun's own runner) and plain `jest`/`npx jest` reintroduce Bun/Jest runtime failures. The contradicting doc lines kept steering agents onto the broken path.

## Changes

- Reconcile all three lines to `bun run test`.
- Add a one-line runner note to the CLAUDE.md **Tests** section pointing at the README.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)