### PR TITLE
chore(deps): ignore prettier 3.9.x (markdown non-idempotency regression)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,13 @@ updates:
         versions: ["30.4.x"]
       - dependency-name: "babel-jest"
         versions: ["30.4.x"]
+      # Prettier 3.9.x has a markdown non-idempotency regression: nested-list
+      # continuation paragraphs reformat differently on every --write and never
+      # converge, so format:check can never pass (e.g.
+      # apps/native-rd/docs/plans/2026-06-06-badge-designer-accordion-refactor.md).
+      # Revisit when prettier 3.10 (or a fixed 3.9.x) lands.
+      - dependency-name: "prettier"
+        versions: ["3.9.x"]
       # React Native ecosystem: must be bumped in coordination with the Expo SDK,
       # not piecemeal by Dependabot. Expo's jest preset asserts exact-match peers
       # (react / react-test-renderer) and the RN install layout changes between


### PR DESCRIPTION
## What

Pins prettier `3.9.x` out of Dependabot, mirroring the existing jest `30.4.x` block in `.github/dependabot.yml`.

## Why

Prettier 3.9.x has a non-idempotency regression on markdown: nested-list continuation paragraphs reformat differently on **every** `--write` and never converge, so `format:check` can never pass. Confirmed locally — `apps/native-rd/docs/plans/2026-06-06-badge-designer-accordion-refactor.md` produces a new hash on each write under 3.9.3, and is clean under 3.8.4. Revisit when 3.10 (or a fixed 3.9.x) lands.

## Unblocks #391

The dev-dependencies group PR (#391) is red solely because prettier 3.9 reformats 20 files. After this merges, `@dependabot recreate` on #391 rebuilds the group with **lint-staged + turbo + typescript-eslint** only (all patch/minor), which passes CI.

## Verification

- After merge: comment `@dependabot recreate` on #391, confirm prettier is dropped from the group and `Native-RD Validate` (incl. `format:check`) goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)