### PR TITLE
feat(native-rd): add BadgeWallCell primitive + Storybook story (#403)

### DIFF
--- a/apps/native-rd/docs/plans/2026-06-29-full-ride-redesign-rescope.md
+++ b/apps/native-rd/docs/plans/2026-06-29-full-ride-redesign-rescope.md
@@ -59,11 +59,11 @@ Every screen redesign decomposes into these. The architecture is the one already
 
 > **Highest priority** — this work is designed, planned (#381 dev-plan Steps 4–7), and lost from the board. File fresh under #384.
 
-| Key | Type          | Title                               | Scope                                                                                                                                                          | N/R | ~LOC | Blocked by |
-| --- | ------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | ---- | ---------- |
-| A1  | `[Storybook]` | `BadgeCircleCell` primitive + story | 60×60 circular gallery cell: badge design via `BadgeRenderer` or initial fallback; `accessibilityRole="button"`, 44pt target                                   | NEW | 200  | —          |
-| A2  | `[Storybook]` | `BadgesWall` view + story           | Count header + "Just earned" spotlight + dense `FlatList` gallery (`numColumns`) + empty state. `AllThemesMatrix` story resolves the dark-wall token risk (D4) | NEW | 300  | A1         |
-| A3  | `[Integrate]` | `BadgesScreen` thin container       | `useQuery` → `BadgesWall` props + nav to `BadgeDetail`; container tests                                                                                        | —   | 150  | A2         |
+| Key | Type          | Title                             | Scope                                                                                                                                                                                                  | N/R | ~LOC | Blocked by |
+| --- | ------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | ---- | ---------- |
+| A1  | `[Storybook]` | `BadgeWallCell` primitive + story | 60px gallery cell: renders each badge in its OWN shape (circle/shield/star/hexagon) via `BadgeRenderer` — no circular clip; rounded-square initial fallback; `accessibilityRole="button"`, 44pt target | NEW | 200  | —          |
+| A2  | `[Storybook]` | `BadgesWall` view + story         | Count header + "Just earned" spotlight + dense `FlatList` gallery (`numColumns`) + empty state. `AllThemesMatrix` story resolves the dark-wall token risk (D4)                                         | NEW | 300  | A1         |
+| A3  | `[Integrate]` | `BadgesScreen` thin container     | `useQuery` → `BadgesWall` props + nav to `BadgeDetail`; container tests                                                                                                                                | —   | 150  | A2         |
 
 **Conditional (do not pre-file):** if A2's matrix shows full-black (`#000`/`#161616`) doesn't adapt in some theme, file a `badgeWall` per-theme surface token issue _then_ (epic: "don't pre-author the token"). Drop the prototype's `wall.moreCount` / "+N MORE" (D9 — wall = density, no cap).
 

--- a/apps/native-rd/docs/plans/dev-plans/issue-403-badgewallcell-primitive.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-403-badgewallcell-primitive.md
@@ -21,17 +21,17 @@ The whole `BadgeCircleCell` line of work (4 commits) was reset and rebuilt as **
 - [x] Touch target is at least 44×44pt (explicit `minWidth`/`minHeight: 44` floor on the `Pressable`; verified by test).
 - [x] An `AllThemesMatrix` story renders all 7 product themes side by side via `ScopedTheme`. Both rows vary per theme: the designed cell's shadow (dropped in highContrast/lowVision/autismFriendly) and stroke width (3 vs 4), and the undesigned tile's `accentPurple` fill + border.
 - [x] Zero hardcoded hex in `BadgeWallCell.tsx` / `BadgeWallCell.styles.ts` — all colors from `theme.*` tokens + `palette.white`.
-- [x] Unit tests pass (10/10); `BadgeWallCell` is not imported by any screen.
+- [x] Unit tests pass (13/13); `BadgeWallCell` is not imported by any screen.
 
 ## Decisions
 
-| ID  | Decision                                                                                                                                                | Rationale                                                                                                                                                                                                 |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| D1  | Render `<BadgeRenderer design={badge.design} size={60} />` directly inside the `Pressable` — **no** clipping `View`.                                    | The badge's shape IS the design. `BadgeRenderer` already paints shape + border + theme-aware hard shadow; clipping it into a circle defeats the wall. Simpler than the old clip + less code.              |
-| D2  | Do **not** pass `showShadow` — let `BadgeRenderer` derive it from the theme.                                                                            | The neo-brutalist wall wants the hard shadow in default/dark themes and none in highContrast/lowVision/autismFriendly. `BadgeRenderer`'s `theme.shadows.opacity > 0` default already does exactly this.   |
-| D3  | Null-design fallback is a **rounded square** (`borderRadius: 8`) with the title initial, bg `theme.colors.accentPurple`, 3px `theme.colors.border`.     | A null design has no shape — a square-ish tile is honest and stays visually distinct from real badges. Crucially **not** a circle (the exact mistake this rebuild fixes). Mirrors `BadgeCard`'s initials. |
-| D4  | `badge` prop typed `{ title: string; design: BadgeDesign \| null }` — minimal presentational subset.                                                    | Presentational primitive in `src/components/`; must not couple to a query row type. The parent (`BadgesWall`, A2) maps rows to this shape. `design` is nullable in the schema (`nullOr(NonEmptyString)`). |
-| D5  | Story title `"Badges/BadgeWallCell"`; `AllThemesMatrix` scopes the **real** component per theme via `ScopedTheme` (verified on web in the prior build). | Groups badge-domain primitives with `BadgeRenderer`. `ScopedTheme` was confirmed to scope per-column on the web Storybook target during the `BadgeCircleCell` build; the mechanism is unchanged.          |
+| ID  | Decision                                                                                                                                                                                | Rationale                                                                                                                                                                                                 |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Render `<BadgeRenderer design={badge.design} size={60} />` directly inside the `Pressable` — **no** clipping `View`.                                                                    | The badge's shape IS the design. `BadgeRenderer` already paints shape + border + theme-aware hard shadow; clipping it into a circle defeats the wall. Simpler than the old clip + less code.              |
+| D2  | Do **not** pass `showShadow` — let `BadgeRenderer` derive it from the theme.                                                                                                            | The neo-brutalist wall wants the hard shadow in default/dark themes and none in highContrast/lowVision/autismFriendly. `BadgeRenderer`'s `theme.shadows.opacity > 0` default already does exactly this.   |
+| D3  | Null-design fallback is a **rounded square** (`theme.radius.sm`) with the title initial, bg `theme.colors.accentPurple`, and border `theme.borderWidth.medium` / `theme.colors.border`. | A null design has no shape — a square-ish tile is honest and stays visually distinct from real badges. Crucially **not** a circle (the exact mistake this rebuild fixes). Mirrors `BadgeCard`'s initials. |
+| D4  | `badge` prop typed `{ title: string; design: BadgeDesign \| null }` — minimal presentational subset.                                                                                    | Presentational primitive in `src/components/`; must not couple to a query row type. The parent (`BadgesWall`, A2) maps rows to this shape. `design` is nullable in the schema (`nullOr(NonEmptyString)`). |
+| D5  | Story title `"Badges/BadgeWallCell"`; `AllThemesMatrix` scopes the **real** component per theme via `ScopedTheme` (verified on web in the prior build).                                 | Groups badge-domain primitives with `BadgeRenderer`. `ScopedTheme` was confirmed to scope per-column on the web Storybook target during the `BadgeCircleCell` build; the mechanism is unchanged.          |
 
 ## Affected Areas
 
@@ -39,7 +39,7 @@ The whole `BadgeCircleCell` line of work (4 commits) was reset and rebuilt as **
 - `src/components/BadgeWallCell/BadgeWallCell.styles.ts` — new styles
 - `src/components/BadgeWallCell/BadgeWallCell.stories.tsx` — new story (`WithDesign`, `Undesigned`, `Row`, `AllThemesMatrix`)
 - `src/components/BadgeWallCell/index.ts` — barrel export
-- `src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx` — 10 unit tests
+- `src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx` — 13 unit tests
 - `docs/plans/2026-06-29-full-ride-redesign-rescope.md` — A1 row renamed to BadgeWallCell
 
 No existing source files modified. No screen imports this component.
@@ -47,7 +47,7 @@ No existing source files modified. No screen imports this component.
 ## Testing Strategy
 
 - Unit tests: Jest 30, `@testing-library/react-native` v13, `renderWithProviders`. `BadgeRenderer` mocked to a host `View` with `testID="badge-renderer-mock"` (SVG not rendered by JSDOM) — its presence is the positive proof the shape renderer (not a clip/fallback) is used.
-- Run: `bun run test --testPathPatterns BadgeWallCell` (NEVER `bun test`). → 10/10.
+- Run: `bun run test --testPathPatterns BadgeWallCell` (NEVER `bun test`). → 13/13.
 - `bun run type-check` → clean. `bun run lint` → no BadgeWallCell findings.
 - **Storybook visual gate** (the real shape proof — SVG can't render under JSDOM): `bun run storybook:web` → `Badges/BadgeWallCell` → `Row` confirms circle/shield/star/hexagon render as their true silhouettes (no circular crop); `AllThemesMatrix` confirms per-theme shadow/border variation.
 
@@ -65,5 +65,5 @@ No existing source files modified. No screen imports this component.
 ### 2026-06-29 — rebuilt as BadgeWallCell — COMPLETE
 
 - User flagged that the shipped `BadgeCircleCell` clipped all badges into circles, contradicting the varied-shape badge vocabulary and the prototype's mixed-shape wall. Reset the 4 `BadgeCircleCell` commits, renamed the branch, rebuilt as `BadgeWallCell` (D1–D5).
-- Gates green: `type-check` ✓, `lint` (no BadgeWallCell findings) ✓, `test --testPathPatterns BadgeWallCell` → 10/10 ✓.
+- Gates green: `type-check` ✓, `lint` (no BadgeWallCell findings) ✓, `test --testPathPatterns BadgeWallCell` → 13/13 ✓.
 - Remaining: Storybook web visual confirmation of the shapes (manual gate).

--- a/apps/native-rd/docs/plans/dev-plans/issue-403-badgewallcell-primitive.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-403-badgewallcell-primitive.md
@@ -1,0 +1,69 @@
+# Development Plan: Issue #403
+
+## Issue Summary
+
+**Title**: [Storybook] BadgeWallCell primitive + story
+**Type**: enhancement
+**Complexity**: SMALL
+**Estimated Lines**: ~230 lines (component + styles + story incl. `AllThemesMatrix` + tests + index)
+
+## Course correction (2026-06-29)
+
+This issue was first built as **`BadgeCircleCell`** — a 60×60 `View` with `borderRadius: 30; overflow: hidden` that clipped **every** badge into a circle. That was wrong. Rollercoaster.dev badges have **distinct shapes** — `circle`, `shield`, `hexagon`, `roundedRect`, `star` (`BadgeShape` in `src/badges/types.ts`, rendered by `BadgeRenderer`/`BadgeShapeView`). The "wall of proof" in `prototypes/screen-redesign/Goals + Badges C Prototype.dc.html` shows a grid of **mixed** shapes, not a grid of circles. Clipping a shield/star/hexagon into a circle destroys the silhouette that makes the wall read.
+
+The whole `BadgeCircleCell` line of work (4 commits) was reset and rebuilt as **`BadgeWallCell`**, which renders each badge in its own shape. The branch was renamed `feat/issue-403-badge-circle-cell` → `feat/issue-403-badge-wall-cell` (no PR was open, so the rename was clean).
+
+## Intent Verification
+
+- [x] When `BadgeWallCell` receives a designed `badge`, it renders `BadgeRenderer` at 60px **with no circular clip** — the badge keeps its own shape (circle / shield / star / hexagon / roundedRect). Border + hard shadow come from `BadgeRenderer` and follow the active theme.
+- [x] When `badge.design` is `null`, it shows an initial-letter fallback in a **rounded-square** tile (NOT a circle), styled from theme tokens — an honest placeholder, since a null design has no shape to represent.
+- [x] Pressing the cell fires `onPress`; the accessible element has `accessibilityRole="button"` and an `accessibilityLabel` equal to the badge title.
+- [x] Touch target is at least 44×44pt (explicit `minWidth`/`minHeight: 44` floor on the `Pressable`; verified by test).
+- [x] An `AllThemesMatrix` story renders all 7 product themes side by side via `ScopedTheme`. Both rows vary per theme: the designed cell's shadow (dropped in highContrast/lowVision/autismFriendly) and stroke width (3 vs 4), and the undesigned tile's `accentPurple` fill + border.
+- [x] Zero hardcoded hex in `BadgeWallCell.tsx` / `BadgeWallCell.styles.ts` — all colors from `theme.*` tokens + `palette.white`.
+- [x] Unit tests pass (10/10); `BadgeWallCell` is not imported by any screen.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                | Rationale                                                                                                                                                                                                 |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Render `<BadgeRenderer design={badge.design} size={60} />` directly inside the `Pressable` — **no** clipping `View`.                                    | The badge's shape IS the design. `BadgeRenderer` already paints shape + border + theme-aware hard shadow; clipping it into a circle defeats the wall. Simpler than the old clip + less code.              |
+| D2  | Do **not** pass `showShadow` — let `BadgeRenderer` derive it from the theme.                                                                            | The neo-brutalist wall wants the hard shadow in default/dark themes and none in highContrast/lowVision/autismFriendly. `BadgeRenderer`'s `theme.shadows.opacity > 0` default already does exactly this.   |
+| D3  | Null-design fallback is a **rounded square** (`borderRadius: 8`) with the title initial, bg `theme.colors.accentPurple`, 3px `theme.colors.border`.     | A null design has no shape — a square-ish tile is honest and stays visually distinct from real badges. Crucially **not** a circle (the exact mistake this rebuild fixes). Mirrors `BadgeCard`'s initials. |
+| D4  | `badge` prop typed `{ title: string; design: BadgeDesign \| null }` — minimal presentational subset.                                                    | Presentational primitive in `src/components/`; must not couple to a query row type. The parent (`BadgesWall`, A2) maps rows to this shape. `design` is nullable in the schema (`nullOr(NonEmptyString)`). |
+| D5  | Story title `"Badges/BadgeWallCell"`; `AllThemesMatrix` scopes the **real** component per theme via `ScopedTheme` (verified on web in the prior build). | Groups badge-domain primitives with `BadgeRenderer`. `ScopedTheme` was confirmed to scope per-column on the web Storybook target during the `BadgeCircleCell` build; the mechanism is unchanged.          |
+
+## Affected Areas
+
+- `src/components/BadgeWallCell/BadgeWallCell.tsx` — new component
+- `src/components/BadgeWallCell/BadgeWallCell.styles.ts` — new styles
+- `src/components/BadgeWallCell/BadgeWallCell.stories.tsx` — new story (`WithDesign`, `Undesigned`, `Row`, `AllThemesMatrix`)
+- `src/components/BadgeWallCell/index.ts` — barrel export
+- `src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx` — 10 unit tests
+- `docs/plans/2026-06-29-full-ride-redesign-rescope.md` — A1 row renamed to BadgeWallCell
+
+No existing source files modified. No screen imports this component.
+
+## Testing Strategy
+
+- Unit tests: Jest 30, `@testing-library/react-native` v13, `renderWithProviders`. `BadgeRenderer` mocked to a host `View` with `testID="badge-renderer-mock"` (SVG not rendered by JSDOM) — its presence is the positive proof the shape renderer (not a clip/fallback) is used.
+- Run: `bun run test --testPathPatterns BadgeWallCell` (NEVER `bun test`). → 10/10.
+- `bun run type-check` → clean. `bun run lint` → no BadgeWallCell findings.
+- **Storybook visual gate** (the real shape proof — SVG can't render under JSDOM): `bun run storybook:web` → `Badges/BadgeWallCell` → `Row` confirms circle/shield/star/hexagon render as their true silhouettes (no circular crop); `AllThemesMatrix` confirms per-theme shadow/border variation.
+
+## Not in Scope
+
+| Item                                                  | Owner |
+| ----------------------------------------------------- | ----- |
+| `BadgesWall` view (count header, spotlight, FlatList) | A2    |
+| `BadgesScreen` container wiring                       | A3    |
+| `badgeWall` surface token decision                    | A2    |
+| Spotlight/glow animation                              | A2    |
+
+## Discovery Log
+
+### 2026-06-29 — rebuilt as BadgeWallCell — COMPLETE
+
+- User flagged that the shipped `BadgeCircleCell` clipped all badges into circles, contradicting the varied-shape badge vocabulary and the prototype's mixed-shape wall. Reset the 4 `BadgeCircleCell` commits, renamed the branch, rebuilt as `BadgeWallCell` (D1–D5).
+- Gates green: `type-check` ✓, `lint` (no BadgeWallCell findings) ✓, `test --testPathPatterns BadgeWallCell` → 10/10 ✓.
+- Remaining: Storybook web visual confirmation of the shapes (manual gate).

--- a/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.stories.tsx
+++ b/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ScrollView, Text, View } from "react-native";
+import { ScopedTheme, StyleSheet } from "react-native-unistyles";
+import { BadgeWallCell } from "./BadgeWallCell";
+import { BadgeShape, BadgeFrame, BadgeIconWeight } from "../../badges/types";
+import type { BadgeDesign } from "../../badges/types";
+import { themeNames, type ThemeName } from "../../themes/compose";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDesign(overrides: Partial<BadgeDesign> = {}): BadgeDesign {
+  return {
+    shape: BadgeShape.circle,
+    frame: BadgeFrame.none,
+    color: "#a78bfa",
+    iconName: "Trophy",
+    iconWeight: BadgeIconWeight.regular,
+    title: "Sample Badge",
+    centerMode: "icon" as const,
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+// Mirror of the (non-exported) MOOD_NAMES map in ContrastAudit.stories.tsx —
+// the human-facing mood label for each of the 7 product themes.
+const MOOD_NAMES: Record<ThemeName, string> = {
+  "light-default": "Full Ride",
+  "dark-default": "Night Ride",
+  "light-highContrast": "Bold Ink",
+  "light-dyslexia": "Warm Studio",
+  "light-autismFriendly": "Still Water",
+  "light-lowVision": "Loud & Clear",
+  "light-lowInfo": "Clean Signal",
+};
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof BadgeWallCell> = {
+  title: "Badges/BadgeWallCell",
+  component: BadgeWallCell,
+  args: { onPress: noop },
+};
+
+export default meta;
+type Story = StoryObj<typeof BadgeWallCell>;
+
+// ---------------------------------------------------------------------------
+// Single-state stories — viewable across themes via the web toolbar
+// ---------------------------------------------------------------------------
+
+export const WithDesign: Story = {
+  args: { badge: { title: "Sample Badge", design: makeDesign() } },
+};
+
+export const Undesigned: Story = {
+  args: { badge: { title: "Goal Title", design: null } },
+};
+
+// ---------------------------------------------------------------------------
+// Row — the dense gallery context. The whole point of #403: each badge keeps
+// its OWN shape (circle / shield / star / hexagon), with one undesigned tile.
+// Nothing is clipped into a circle.
+// ---------------------------------------------------------------------------
+
+const ROW_BADGES = [
+  { title: "Trophy", design: makeDesign({ iconName: "Trophy" }) },
+  {
+    title: "Shield",
+    design: makeDesign({ shape: BadgeShape.shield, iconName: "ShieldCheck" }),
+  },
+  {
+    title: "Star",
+    design: makeDesign({ shape: BadgeShape.star, iconName: "Star" }),
+  },
+  { title: "Undesigned Goal", design: null },
+  {
+    title: "Medal",
+    design: makeDesign({ shape: BadgeShape.hexagon, iconName: "Medal" }),
+  },
+];
+
+export const Row: Story = {
+  render: () => (
+    <View style={styles.row}>
+      {ROW_BADGES.map((badge) => (
+        <BadgeWallCell key={badge.title} badge={badge} onPress={noop} />
+      ))}
+    </View>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// AllThemesMatrix — all 7 product themes side by side at once. Each column
+// scopes the *real* BadgeWallCell to one theme via ScopedTheme.
+//
+// Both rows vary per theme:
+//  - designed cell: border thickness (3 vs 4 in highContrast/lowVision) and
+//    the hard shadow (present in default/dark, dropped in highContrast /
+//    lowVision / autismFriendly) come from BadgeRenderer + the active theme.
+//  - undesigned tile: its accentPurple fill + border track the theme.
+//
+// Label chrome follows the toolbar theme; only the cells are scoped.
+// ---------------------------------------------------------------------------
+
+export const AllThemesMatrix: Story = {
+  render: () => (
+    <ScrollView horizontal showsHorizontalScrollIndicator>
+      <View style={styles.matrix}>
+        {themeNames.map((name) => (
+          <View key={name} style={styles.column}>
+            <Text style={styles.columnTitle}>{MOOD_NAMES[name]}</Text>
+            <Text style={styles.columnKey}>{name}</Text>
+            <ScopedTheme name={name}>
+              <View style={styles.cellStack}>
+                <BadgeWallCell
+                  badge={{ title: name, design: makeDesign() }}
+                  onPress={noop}
+                />
+                <BadgeWallCell
+                  badge={{ title: name, design: null }}
+                  onPress={noop}
+                />
+              </View>
+            </ScopedTheme>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create((theme) => ({
+  row: {
+    flexDirection: "row",
+    gap: theme.space[3],
+    padding: theme.space[4],
+    alignItems: "center",
+  },
+  matrix: {
+    flexDirection: "row",
+    gap: theme.space[4],
+    padding: theme.space[4],
+  },
+  column: {
+    alignItems: "center",
+    gap: theme.space[1],
+  },
+  columnTitle: {
+    fontFamily: theme.fontFamily.headline,
+    fontSize: theme.size.sm,
+    fontWeight: theme.fontWeight.bold,
+    color: theme.colors.text,
+  },
+  columnKey: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+    marginBottom: theme.space[2],
+  },
+  cellStack: {
+    gap: theme.space[3],
+    alignItems: "center",
+  },
+}));

--- a/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.styles.ts
+++ b/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.styles.ts
@@ -1,0 +1,35 @@
+import { StyleSheet } from "react-native-unistyles";
+import { palette } from "../../themes/palette";
+
+/** Logical-pixel size each badge renders at in the wall grid. */
+const CELL_SIZE = 60;
+
+export const styles = StyleSheet.create((theme) => ({
+  // 44pt floor guarantees the touch target; the 60pt badge already clears it.
+  // No clip here — the badge keeps its own shape (the whole point of #403).
+  pressable: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // Undesigned fallback — a neutral ROUNDED SQUARE (not a circle): a null
+  // design has no shape to represent, so a square-ish tile is the honest
+  // placeholder. Border mirrors the badge stroke for a coherent wall.
+  fallback: {
+    width: CELL_SIZE,
+    height: CELL_SIZE,
+    borderRadius: 8,
+    backgroundColor: theme.colors.accentPurple,
+    borderWidth: 3,
+    borderColor: theme.colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  fallbackText: {
+    color: palette.white,
+    fontSize: 24,
+    fontWeight: theme.fontWeight.black,
+    fontFamily: theme.fontFamily.headline,
+  },
+}));

--- a/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.styles.ts
+++ b/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from "react-native-unistyles";
 import { palette } from "../../themes/palette";
 
 /** Logical-pixel size each badge renders at in the wall grid. */
-const CELL_SIZE = 60;
+export const CELL_SIZE = 60;
 
 export const styles = StyleSheet.create((theme) => ({
   // 44pt floor guarantees the touch target; the 60pt badge already clears it.

--- a/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.styles.ts
+++ b/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.styles.ts
@@ -19,9 +19,9 @@ export const styles = StyleSheet.create((theme) => ({
   fallback: {
     width: CELL_SIZE,
     height: CELL_SIZE,
-    borderRadius: 8,
+    borderRadius: theme.radius.sm,
     backgroundColor: theme.colors.accentPurple,
-    borderWidth: 3,
+    borderWidth: theme.borderWidth.medium,
     borderColor: theme.colors.border,
     alignItems: "center",
     justifyContent: "center",

--- a/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.tsx
+++ b/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.tsx
@@ -1,0 +1,56 @@
+import { View, Text, Pressable } from "react-native";
+import { BadgeRenderer } from "../../badges/BadgeRenderer";
+import type { BadgeDesign } from "../../badges/types";
+import { styles } from "./BadgeWallCell.styles";
+
+/** Logical-pixel size each badge renders at in the wall grid. */
+const CELL_SIZE = 60;
+
+/** Minimal presentational subset of a badge row this cell needs. */
+export interface BadgeWallCellBadge {
+  title: string;
+  design: BadgeDesign | null;
+}
+
+export interface BadgeWallCellProps {
+  badge: BadgeWallCellBadge;
+  onPress: () => void;
+  testID?: string;
+}
+
+/**
+ * BadgeWallCell — one pressable badge in the dense BadgesWall gallery (#403).
+ *
+ * Renders the badge in its OWN designed shape — circle, shield, star, hexagon,
+ * roundedRect — via {@link BadgeRenderer}. There is deliberately no circular
+ * clip: the wall is a "wall of proof" of distinct shapes, not a grid of
+ * identical circles. Border and hard shadow come from the renderer and follow
+ * the active theme (shadow dropped in highContrast / lowVision / autismFriendly).
+ *
+ * When a badge has no design yet, it falls back to an initial-letter tile in a
+ * neutral rounded square — NOT a circle. A null design has no shape to
+ * represent, so a square-ish placeholder is the honest stand-in (mirrors the
+ * initials pattern in BadgeCard) and stays visually distinct from real badges.
+ */
+export function BadgeWallCell({ badge, onPress, testID }: BadgeWallCellProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={badge.title}
+      style={styles.pressable}
+      testID={testID}
+    >
+      {badge.design ? (
+        <BadgeRenderer design={badge.design} size={CELL_SIZE} />
+      ) : (
+        <View style={styles.fallback}>
+          <Text style={styles.fallbackText}>
+            {(badge.title.charAt(0) || "?").toUpperCase()}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}

--- a/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.tsx
+++ b/apps/native-rd/src/components/BadgeWallCell/BadgeWallCell.tsx
@@ -1,10 +1,7 @@
 import { View, Text, Pressable } from "react-native";
 import { BadgeRenderer } from "../../badges/BadgeRenderer";
 import type { BadgeDesign } from "../../badges/types";
-import { styles } from "./BadgeWallCell.styles";
-
-/** Logical-pixel size each badge renders at in the wall grid. */
-const CELL_SIZE = 60;
+import { styles, CELL_SIZE } from "./BadgeWallCell.styles";
 
 /** Minimal presentational subset of a badge row this cell needs. */
 export interface BadgeWallCellBadge {
@@ -21,9 +18,10 @@ export interface BadgeWallCellProps {
 /**
  * BadgeWallCell — one pressable badge in the dense BadgesWall gallery (#403).
  *
- * Renders the badge in its OWN designed shape — circle, shield, star, hexagon,
- * roundedRect — via {@link BadgeRenderer}. There is deliberately no circular
- * clip: the wall is a "wall of proof" of distinct shapes, not a grid of
+ * Renders the badge in its OWN designed shape (circle, shield, star, hexagon,
+ * roundedRect, diamond — whatever {@link BadgeRenderer} supports). There is
+ * deliberately no circular clip: the wall is a "wall of proof" of distinct
+ * shapes, not a grid of
  * identical circles. Border and hard shadow come from the renderer and follow
  * the active theme (shadow dropped in highContrast / lowVision / autismFriendly).
  *

--- a/apps/native-rd/src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx
+++ b/apps/native-rd/src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx
@@ -53,36 +53,45 @@ describe("BadgeWallCell", () => {
     expect(screen.getByText("T")).toBeOnTheScreen();
   });
 
-  it("fires onPress when pressed", () => {
-    const onPress = jest.fn();
-    renderWithProviders(
-      <BadgeWallCell
-        badge={{ title: "Trophy Goal", design: null }}
-        onPress={onPress}
-      />,
-    );
-    fireEvent.press(screen.getByRole("button"));
-    expect(onPress).toHaveBeenCalledTimes(1);
-  });
+  // The Pressable and its a11y props live on the OUTER element, identical in
+  // both render branches — but the cell's primary real-world state is "has a
+  // design", so the press + a11y contracts are asserted through BOTH branches.
+  // A regression that moved them into the fallback branch would otherwise pass.
+  describe.each<[string, BadgeDesign | null]>([
+    ["with a design", design],
+    ["with a null design", null],
+  ])("press + a11y contracts (%s)", (_label, cellDesign) => {
+    it("fires onPress when pressed", () => {
+      const onPress = jest.fn();
+      renderWithProviders(
+        <BadgeWallCell
+          badge={{ title: "Trophy Goal", design: cellDesign }}
+          onPress={onPress}
+        />,
+      );
+      fireEvent.press(screen.getByRole("button"));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
 
-  it('has accessibilityRole="button"', () => {
-    renderWithProviders(
-      <BadgeWallCell
-        badge={{ title: "Trophy Goal", design: null }}
-        onPress={() => {}}
-      />,
-    );
-    expect(screen.getByRole("button")).toBeOnTheScreen();
-  });
+    it('has accessibilityRole="button"', () => {
+      renderWithProviders(
+        <BadgeWallCell
+          badge={{ title: "Trophy Goal", design: cellDesign }}
+          onPress={() => {}}
+        />,
+      );
+      expect(screen.getByRole("button")).toBeOnTheScreen();
+    });
 
-  it("uses the badge title as the accessibilityLabel", () => {
-    renderWithProviders(
-      <BadgeWallCell
-        badge={{ title: "Trophy Goal", design: null }}
-        onPress={() => {}}
-      />,
-    );
-    expect(screen.getByLabelText("Trophy Goal")).toBeOnTheScreen();
+    it("uses the badge title as the accessibilityLabel", () => {
+      renderWithProviders(
+        <BadgeWallCell
+          badge={{ title: "Trophy Goal", design: cellDesign }}
+          onPress={() => {}}
+        />,
+      );
+      expect(screen.getByLabelText("Trophy Goal")).toBeOnTheScreen();
+    });
   });
 
   it("guarantees a 44x44pt minimum touch target", () => {

--- a/apps/native-rd/src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx
+++ b/apps/native-rd/src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from "../../../__tests__/test-utils";
+import { BadgeWallCell } from "../BadgeWallCell";
+import type { BadgeDesign } from "../../../badges/types";
+
+// BadgeRenderer renders SVG, which JSDOM does not render — mock it to a host
+// View carrying a testID. Its presence proves the badge goes through the real
+// shape renderer rather than a circular clip / initials fallback.
+jest.mock("../../../badges/BadgeRenderer", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    BadgeRenderer: () =>
+      React.createElement(View, { testID: "badge-renderer-mock" }),
+  };
+});
+
+const design: BadgeDesign = {
+  shape: "shield",
+  frame: "none",
+  color: "#a78bfa",
+  iconName: "ShieldCheck",
+  iconWeight: "regular",
+  title: "Trophy Goal",
+  centerMode: "icon",
+};
+
+describe("BadgeWallCell", () => {
+  it("renders the badge through BadgeRenderer (its own shape) when a design is provided", () => {
+    renderWithProviders(
+      <BadgeWallCell
+        badge={{ title: "Trophy Goal", design }}
+        onPress={() => {}}
+      />,
+    );
+    // The shape-preserving renderer is used — no initial-letter fallback.
+    expect(screen.getByTestId("badge-renderer-mock")).toBeOnTheScreen();
+    expect(screen.queryByText(/^[A-Z]$/)).toBeNull();
+  });
+
+  it("renders the initial-letter fallback when design is null", () => {
+    renderWithProviders(
+      <BadgeWallCell
+        badge={{ title: "Trophy Goal", design: null }}
+        onPress={() => {}}
+      />,
+    );
+    expect(screen.getByText("T")).toBeOnTheScreen();
+  });
+
+  it("fires onPress when pressed", () => {
+    const onPress = jest.fn();
+    renderWithProviders(
+      <BadgeWallCell
+        badge={{ title: "Trophy Goal", design: null }}
+        onPress={onPress}
+      />,
+    );
+    fireEvent.press(screen.getByRole("button"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('has accessibilityRole="button"', () => {
+    renderWithProviders(
+      <BadgeWallCell
+        badge={{ title: "Trophy Goal", design: null }}
+        onPress={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button")).toBeOnTheScreen();
+  });
+
+  it("uses the badge title as the accessibilityLabel", () => {
+    renderWithProviders(
+      <BadgeWallCell
+        badge={{ title: "Trophy Goal", design: null }}
+        onPress={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Trophy Goal")).toBeOnTheScreen();
+  });
+
+  it("guarantees a 44x44pt minimum touch target", () => {
+    renderWithProviders(
+      <BadgeWallCell
+        badge={{ title: "Trophy Goal", design: null }}
+        onPress={() => {}}
+      />,
+    );
+    const flattened = StyleSheet.flatten(
+      screen.getByRole("button").props.style,
+    );
+    expect(flattened.minWidth).toBeGreaterThanOrEqual(44);
+    expect(flattened.minHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  describe("initial-letter fallback", () => {
+    it.each([
+      ["Trophy Goal", "T"],
+      ["apple", "A"],
+      ["zebra crossing", "Z"],
+      ["", "?"],
+    ])("title %p renders %p", (title, expected) => {
+      renderWithProviders(
+        <BadgeWallCell badge={{ title, design: null }} onPress={() => {}} />,
+      );
+      expect(screen.getByText(expected)).toBeOnTheScreen();
+    });
+  });
+});

--- a/apps/native-rd/src/components/BadgeWallCell/index.ts
+++ b/apps/native-rd/src/components/BadgeWallCell/index.ts
@@ -1,0 +1,2 @@
+export { BadgeWallCell } from "./BadgeWallCell";
+export type { BadgeWallCellProps, BadgeWallCellBadge } from "./BadgeWallCell";


### PR DESCRIPTION
## Summary

- Adds the `BadgeWallCell` presentational primitive — one pressable badge in the dense "wall of proof" BadgesWall gallery (#403).
- Renders each badge in its **own** designed shape (circle / shield / star / hexagon / roundedRect / diamond) via `BadgeRenderer` — **no circular clip**. A `null` design falls back to an initial-letter **rounded-square** tile (deliberately not a circle), mirroring `BadgeCard`'s initials.
- Storybook-gated primitive (`WithDesign`, `Undesigned`, `Row`, `AllThemesMatrix`); **not yet imported by any screen** — `BadgesWall` (A2) and `BadgesScreen` (A3) wiring are separate issues.

> Course correction: this issue first shipped as `BadgeCircleCell`, which clipped every badge into a circle and destroyed the silhouettes that make the wall read. Those 4 commits were reset and the work rebuilt as `BadgeWallCell`. Branch renamed `feat/issue-403-badge-circle-cell` → `feat/issue-403-badge-wall-cell` (no PR was open, so the rename was clean).

## Changes

- `src/components/BadgeWallCell/BadgeWallCell.tsx` — the component
- `src/components/BadgeWallCell/BadgeWallCell.styles.ts` — unistyles (exports the shared `CELL_SIZE`)
- `src/components/BadgeWallCell/BadgeWallCell.stories.tsx` — `WithDesign` / `Undesigned` / `Row` / `AllThemesMatrix`
- `src/components/BadgeWallCell/__tests__/BadgeWallCell.test.tsx` — 13 unit tests
- `src/components/BadgeWallCell/index.ts` — barrel export
- docs: per-issue dev plan + Full Ride rescope row renamed to BadgeWallCell

## Intent Verification

- [x] When `BadgeWallCell` receives a designed `badge`, it renders `BadgeRenderer` at 60px **with no circular clip** — the badge keeps its own shape (circle / shield / star / hexagon / roundedRect). Border + hard shadow come from `BadgeRenderer` and follow the active theme.
- [x] When `badge.design` is `null`, it shows an initial-letter fallback in a **rounded-square** tile (NOT a circle), styled from theme tokens — an honest placeholder, since a null design has no shape to represent.
- [x] Pressing the cell fires `onPress`; the accessible element has `accessibilityRole="button"` and an `accessibilityLabel` equal to the badge title.
- [x] Touch target is at least 44×44pt (explicit `minWidth`/`minHeight: 44` floor on the `Pressable`; verified by test).
- [x] An `AllThemesMatrix` story renders all 7 product themes side by side via `ScopedTheme`. Both rows vary per theme: the designed cell's shadow (dropped in highContrast/lowVision/autismFriendly) and stroke width (3 vs 4), and the undesigned tile's `accentPurple` fill + border.
- [x] Zero hardcoded hex in `BadgeWallCell.tsx` / `BadgeWallCell.styles.ts` — all colors from `theme.*` tokens + `palette.white`.
- [x] Unit tests pass (13/13 after pre-PR review); `BadgeWallCell` is not imported by any screen.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| D1 — Render `<BadgeRenderer design={badge.design} size={CELL_SIZE} />` directly inside the `Pressable`; **no** clipping `View`. | The badge's shape IS the design. `BadgeRenderer` already paints shape + border + theme-aware hard shadow; clipping it into a circle defeats the wall. |
| D2 — Do **not** pass `showShadow`; let `BadgeRenderer` derive it from the theme. | The wall wants the hard shadow in default/dark and none in highContrast/lowVision/autismFriendly — `BadgeRenderer`'s `theme.shadows.opacity > 0` default already does exactly this. |
| D3 — Null-design fallback is a **rounded square** (`borderRadius: 8`) with the title initial, bg `accentPurple`, 3px `border`. | A null design has no shape — a square tile is honest and stays distinct from real badges. Crucially **not** a circle (the mistake this rebuild fixes). Mirrors `BadgeCard`'s initials. |
| D4 — `badge` prop typed `{ title: string; design: BadgeDesign \| null }` — minimal presentational subset. | Presentational primitive in `src/components/`; must not couple to a query row type. The parent (`BadgesWall`, A2) maps rows to this shape. `design` is nullable in the schema. |
| D5 — Story title `"Badges/BadgeWallCell"`; `AllThemesMatrix` scopes the **real** component per theme via `ScopedTheme`. | Groups badge-domain primitives with `BadgeRenderer`; `ScopedTheme` was confirmed to scope per-column on the web Storybook target. |

## Discovery Log

- [2026-06-29] Rebuilt as `BadgeWallCell`. User flagged that the shipped `BadgeCircleCell` clipped all badges into circles, contradicting the varied-shape badge vocabulary and the prototype's mixed-shape wall. Reset the 4 `BadgeCircleCell` commits, renamed the branch, rebuilt per D1–D5.
- [2026-06-29] Pre-PR review (code / tests / comments / types agents): **zero critical/important** findings. Three suggestions folded in — added `diamond` to the JSDoc shape list, parametrized the press + a11y tests across both render branches (10 → 13 tests), and de-duplicated `CELL_SIZE` into a single exported constant.

## Test Plan

- [x] Type-check passes (4/4 tsconfig projects)
- [x] Lint passes (0 errors; the only 2 warnings are `require()` inside the `jest.mock` factory — unavoidable hoisting pattern)
- [x] Tests pass (full suite 9201/9201; `BadgeWallCell` 13/13)
- [x] Build script (no-op for native-rd) returns successfully
- [ ] **Manual Storybook web shape gate** — `Badges/BadgeWallCell` → `Row` confirms circle/shield/star/hexagon render as their true silhouettes (no circular crop); `AllThemesMatrix` confirms per-theme shadow/border variation. SVG can't render under JSDOM, so this visual proof is owed by a human before merge.

---

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
