### PR TITLE
fix(native-rd): load Storybook fonts from relative paths

### DIFF
--- a/apps/native-rd/.storybook-web/preview.tsx
+++ b/apps/native-rd/.storybook-web/preview.tsx
@@ -1,4 +1,4 @@
-// Must configure unistyles before any component imports
+// Configure Unistyles early so stories render with the app theme.
 import { StyleSheet, UnistylesRuntime } from "react-native-unistyles";
 import { themes } from "../src/themes";
 

--- a/apps/native-rd/.storybook-web/preview.tsx
+++ b/apps/native-rd/.storybook-web/preview.tsx
@@ -1,6 +1,12 @@
 // Must configure unistyles before any component imports
-import { StyleSheet } from "react-native-unistyles";
+import { StyleSheet, UnistylesRuntime } from "react-native-unistyles";
 import { themes } from "../src/themes";
+
+import type { Preview } from "@storybook/react";
+import React from "react";
+import { ScrollView } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { themeNames, type ThemeName } from "../src/themes";
 
 StyleSheet.configure({
   themes,
@@ -9,31 +15,24 @@ StyleSheet.configure({
   },
 });
 
-import type { Preview } from "@storybook/react";
-import React from "react";
-import { ScrollView } from "react-native";
-import { SafeAreaProvider } from "react-native-safe-area-context";
-import { UnistylesRuntime } from "react-native-unistyles";
-import { themeNames, type ThemeName } from "../src/themes";
-
 const FONT_FACE_CSS = `
-@font-face { font-family: 'Anybody'; font-weight: 400; font-display: swap; src: url('/fonts/anybody-400.woff2') format('woff2'); }
-@font-face { font-family: 'Anybody'; font-weight: 700; font-display: swap; src: url('/fonts/anybody-700.woff2') format('woff2'); }
-@font-face { font-family: 'Anybody'; font-weight: 900; font-display: swap; src: url('/fonts/anybody-900.woff2') format('woff2'); }
-@font-face { font-family: 'DM Mono'; font-weight: 400; font-display: swap; src: url('/fonts/dm-mono-400.woff2') format('woff2'); }
-@font-face { font-family: 'DM Mono'; font-weight: 500; font-display: swap; src: url('/fonts/dm-mono-500.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 400; font-display: swap; src: url('/fonts/instrument-sans-400.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 500; font-display: swap; src: url('/fonts/instrument-sans-500.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 600; font-display: swap; src: url('/fonts/instrument-sans-600.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 700; font-display: swap; src: url('/fonts/instrument-sans-700.woff2') format('woff2'); }
-@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 400; font-display: swap; src: url('/fonts/AtkinsonHyperlegible-Regular.ttf') format('truetype'); }
-@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 700; font-display: swap; src: url('/fonts/AtkinsonHyperlegible-Bold.ttf') format('truetype'); }
-@font-face { font-family: 'OpenDyslexic'; font-weight: 400; font-display: swap; src: url('/fonts/OpenDyslexic-Regular.otf') format('opentype'); }
-@font-face { font-family: 'OpenDyslexic'; font-weight: 700; font-display: swap; src: url('/fonts/OpenDyslexic-Bold.otf') format('opentype'); }
-@font-face { font-family: 'Lexend'; font-weight: 400; font-display: swap; src: url('/fonts/Lexend-Regular.woff2') format('woff2'); }
-@font-face { font-family: 'Lexend'; font-weight: 500; font-display: swap; src: url('/fonts/Lexend-Medium.woff2') format('woff2'); }
-@font-face { font-family: 'Lexend'; font-weight: 600; font-display: swap; src: url('/fonts/Lexend-SemiBold.woff2') format('woff2'); }
-@font-face { font-family: 'Lexend'; font-weight: 700; font-display: swap; src: url('/fonts/Lexend-Bold.woff2') format('woff2'); }
+@font-face { font-family: 'Anybody'; font-weight: 400; font-display: swap; src: url('./fonts/anybody-400.woff2') format('woff2'); }
+@font-face { font-family: 'Anybody'; font-weight: 700; font-display: swap; src: url('./fonts/anybody-700.woff2') format('woff2'); }
+@font-face { font-family: 'Anybody'; font-weight: 900; font-display: swap; src: url('./fonts/anybody-900.woff2') format('woff2'); }
+@font-face { font-family: 'DM Mono'; font-weight: 400; font-display: swap; src: url('./fonts/dm-mono-400.woff2') format('woff2'); }
+@font-face { font-family: 'DM Mono'; font-weight: 500; font-display: swap; src: url('./fonts/dm-mono-500.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 400; font-display: swap; src: url('./fonts/instrument-sans-400.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 500; font-display: swap; src: url('./fonts/instrument-sans-500.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 600; font-display: swap; src: url('./fonts/instrument-sans-600.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 700; font-display: swap; src: url('./fonts/instrument-sans-700.woff2') format('woff2'); }
+@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 400; font-display: swap; src: url('./fonts/AtkinsonHyperlegible-Regular.ttf') format('truetype'); }
+@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 700; font-display: swap; src: url('./fonts/AtkinsonHyperlegible-Bold.ttf') format('truetype'); }
+@font-face { font-family: 'OpenDyslexic'; font-weight: 400; font-display: swap; src: url('./fonts/OpenDyslexic-Regular.otf') format('opentype'); }
+@font-face { font-family: 'OpenDyslexic'; font-weight: 700; font-display: swap; src: url('./fonts/OpenDyslexic-Bold.otf') format('opentype'); }
+@font-face { font-family: 'Lexend'; font-weight: 400; font-display: swap; src: url('./fonts/Lexend-Regular.woff2') format('woff2'); }
+@font-face { font-family: 'Lexend'; font-weight: 500; font-display: swap; src: url('./fonts/Lexend-Medium.woff2') format('woff2'); }
+@font-face { font-family: 'Lexend'; font-weight: 600; font-display: swap; src: url('./fonts/Lexend-SemiBold.woff2') format('woff2'); }
+@font-face { font-family: 'Lexend'; font-weight: 700; font-display: swap; src: url('./fonts/Lexend-Bold.woff2') format('woff2'); }
 `;
 
 if (
@@ -46,8 +45,7 @@ if (
   document.head.appendChild(style);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const themeDecorator = (Story: React.ComponentType, context: any) => {
+const ThemeDecorator = (Story: React.ComponentType, context: any) => {
   const selectedTheme = context.globals?.theme as ThemeName | undefined;
 
   React.useEffect(() => {
@@ -80,7 +78,7 @@ const styles = StyleSheet.create((theme) => ({
 }));
 
 const preview: Preview = {
-  decorators: [themeDecorator],
+  decorators: [ThemeDecorator],
   globalTypes: {
     theme: {
       name: "Theme",

--- a/apps/native-rd/.storybook/preview.tsx
+++ b/apps/native-rd/.storybook/preview.tsx
@@ -7,23 +7,23 @@ import { themeNames, type ThemeName } from "../src/themes";
 import { EvoluAppProvider } from "../src/db/evolu";
 
 const FONT_FACE_CSS = `
-@font-face { font-family: 'Anybody'; font-weight: 400; font-display: swap; src: url('/fonts/anybody-400.woff2') format('woff2'); }
-@font-face { font-family: 'Anybody'; font-weight: 700; font-display: swap; src: url('/fonts/anybody-700.woff2') format('woff2'); }
-@font-face { font-family: 'Anybody'; font-weight: 900; font-display: swap; src: url('/fonts/anybody-900.woff2') format('woff2'); }
-@font-face { font-family: 'DM Mono'; font-weight: 400; font-display: swap; src: url('/fonts/dm-mono-400.woff2') format('woff2'); }
-@font-face { font-family: 'DM Mono'; font-weight: 500; font-display: swap; src: url('/fonts/dm-mono-500.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 400; font-display: swap; src: url('/fonts/instrument-sans-400.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 500; font-display: swap; src: url('/fonts/instrument-sans-500.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 600; font-display: swap; src: url('/fonts/instrument-sans-600.woff2') format('woff2'); }
-@font-face { font-family: 'Instrument Sans'; font-weight: 700; font-display: swap; src: url('/fonts/instrument-sans-700.woff2') format('woff2'); }
-@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 400; font-display: swap; src: url('/fonts/AtkinsonHyperlegible-Regular.ttf') format('truetype'); }
-@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 700; font-display: swap; src: url('/fonts/AtkinsonHyperlegible-Bold.ttf') format('truetype'); }
-@font-face { font-family: 'OpenDyslexic'; font-weight: 400; font-display: swap; src: url('/fonts/OpenDyslexic-Regular.otf') format('opentype'); }
-@font-face { font-family: 'OpenDyslexic'; font-weight: 700; font-display: swap; src: url('/fonts/OpenDyslexic-Bold.otf') format('opentype'); }
-@font-face { font-family: 'Lexend'; font-weight: 400; font-display: swap; src: url('/fonts/Lexend-Regular.woff2') format('woff2'); }
-@font-face { font-family: 'Lexend'; font-weight: 500; font-display: swap; src: url('/fonts/Lexend-Medium.woff2') format('woff2'); }
-@font-face { font-family: 'Lexend'; font-weight: 600; font-display: swap; src: url('/fonts/Lexend-SemiBold.woff2') format('woff2'); }
-@font-face { font-family: 'Lexend'; font-weight: 700; font-display: swap; src: url('/fonts/Lexend-Bold.woff2') format('woff2'); }
+@font-face { font-family: 'Anybody'; font-weight: 400; font-display: swap; src: url('./fonts/anybody-400.woff2') format('woff2'); }
+@font-face { font-family: 'Anybody'; font-weight: 700; font-display: swap; src: url('./fonts/anybody-700.woff2') format('woff2'); }
+@font-face { font-family: 'Anybody'; font-weight: 900; font-display: swap; src: url('./fonts/anybody-900.woff2') format('woff2'); }
+@font-face { font-family: 'DM Mono'; font-weight: 400; font-display: swap; src: url('./fonts/dm-mono-400.woff2') format('woff2'); }
+@font-face { font-family: 'DM Mono'; font-weight: 500; font-display: swap; src: url('./fonts/dm-mono-500.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 400; font-display: swap; src: url('./fonts/instrument-sans-400.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 500; font-display: swap; src: url('./fonts/instrument-sans-500.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 600; font-display: swap; src: url('./fonts/instrument-sans-600.woff2') format('woff2'); }
+@font-face { font-family: 'Instrument Sans'; font-weight: 700; font-display: swap; src: url('./fonts/instrument-sans-700.woff2') format('woff2'); }
+@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 400; font-display: swap; src: url('./fonts/AtkinsonHyperlegible-Regular.ttf') format('truetype'); }
+@font-face { font-family: 'Atkinson Hyperlegible'; font-weight: 700; font-display: swap; src: url('./fonts/AtkinsonHyperlegible-Bold.ttf') format('truetype'); }
+@font-face { font-family: 'OpenDyslexic'; font-weight: 400; font-display: swap; src: url('./fonts/OpenDyslexic-Regular.otf') format('opentype'); }
+@font-face { font-family: 'OpenDyslexic'; font-weight: 700; font-display: swap; src: url('./fonts/OpenDyslexic-Bold.otf') format('opentype'); }
+@font-face { font-family: 'Lexend'; font-weight: 400; font-display: swap; src: url('./fonts/Lexend-Regular.woff2') format('woff2'); }
+@font-face { font-family: 'Lexend'; font-weight: 500; font-display: swap; src: url('./fonts/Lexend-Medium.woff2') format('woff2'); }
+@font-face { font-family: 'Lexend'; font-weight: 600; font-display: swap; src: url('./fonts/Lexend-SemiBold.woff2') format('woff2'); }
+@font-face { font-family: 'Lexend'; font-weight: 700; font-display: swap; src: url('./fonts/Lexend-Bold.woff2') format('woff2'); }
 `;
 
 if (Platform.OS === "web" && typeof document !== "undefined") {
@@ -32,8 +32,7 @@ if (Platform.OS === "web" && typeof document !== "undefined") {
   document.head.appendChild(style);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const themeDecorator = (Story: React.ComponentType, context: any) => {
+const ThemeDecorator = (Story: React.ComponentType, context: any) => {
   const selectedTheme = context.globals?.theme as ThemeName | undefined;
 
   React.useEffect(() => {
@@ -68,7 +67,7 @@ const styles = StyleSheet.create((theme) => ({
 }));
 
 const preview: Preview = {
-  decorators: [themeDecorator],
+  decorators: [ThemeDecorator],
   globalTypes: {
     theme: {
       name: "Theme",


### PR DESCRIPTION
## Summary

- Fix published Storybook font loading on GitHub Pages by using relative font asset URLs.
- Update both web and native Storybook preview font-face declarations to avoid path drift.
- Fix preview decorator naming/import lint issues surfaced by the commit hook.

## Changes

- Replace root-relative `/fonts/...` URLs with `./fonts/...` in Storybook previews.
- Rename Storybook theme decorators to `ThemeDecorator` so hooks lint rules pass.
- Deduplicate the web preview `react-native-unistyles` import.

## Test Plan

- [x] `cd apps/native-rd && bunx eslint --fix --cache --config eslint.config.js .storybook/preview.tsx .storybook-web/preview.tsx`
- [x] `cd apps/native-rd && bun run storybook:web:build`
- [x] Commit hook ran lint-staged and root `bun run type-check`

## Notes

`storybook:web:build` still emits existing Vite `tsconfig-paths` warnings while scanning `.bun-cache` Expo package tsconfigs, but the build completes successfully.

Generated with pi.