### PR TITLE
feat(theme-picker): ThemeSwatchRail + ThemeSampleCard (#413)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-413-theme-swatch-rail-sample-card.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-413-theme-swatch-rail-sample-card.md
@@ -1,0 +1,173 @@
+# Development Plan: Issue #413
+
+## Issue Summary
+
+**Title**: [Storybook] ThemeSwatchRail + ThemeSampleCard
+**Type**: feature
+**Complexity**: SMALL
+**Estimated Lines**: ~240 lines (implementation ~130, stories ~60, tests ~50)
+
+## Intent Verification
+
+Observable criteria derived from the issue. These describe what success looks like from a user/system perspective.
+
+- [ ] `ThemeSampleCard` rendered for each of the 7 product themes in Storybook shows its own bg color, border, shadow presence/absence, and font — verifiable by eye in the theme toolbar or an AllThemesMatrix story row
+- [ ] Night Ride sample card shows a vertical offset shadow (`0px 6px 0 0`), not a `3px 3px` hard shadow — its darkShadow token maps hardMd to `{offsetX:0, offsetY:6, opacity:1}` (**whether this should be shadowless is deferred to #429**, see Decisions D7)
+- [ ] Bold Ink, Still Water, and Loud & Clear sample cards show no visible shadow (all hard\* token opacities are 0 for those variants)
+- [ ] Warm Studio sample card renders with Lexend font body and soft blurred shadow (`opacity:0.1`), not the hard brutalist offset
+- [ ] Loud & Clear and Clean Signal sample cards render with Atkinson Hyperlegible font
+- [ ] Clean Signal sample card shows the full `2px 2px 0` hard shadow (lowInfo keeps hardSm/hardMd at opacity 0.8 with no `shadows.opacity` override) (**whether this should be shadowless is deferred to #429**, see Decisions D7)
+- [ ] `ThemeSwatchRail` renders one circular 3-stripe swatch per theme using the same `getSwatch` color extraction pattern as `ThemeChipGrid`
+- [ ] Selecting a swatch fires `onSelect(themeId)` with the correct theme ID; selected swatch shows a checkmark or active indicator
+- [ ] All 7 swatches are wrapped in a `radiogroup` with E2E gating (same pattern as `ThemeChipGrid` and `ThemeSwitcher`); each swatch has `accessibilityRole="radio"` + `themeA11yLabel`
+- [ ] Each swatch Pressable meets the 44pt min touch target requirement
+- [ ] Zero hardcoded hex colors — all colors sourced from `themes[id].colors.*` and `shadowStyle(cardTheme, "cardElevationSmall")` / `"cardElevation"`
+- [ ] No screen imports these components — they remain purely presentational pending #414 and #415
+
+## Dependencies
+
+| Issue | Title                  | Status | Type |
+| ----- | ---------------------- | ------ | ---- |
+| none  | No dependencies listed | N/A    | N/A  |
+
+**Status**: No dependencies — start now.
+
+## Objective
+
+Extract the per-theme preview card logic already embedded in `ThemeSwitcher` into a standalone `ThemeSampleCard` component, and build a new `ThemeSwatchRail` that renders 7 circular 3-stripe swatches using the color extraction pattern from `ThemeChipGrid`. Both components are pure and theme-parametrized — they share the picker vocabulary that Welcome (#414) and Settings (#415) will mount.
+
+## Decisions
+
+| ID  | Decision                                                                                                                       | Alternatives Considered                                            | Rationale                                                                                                                                                                                                                                                                                                              |
+| --- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | `previewStyles(themeId)` logic extracted verbatim from `ThemeSwitcher`                                                         | Rewrite from scratch; leave inline in ThemeSwitcher                | The existing function already correctly threads `themes[id]`, `variantOverrides[variant]`, and `shadowStyle`; extracting avoids drift                                                                                                                                                                                  |
+| D2  | `ThemeSampleCard` accepts `themeId: ThemeName` prop (not `theme` object)                                                       | Accept full `ComposedTheme`; accept both                           | `themeId` keeps the public surface minimal and mirrors how ThemeSwitcher iterates `themeOptions`                                                                                                                                                                                                                       |
+| D3  | Shadow honesty is driven purely by existing tokens — no new logic required                                                     | Conditionally branch on variant to zero shadows                    | `shadowStyle(themes[id], "cardElevationSmall")` already returns 0 for Bold Ink/Still Water/Loud & Clear (token opacity=0); Night Ride gets offset shadow from darkShadow; no manual branching needed                                                                                                                   |
+| D4  | `ThemeSwatchRail` is controlled (accepts `selectedThemeId` + `onSelect`)                                                       | Uncontrolled with internal state                                   | Welcome and Settings each own theme state; keeping the rail stateless makes it testable without a ThemeProvider                                                                                                                                                                                                        |
+| D5  | `getSwatch` / `stripeWidths` extracted from `ThemeChipGrid` into a shared util file                                            | Inline in ThemeSwatchRail; duplicate values                        | Single source of truth; ThemeChipGrid can import from the same util, avoiding silent drift between the two swatch surfaces                                                                                                                                                                                             |
+| D6  | Circular swatch shape: fixed 48pt diameter Pressable with `borderRadius: 24`                                                   | Pill shape; square with rounding                                   | Matches prototype description; 48pt satisfies 44pt min touch target with margin to spare                                                                                                                                                                                                                               |
+| D7  | Build to the **real token output** for all 7 themes; Night Ride / Clean Signal shadow _intent_ reviewed separately in **#429** | Hardcode shadow-off for those two to match issue AC; block on #429 | User decision (2026-06-30): components are pure and honestly render token output either way, so they ship now. The two issue-AC bullets claiming those themes are shadowless are factually wrong vs the tokens — whether the _tokens_ should change is a design call tracked in #429, not a change to these components |
+
+## Affected Areas
+
+- `src/components/ThemeSampleCard/ThemeSampleCard.tsx` — new component (extracted from ThemeSwitcher's previewStyles + sampleCard/badge render)
+- `src/components/ThemeSampleCard/ThemeSampleCard.styles.ts` — new (shell styles; inline styles remain in previewStyles for per-theme overrides)
+- `src/components/ThemeSampleCard/ThemeSampleCard.stories.tsx` — new (Default story + AllThemesMatrix story)
+- `src/components/ThemeSampleCard/index.ts` — new barrel
+- `src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx` — new tests
+- `src/components/ThemeSwatchRail/ThemeSwatchRail.tsx` — new component
+- `src/components/ThemeSwatchRail/ThemeSwatchRail.styles.ts` — new
+- `src/components/ThemeSwatchRail/ThemeSwatchRail.stories.tsx` — new
+- `src/components/ThemeSwatchRail/index.ts` — new barrel
+- `src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx` — new tests
+- `src/components/ThemeChipGrid/swatch-utils.ts` — new shared utility extracted from `ThemeChipGrid.tsx` (`getSwatch` + `stripeWidths`)
+- `src/components/ThemeChipGrid/ThemeChipGrid.tsx` — updated to import from `swatch-utils` (no behavioral change)
+
+## Implementation Plan
+
+### Step 1: Extract shared swatch utilities from ThemeChipGrid
+
+**Files**: `src/components/ThemeChipGrid/swatch-utils.ts`, `src/components/ThemeChipGrid/ThemeChipGrid.tsx`
+**Commit**: `refactor(ThemeChipGrid): extract getSwatch + stripeWidths to swatch-utils`
+**Changes**:
+
+- [ ] Create `swatch-utils.ts` with `ChipSwatch` interface, `getSwatch(themeName: ThemeName): ChipSwatch`, and `stripeWidths: Record<ThemeName, [number, number]>` — exact values from current `ThemeChipGrid.tsx`
+- [ ] Update `ThemeChipGrid.tsx` to import from `./swatch-utils` in place of the inlined definitions
+- [ ] Verify `bun run test --testPathPatterns ThemeChipGrid` still passes — no behavioral change
+
+### Step 2: ThemeSampleCard component
+
+**Files**: `src/components/ThemeSampleCard/ThemeSampleCard.tsx`, `ThemeSampleCard.styles.ts`, `index.ts`
+**Commit**: `feat(ThemeSampleCard): extract per-theme preview card from ThemeSwitcher`
+**Changes**:
+
+- [ ] Props interface: `{ themeId: ThemeName }` — no callbacks, pure display
+- [ ] Move `previewStyles(themeId)` function verbatim from `ThemeSwitcher.tsx` into this file (or a co-located `previewStyles.ts`); it already correctly handles `themes[themeId]`, `parseThemeName`, `variantOverrides[variant]`, `size`/`lineHeight` scale, `fontFamily`, and `shadowStyle(cardTheme, "cardElevationSmall")`
+- [ ] Render the card: `View[sampleCard]` → `View[badge]` with `★` text → `View[sampleTextCol]` with title and meta texts → `View[ctaPill]` with CTA text
+- [ ] i18n keys (already confirmed present in `en/common.json`): `common:theme.preview.title` ("Daily reading"), `common:theme.preview.progress` ("3 of 5 done"), `common:theme.preview.cta` ("+ ADD")
+- [ ] Badge uses `cardTheme.colors.accentPurple` bg and `cardTheme.colors.accentPurpleFg` text — tokens confirmed present in `ComposedTheme.colors`
+- [ ] Shell `ThemeSampleCard.styles.ts` holds any static wrapper styles needed; per-theme inline styles stay in `previewStyles`
+
+### Step 3: ThemeSampleCard stories and tests
+
+**Files**: `src/components/ThemeSampleCard/ThemeSampleCard.stories.tsx`, `src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx`
+**Commit**: `test(ThemeSampleCard): stories and unit tests covering all 7 themes`
+**Changes**:
+
+- [ ] Story 1 `Default`: renders `ThemeSampleCard` for `"light-default"`
+- [ ] Story 2 `AllThemesMatrix`: renders all 7 theme IDs side by side in a `ScrollView` — reviewer visual gate for the honesty matrix
+- [ ] Unit tests using `renderWithProviders` (same pattern as `ThemeSwitcher.test.tsx` and `ThemeChipGrid.test.tsx`):
+  - [ ] `test.each(themeOptions)` — each theme ID renders without crashing
+  - [ ] The card text content shows the correct i18n strings (`"Daily reading"`, `"3 of 5 done"`, `"+ ADD"`)
+  - [ ] No `accessibilityRole` on the card itself — it is display-only, not interactive
+
+### Step 4: ThemeSwatchRail component
+
+**Files**: `src/components/ThemeSwatchRail/ThemeSwatchRail.tsx`, `ThemeSwatchRail.styles.ts`, `index.ts`
+**Commit**: `feat(ThemeSwatchRail): horizontal circular swatch rail with radio a11y`
+**Changes**:
+
+- [ ] Props interface: `{ selectedThemeId: ThemeName; onSelect: (id: ThemeName) => void }`
+- [ ] Render a horizontal `ScrollView` (or `FlatList`) of 7 circular Pressables using `getSwatch` and `stripeWidths` from `swatch-utils.ts`
+- [ ] Swatch shape: 48pt circular `Pressable` (`borderRadius: 24`, overflow hidden) containing three vertical stripes — `stripeBg` fills remainder, `stripe1` covers `w1%`, `stripe2` covers `w2%` (same flex-row layout as `ThemeChipGrid`)
+- [ ] Selected treatment: `borderColor: themes[id].colors.accentPurple`, border width 3, plus a `✓` overlay text with `colors.accentPurple`; unselected: `borderColor: themes[id].colors.border`, border width 1
+- [ ] Selected theme name and description displayed below the rail using `t("common:theme.options.<id>.label")` / `.description`
+- [ ] a11y: same E2E-gated radiogroup pattern from `ThemeSwitcher` / `ThemeChipGrid`; each Pressable gets `accessibilityRole="radio"`, `accessibilityState={{ checked: isSelected }}`, `accessibilityLabel={themeA11yLabel(t, id)}`; rail wrapper gets `accessibilityRole="radiogroup"` label "Theme selection" (guarded by `EXPO_PUBLIC_E2E_MODE`)
+- [ ] Pressable min hit area: 48pt height/width meets 44pt requirement
+
+### Step 5: ThemeSwatchRail stories and tests
+
+**Files**: `src/components/ThemeSwatchRail/ThemeSwatchRail.stories.tsx`, `src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx`
+**Commit**: `test(ThemeSwatchRail): stories and unit tests`
+**Changes**:
+
+- [ ] Story 1 `Default`: rail with `selectedThemeId="light-default"` and a no-op `onSelect`
+- [ ] Story 2 `NightRideSelected`: shows the dark theme selected, verifying the dark swatch colors render
+- [ ] Unit tests mirroring `ThemeChipGrid.test.tsx` pattern:
+  - [ ] Renders one radio per theme with correct `themeA11yLabel`
+  - [ ] `checked` state is `true` for `selectedThemeId`, `false` for others
+  - [ ] `onSelect` called with correct `ThemeName` when swatch pressed
+  - [ ] `radiogroup` present in production mode; absent in E2E mode (`EXPO_PUBLIC_E2E_MODE=true`)
+
+## Testing Strategy
+
+- [ ] Unit tests via `bun run test --testPathPatterns "ThemeSampleCard|ThemeSwatchRail|ThemeChipGrid"` — all must pass after Step 1 refactor and new components
+- [ ] Test files at `src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx` and `src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx`, mirroring the established `ThemeChipGrid`/`ThemeSwitcher` test structure (`renderWithProviders`, `themeA11yLabel`, `test.each`)
+- [ ] `bun run test` (node-wrapped jest) — never `bun test` or `npx jest`
+- [ ] Storybook visual gate: load `ThemeSampleCard.AllThemesMatrix` and verify all 7 rows in the browser — Night Ride shows a vertical 6px shadow, Bold Ink/Still Water/Loud & Clear show no shadow, Warm Studio shows soft shadow + Lexend, Clean Signal shows the hard 3px offset shadow
+- [ ] Type-check passes: `bun run type-check`
+
+## Shadow Honesty Matrix (verified from built token output)
+
+| Theme        | ThemeName              | Shadow behavior in `cardElevationSmall`                           |
+| ------------ | ---------------------- | ----------------------------------------------------------------- |
+| Full Ride    | `light-default`        | Hard offset `2px 2px 0` (hardSm opacity=0.8, shadows.opacity=1.0) |
+| Night Ride   | `dark-default`         | Vertical offset `0px 6px 0` (darkShadow.hardSm opacity=1.0)       |
+| Bold Ink     | `light-highContrast`   | No shadow (all hardX opacity=0; shadows.opacity=0)                |
+| Warm Studio  | `light-dyslexia`       | Soft blurred shadow (hardSm opacity=0.1, radius=2)                |
+| Still Water  | `light-autismFriendly` | No shadow (all hardX opacity=0; shadows.opacity=0)                |
+| Loud & Clear | `light-lowVision`      | No shadow (all hardX opacity=0; shadows.opacity=0)                |
+| Clean Signal | `light-lowInfo`        | Hard offset `2px 2px 0` (hardSm opacity=0.8, no opacity override) |
+
+Note: The issue body states Clean Signal has "shadows.opacity: 0" — this is incorrect per the built tokens. `lowInfo` variant sets `shadow: shadowVariants.lowInfo` but does NOT set `shadows: { opacity: 0 }`, so `shadows.opacity` remains 1.0. The hard shadow `hardMd.opacity=0.8` is fully rendered. This plan reflects the actual token behavior.
+
+Note: The issue body states Night Ride shadow "composes to 0 (border carries depth)" — also incorrect. Night Ride uses `darkShadow` where `hardSm = {offsetX:0, offsetY:6, radius:0, opacity:1}`, so a real shadow is visible. It differs from the light hard shadow (no X offset, pure vertical drop) but is not zero.
+
+## Not in Scope
+
+| Item                                                           | Reason                                                                                                        | Follow-up |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | --------- |
+| Mounting in Welcome screen                                     | #414 owns that wiring                                                                                         | #414      |
+| Mounting in Settings screen                                    | #415 owns that wiring                                                                                         | #415      |
+| Persisting theme selection to storage                          | ThemeProvider / useThemePersistence handles                                                                   | existing  |
+| Refactoring ThemeSwitcher to use ThemeSampleCard               | Separate concern; no user-facing change                                                                       | none      |
+| `largeText` variant as a swatch option                         | Not a runtime picker option per `themeOptions` in `useTheme.ts`                                               | by design |
+| Changing Night Ride / Clean Signal shadow tokens to shadowless | Components render token output faithfully; whether those tokens match design intent is a separate design call | #429      |
+
+## Discovery Log
+
+- [2026-06-30] Research caught two factual errors in issue #413's acceptance criteria: it claims Night Ride (`dark-default`) and Clean Signal (`light-lowInfo`) render with zero shadow. Verified against `src/themes/variants.ts`: only `highContrast`/`lowVision`/`autismFriendly` set `shadows: { opacity: 0 }`; `lowInfo` (variants.ts:148-155) does not, and Night Ride's `darkShadow` renders a `0px 6px 0` drop. User decision (Review-tokens-separately): build the pure components to real token output now; track the shadow-token design-intent question in **#429**. The two AC bullets above are annotated as deferred.
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/docs/plans/dev-plans/issue-413-theme-swatch-rail-sample-card.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-413-theme-swatch-rail-sample-card.md
@@ -11,18 +11,18 @@
 
 Observable criteria derived from the issue. These describe what success looks like from a user/system perspective.
 
-- [ ] `ThemeSampleCard` rendered for each of the 7 product themes in Storybook shows its own bg color, border, shadow presence/absence, and font — verifiable by eye in the theme toolbar or an AllThemesMatrix story row
-- [ ] Night Ride sample card shows a vertical offset shadow (`0px 6px 0 0`), not a `3px 3px` hard shadow — its darkShadow token maps hardMd to `{offsetX:0, offsetY:6, opacity:1}` (**whether this should be shadowless is deferred to #429**, see Decisions D7)
-- [ ] Bold Ink, Still Water, and Loud & Clear sample cards show no visible shadow (all hard\* token opacities are 0 for those variants)
-- [ ] Warm Studio sample card renders with Lexend font body and soft blurred shadow (`opacity:0.1`), not the hard brutalist offset
-- [ ] Loud & Clear and Clean Signal sample cards render with Atkinson Hyperlegible font
-- [ ] Clean Signal sample card shows the full `2px 2px 0` hard shadow (lowInfo keeps hardSm/hardMd at opacity 0.8 with no `shadows.opacity` override) (**whether this should be shadowless is deferred to #429**, see Decisions D7)
-- [ ] `ThemeSwatchRail` renders one circular 3-stripe swatch per theme using the same `getSwatch` color extraction pattern as `ThemeChipGrid`
-- [ ] Selecting a swatch fires `onSelect(themeId)` with the correct theme ID; selected swatch shows a checkmark or active indicator
-- [ ] All 7 swatches are wrapped in a `radiogroup` with E2E gating (same pattern as `ThemeChipGrid` and `ThemeSwitcher`); each swatch has `accessibilityRole="radio"` + `themeA11yLabel`
-- [ ] Each swatch Pressable meets the 44pt min touch target requirement
-- [ ] Zero hardcoded hex colors — all colors sourced from `themes[id].colors.*` and `shadowStyle(cardTheme, "cardElevationSmall")` / `"cardElevation"`
-- [ ] No screen imports these components — they remain purely presentational pending #414 and #415
+- [x] `ThemeSampleCard` rendered for each of the 7 product themes in Storybook shows its own bg color, border, shadow presence/absence, and font — `AllThemesMatrix` story renders all 7 on their own backgrounds; `it.each(themeIds)` covers all 7 in tests (final by-eye gate is the reviewer's)
+- [x] Night Ride sample card shows a vertical offset shadow (`0px 6px 0 0`), not a `3px 3px` hard shadow — rendered faithfully via `shadowStyle(themes["dark-default"], "cardElevationSmall")` over the darkShadow token (**design intent deferred to #429**, see Decisions D7)
+- [x] Bold Ink, Still Water, and Loud & Clear sample cards show no visible shadow (all hard\* token opacities are 0 for those variants)
+- [x] Warm Studio sample card renders with Lexend font body and soft blurred shadow (`opacity:0.1`), not the hard brutalist offset — `fontFamily` threaded from `variantOverrides["dyslexia"]`
+- [x] Loud & Clear and Clean Signal sample cards render with Atkinson Hyperlegible font
+- [x] Clean Signal sample card shows the full `2px 2px 0` hard shadow (lowInfo keeps hardSm/hardMd at opacity 0.8 with no `shadows.opacity` override) (**design intent deferred to #429**, see Decisions D7)
+- [x] `ThemeSwatchRail` renders one circular 3-stripe swatch per theme using the same `getSwatch` color extraction pattern as `ThemeChipGrid` (now shared via `swatch-utils.ts`)
+- [x] Selecting a swatch fires `onSelect(themeId)` with the correct theme ID; selected swatch shows a checkmark + 3pt accent border (tested)
+- [x] All 7 swatches are wrapped in a `radiogroup` with E2E gating (same pattern as `ThemeChipGrid` and `ThemeSwitcher`); each swatch has `accessibilityRole="radio"` + `themeA11yLabel` (tested, incl. E2E-mode drop)
+- [x] Each swatch Pressable meets the 44pt min touch target requirement (48pt fixed diameter)
+- [x] Zero hardcoded hex colors — all colors sourced from `themes[id].colors.*` and `shadowStyle(cardTheme, "cardElevationSmall")`
+- [x] No screen imports these components — they remain purely presentational pending #414 and #415 (grep confirmed)
 
 ## Dependencies
 
@@ -71,9 +71,9 @@ Extract the per-theme preview card logic already embedded in `ThemeSwitcher` int
 **Commit**: `refactor(ThemeChipGrid): extract getSwatch + stripeWidths to swatch-utils`
 **Changes**:
 
-- [ ] Create `swatch-utils.ts` with `ChipSwatch` interface, `getSwatch(themeName: ThemeName): ChipSwatch`, and `stripeWidths: Record<ThemeName, [number, number]>` — exact values from current `ThemeChipGrid.tsx`
-- [ ] Update `ThemeChipGrid.tsx` to import from `./swatch-utils` in place of the inlined definitions
-- [ ] Verify `bun run test --testPathPatterns ThemeChipGrid` still passes — no behavioral change
+- [x] Create `swatch-utils.ts` with `ChipSwatch` interface, `getSwatch(themeName: ThemeName): ChipSwatch`, and `stripeWidths: Record<ThemeName, [number, number]>` — exact values from current `ThemeChipGrid.tsx`
+- [x] Update `ThemeChipGrid.tsx` to import from `./swatch-utils` in place of the inlined definitions
+- [x] Verify `bun run test --testPathPatterns ThemeChipGrid` still passes — no behavioral change (5/5 pass)
 
 ### Step 2: ThemeSampleCard component
 
@@ -81,12 +81,12 @@ Extract the per-theme preview card logic already embedded in `ThemeSwitcher` int
 **Commit**: `feat(ThemeSampleCard): extract per-theme preview card from ThemeSwitcher`
 **Changes**:
 
-- [ ] Props interface: `{ themeId: ThemeName }` — no callbacks, pure display
-- [ ] Move `previewStyles(themeId)` function verbatim from `ThemeSwitcher.tsx` into this file (or a co-located `previewStyles.ts`); it already correctly handles `themes[themeId]`, `parseThemeName`, `variantOverrides[variant]`, `size`/`lineHeight` scale, `fontFamily`, and `shadowStyle(cardTheme, "cardElevationSmall")`
-- [ ] Render the card: `View[sampleCard]` → `View[badge]` with `★` text → `View[sampleTextCol]` with title and meta texts → `View[ctaPill]` with CTA text
-- [ ] i18n keys (already confirmed present in `en/common.json`): `common:theme.preview.title` ("Daily reading"), `common:theme.preview.progress` ("3 of 5 done"), `common:theme.preview.cta` ("+ ADD")
-- [ ] Badge uses `cardTheme.colors.accentPurple` bg and `cardTheme.colors.accentPurpleFg` text — tokens confirmed present in `ComposedTheme.colors`
-- [ ] Shell `ThemeSampleCard.styles.ts` holds any static wrapper styles needed; per-theme inline styles stay in `previewStyles`
+- [x] Props interface: `{ themeId: ThemeName }` — no callbacks, pure display
+- [x] Extracted the **card subset** of `previewStyles(themeId)` from `ThemeSwitcher.tsx` (sampleCard/badge/badgeText/sampleTitle/sampleMeta/ctaPill/ctaText); threads `themes[themeId]`, `parseThemeName`, `variantOverrides[variant]`, `size` scale, `fontFamily`, and `shadowStyle(cardTheme, "cardElevationSmall")`. Dropped `label`/`description`/`checkmark` (picker-header styles, not part of the card) and the now-unused `lineHeight`/`lhScale` — see Discovery Log
+- [x] Render the card: `View[sampleCard]` → `View[badge]` with `★` text → `View[sampleTextCol]` with title and meta texts → `View[ctaPill]` with CTA text
+- [x] i18n keys (confirmed present in `en/common.json`): `common:theme.preview.title` ("Daily reading"), `common:theme.preview.progress` ("3 of 5 done"), `common:theme.preview.cta` ("+ ADD")
+- [x] Badge uses `cardTheme.colors.accentPurple` bg and `cardTheme.colors.accentPurpleFg` text — tokens confirmed present in `ComposedTheme.colors`
+- [x] Shell `ThemeSampleCard.styles.ts` holds the static `sampleTextCol`; per-theme inline styles stay in `previewStyles`
 
 ### Step 3: ThemeSampleCard stories and tests
 
@@ -94,12 +94,12 @@ Extract the per-theme preview card logic already embedded in `ThemeSwitcher` int
 **Commit**: `test(ThemeSampleCard): stories and unit tests covering all 7 themes`
 **Changes**:
 
-- [ ] Story 1 `Default`: renders `ThemeSampleCard` for `"light-default"`
-- [ ] Story 2 `AllThemesMatrix`: renders all 7 theme IDs side by side in a `ScrollView` — reviewer visual gate for the honesty matrix
-- [ ] Unit tests using `renderWithProviders` (same pattern as `ThemeSwitcher.test.tsx` and `ThemeChipGrid.test.tsx`):
-  - [ ] `test.each(themeOptions)` — each theme ID renders without crashing
-  - [ ] The card text content shows the correct i18n strings (`"Daily reading"`, `"3 of 5 done"`, `"+ ADD"`)
-  - [ ] No `accessibilityRole` on the card itself — it is display-only, not interactive
+- [x] Story 1 `Default`: renders `ThemeSampleCard` for `"light-default"`
+- [x] Story 2 `AllThemesMatrix`: renders all 7 theme IDs stacked, each on its own theme background with a `themeId` caption — reviewer visual gate for the honesty matrix (uses a plain `View`, not a nested `ScrollView`; the Storybook preview decorator already supplies the scroll container — see Discovery Log)
+- [x] Unit tests using `renderWithProviders` (same pattern as `ThemeSwitcher.test.tsx` and `ThemeChipGrid.test.tsx`):
+  - [x] `it.each(themeIds)` — each theme ID renders without crashing
+  - [x] The card text content shows the correct i18n strings (`"Daily reading"`, `"3 of 5 done"`, `"+ ADD"`)
+  - [x] No interactive `accessibilityRole` on the card — asserted no `button`/`radio` role present (display-only)
 
 ### Step 4: ThemeSwatchRail component
 
@@ -107,13 +107,13 @@ Extract the per-theme preview card logic already embedded in `ThemeSwitcher` int
 **Commit**: `feat(ThemeSwatchRail): horizontal circular swatch rail with radio a11y`
 **Changes**:
 
-- [ ] Props interface: `{ selectedThemeId: ThemeName; onSelect: (id: ThemeName) => void }`
-- [ ] Render a horizontal `ScrollView` (or `FlatList`) of 7 circular Pressables using `getSwatch` and `stripeWidths` from `swatch-utils.ts`
-- [ ] Swatch shape: 48pt circular `Pressable` (`borderRadius: 24`, overflow hidden) containing three vertical stripes — `stripeBg` fills remainder, `stripe1` covers `w1%`, `stripe2` covers `w2%` (same flex-row layout as `ThemeChipGrid`)
-- [ ] Selected treatment: `borderColor: themes[id].colors.accentPurple`, border width 3, plus a `✓` overlay text with `colors.accentPurple`; unselected: `borderColor: themes[id].colors.border`, border width 1
-- [ ] Selected theme name and description displayed below the rail using `t("common:theme.options.<id>.label")` / `.description`
-- [ ] a11y: same E2E-gated radiogroup pattern from `ThemeSwitcher` / `ThemeChipGrid`; each Pressable gets `accessibilityRole="radio"`, `accessibilityState={{ checked: isSelected }}`, `accessibilityLabel={themeA11yLabel(t, id)}`; rail wrapper gets `accessibilityRole="radiogroup"` label "Theme selection" (guarded by `EXPO_PUBLIC_E2E_MODE`)
-- [ ] Pressable min hit area: 48pt height/width meets 44pt requirement
+- [x] Props interface: `{ selectedThemeId: ThemeName; onSelect: (id: ThemeName) => void }`
+- [x] Render a horizontal `ScrollView` of 7 circular Pressables using `getSwatch` and `stripeWidths` from `swatch-utils.ts`
+- [x] Swatch shape: 48pt circular `Pressable` (`borderRadius: 24`, overflow hidden) containing three vertical stripes — `stripeBg` fills remainder (absolute-fill `stripeRow`), `stripe1` covers `w1%`, `stripe2` covers `w2%` (same flex-row layout as `ThemeChipGrid`)
+- [x] Selected treatment: `borderColor: themes[id].colors.accentPurple`, border width 3, plus a `✓` overlay text with `colors.accentPurple`; unselected: `borderColor: themes[id].colors.border`, border width 1
+- [x] Selected theme name and description displayed below the rail using `t("common:theme.options.<id>.label")` / `.description`
+- [x] a11y: same E2E-gated radiogroup pattern from `ThemeSwitcher` / `ThemeChipGrid`; each Pressable gets `accessibilityRole="radio"`, `accessibilityState={{ checked: isSelected }}`, `accessibilityLabel={themeA11yLabel(t, id)}`; rail wrapper gets `accessibilityRole="radiogroup"` label "Theme selection" (guarded by `EXPO_PUBLIC_E2E_MODE`)
+- [x] Pressable min hit area: 48pt height/width meets 44pt requirement
 
 ### Step 5: ThemeSwatchRail stories and tests
 
@@ -121,21 +121,21 @@ Extract the per-theme preview card logic already embedded in `ThemeSwitcher` int
 **Commit**: `test(ThemeSwatchRail): stories and unit tests`
 **Changes**:
 
-- [ ] Story 1 `Default`: rail with `selectedThemeId="light-default"` and a no-op `onSelect`
-- [ ] Story 2 `NightRideSelected`: shows the dark theme selected, verifying the dark swatch colors render
-- [ ] Unit tests mirroring `ThemeChipGrid.test.tsx` pattern:
-  - [ ] Renders one radio per theme with correct `themeA11yLabel`
-  - [ ] `checked` state is `true` for `selectedThemeId`, `false` for others
-  - [ ] `onSelect` called with correct `ThemeName` when swatch pressed
-  - [ ] `radiogroup` present in production mode; absent in E2E mode (`EXPO_PUBLIC_E2E_MODE=true`)
+- [x] Story 1 `Default`: rail with `selectedThemeId="light-default"` — wrapped in a stateful `InteractiveRail` (instead of a no-op `onSelect`) so swatches respond to taps in the visual gate (see Discovery Log)
+- [x] Story 2 `NightRideSelected`: shows the dark theme selected, verifying the dark swatch colors render
+- [x] Unit tests mirroring `ThemeChipGrid.test.tsx` pattern:
+  - [x] Renders one radio per theme with correct `themeA11yLabel`
+  - [x] `checked` state is `true` for `selectedThemeId`, `false` for others
+  - [x] `onSelect` called with correct `ThemeName` when swatch pressed
+  - [x] `radiogroup` present in production mode; absent in E2E mode (`EXPO_PUBLIC_E2E_MODE=true`)
 
 ## Testing Strategy
 
-- [ ] Unit tests via `bun run test --testPathPatterns "ThemeSampleCard|ThemeSwatchRail|ThemeChipGrid"` — all must pass after Step 1 refactor and new components
-- [ ] Test files at `src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx` and `src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx`, mirroring the established `ThemeChipGrid`/`ThemeSwitcher` test structure (`renderWithProviders`, `themeA11yLabel`, `test.each`)
-- [ ] `bun run test` (node-wrapped jest) — never `bun test` or `npx jest`
-- [ ] Storybook visual gate: load `ThemeSampleCard.AllThemesMatrix` and verify all 7 rows in the browser — Night Ride shows a vertical 6px shadow, Bold Ink/Still Water/Loud & Clear show no shadow, Warm Studio shows soft shadow + Lexend, Clean Signal shows the hard 3px offset shadow
-- [ ] Type-check passes: `bun run type-check`
+- [x] Unit tests via `bun run test --testPathPatterns "ThemeSampleCard|ThemeSwatchRail|ThemeChipGrid"` — all pass after Step 1 refactor and new components (ThemeChipGrid 5/5, ThemeSampleCard 9/9, ThemeSwatchRail 5/5)
+- [x] Test files at `src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx` and `src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx`, mirroring the established `ThemeChipGrid`/`ThemeSwitcher` test structure (`renderWithProviders`, `themeA11yLabel`, `it.each`)
+- [x] `bun run test` (node-wrapped jest) — full suite 9284/9284 pass; never `bun test` or `npx jest`
+- [ ] Storybook visual gate (reviewer): load `ThemeSampleCard.AllThemesMatrix` and verify all 7 rows in the browser — Night Ride shows a vertical 6px shadow, Bold Ink/Still Water/Loud & Clear show no shadow, Warm Studio shows soft shadow + Lexend, Clean Signal shows the hard 3px offset shadow
+- [x] Type-check passes: `bun run type-check`
 
 ## Shadow Honesty Matrix (verified from built token output)
 
@@ -168,6 +168,7 @@ Note: The issue body states Night Ride shadow "composes to 0 (border carries dep
 
 - [2026-06-30] Research caught two factual errors in issue #413's acceptance criteria: it claims Night Ride (`dark-default`) and Clean Signal (`light-lowInfo`) render with zero shadow. Verified against `src/themes/variants.ts`: only `highContrast`/`lowVision`/`autismFriendly` set `shadows: { opacity: 0 }`; `lowInfo` (variants.ts:148-155) does not, and Night Ride's `darkShadow` renders a `0px 6px 0` drop. User decision (Review-tokens-separately): build the pure components to real token output now; track the shadow-token design-intent question in **#429**. The two AC bullets above are annotated as deferred.
 
-<!-- Entries added by implement skill:
-- [YYYY-MM-DD HH:MM] <discovery description>
--->
+- [2026-06-30] `ThemeSampleCard` renders only the sample card, not the picker option header. Extracted just the card subset of `previewStyles` (sampleCard/badge/badgeText/sampleTitle/sampleMeta/ctaPill/ctaText); `label`/`description`/`checkmark` belong to the `ThemeSwitcher` option wrapper and would be dead code here. The now-unused `lhScale`/`lineHeight` import (they only fed `label`/`description`) was removed in a follow-up `refactor` commit after ESLint flagged it.
+- [2026-06-30] Dropped `marginTop: 12` from the standalone `sampleCard`. In `ThemeSwitcher` it separated the card from the header text above it inside a picker option; a standalone presentational card shouldn't impose its own outer margin — spacing is the parent's job (Welcome/Settings, or the story container).
+- [2026-06-30] `AllThemesMatrix` story renders a plain stacked `View` (each card on its own theme background with a `themeId` caption) rather than its own `ScrollView`. The Storybook preview decorator (`.storybook/preview.tsx`) already wraps every story in a vertical `ScrollView`; nesting a second same-orientation scroll view is an RN anti-pattern. Net effect matches the plan's "7 rows" intent.
+- [2026-06-30] `ThemeSwatchRail` `Default` story uses a stateful `InteractiveRail` wrapper instead of the planned no-op `onSelect`, so swatches actually respond to taps in the visual gate — a better demonstration of the controlled (D4) contract. `NightRideSelected` stays static to show the dark swatch in its selected state.

--- a/apps/native-rd/src/components/ThemeChipGrid/ThemeChipGrid.tsx
+++ b/apps/native-rd/src/components/ThemeChipGrid/ThemeChipGrid.tsx
@@ -2,40 +2,9 @@ import React from "react";
 import { Pressable, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useThemeContext, themeOptions } from "../../hooks/useTheme";
-import { themes, type ThemeName } from "../../themes/compose";
 import { themeA11yLabel } from "../../i18n/labels";
+import { getSwatch, stripeWidths } from "./swatch-utils";
 import { styles, COLUMN_COUNT } from "./ThemeChipGrid.styles";
-
-interface ChipSwatch {
-  stripeBg: string;
-  stripe1: string;
-  stripe2: string;
-  nameBarBg: string;
-  nameBarBorder: string;
-  nameBarText: string;
-}
-
-function getSwatch(themeName: ThemeName): ChipSwatch {
-  const c = themes[themeName].colors;
-  return {
-    stripeBg: c.background,
-    stripe1: c.accentPurple,
-    stripe2: c.text,
-    nameBarBg: c.backgroundSecondary,
-    nameBarBorder: c.border,
-    nameBarText: c.text,
-  };
-}
-
-const stripeWidths: Record<ThemeName, [number, number]> = {
-  "light-default": [30, 25],
-  "dark-default": [30, 25],
-  "light-highContrast": [50, 25],
-  "light-dyslexia": [30, 25],
-  "light-autismFriendly": [35, 30],
-  "light-lowVision": [60, 20],
-  "light-lowInfo": [40, 25],
-};
 
 export function ThemeChipGrid() {
   const { themeName, setTheme } = useThemeContext();

--- a/apps/native-rd/src/components/ThemeChipGrid/swatch-utils.ts
+++ b/apps/native-rd/src/components/ThemeChipGrid/swatch-utils.ts
@@ -1,0 +1,38 @@
+import { themes, type ThemeName } from "../../themes/compose";
+
+/**
+ * Per-theme colors for a 3-stripe theme swatch (background + two accent
+ * stripes) plus the chip's name-bar treatment. Single-sourced here so
+ * ThemeChipGrid and ThemeSwatchRail extract identical colors and never drift.
+ */
+export interface ChipSwatch {
+  stripeBg: string;
+  stripe1: string;
+  stripe2: string;
+  nameBarBg: string;
+  nameBarBorder: string;
+  nameBarText: string;
+}
+
+export function getSwatch(themeName: ThemeName): ChipSwatch {
+  const c = themes[themeName].colors;
+  return {
+    stripeBg: c.background,
+    stripe1: c.accentPurple,
+    stripe2: c.text,
+    nameBarBg: c.backgroundSecondary,
+    nameBarBorder: c.border,
+    nameBarText: c.text,
+  };
+}
+
+/** `[stripe1%, stripe2%]` widths per theme; the background fills the remainder. */
+export const stripeWidths: Record<ThemeName, [number, number]> = {
+  "light-default": [30, 25],
+  "dark-default": [30, 25],
+  "light-highContrast": [50, 25],
+  "light-dyslexia": [30, 25],
+  "light-autismFriendly": [35, 30],
+  "light-lowVision": [60, 20],
+  "light-lowInfo": [40, 25],
+};

--- a/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.stories.tsx
+++ b/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { View, Text } from "react-native";
+import { themeOptions } from "../../hooks/useTheme";
+import { themes } from "../../themes/compose";
+import { ThemeSampleCard } from "./ThemeSampleCard";
+
+const meta: Meta<typeof ThemeSampleCard> = {
+  title: "ThemeSampleCard",
+  component: ThemeSampleCard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ThemeSampleCard>;
+
+export const Default: Story = {
+  render: () => <ThemeSampleCard themeId="light-default" />,
+};
+
+/**
+ * Reviewer visual gate for the shadow-honesty matrix: every product theme's
+ * card rendered on its own background so the per-theme shadow, border, and font
+ * are verifiable by eye. Night Ride shows a vertical 6px drop; Bold Ink, Still
+ * Water, and Loud & Clear show no shadow; Warm Studio shows a soft blurred
+ * shadow with Lexend; Clean Signal shows the hard 2px offset.
+ */
+export const AllThemesMatrix: Story = {
+  render: () => (
+    <View style={{ gap: 16 }}>
+      {themeOptions.map(({ id }) => (
+        <View
+          key={id}
+          style={{
+            gap: 6,
+            padding: 12,
+            borderRadius: 8,
+            backgroundColor: themes[id].colors.backgroundSecondary,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 12,
+              fontWeight: "700",
+              color: themes[id].colors.text,
+            }}
+          >
+            {id}
+          </Text>
+          <ThemeSampleCard themeId={id} />
+        </View>
+      ))}
+    </View>
+  ),
+};

--- a/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.styles.ts
+++ b/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from "react-native-unistyles";
+
+export const styles = StyleSheet.create({
+  sampleTextCol: {
+    flex: 1,
+  },
+});

--- a/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.tsx
+++ b/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.tsx
@@ -1,0 +1,127 @@
+import { View, Text, type TextStyle, type ViewStyle } from "react-native";
+import { useTranslation } from "react-i18next";
+import { themes, parseThemeName, type ThemeName } from "../../themes/compose";
+import { variantOverrides } from "../../themes/variants";
+import { size, lineHeight } from "../../themes/tokens";
+import { shadowStyle } from "../../styles/shadows";
+import { styles } from "./ThemeSampleCard.styles";
+
+interface ThemeSampleCardProps {
+  themeId: ThemeName;
+}
+
+/**
+ * Per-theme inline styles for the sample card. Threads `themes[themeId]`,
+ * the variant's font/scale overrides, and `shadowStyle(..., "cardElevationSmall")`
+ * so the card honestly renders each theme's real token output — including its
+ * shadow (hard offset, soft blur, vertical drop, or none). Extracted from the
+ * preview block in ThemeSwitcher; the per-theme treatment is identical.
+ */
+function previewStyles(themeId: ThemeName) {
+  const cardTheme = themes[themeId];
+  const { variant } = parseThemeName(themeId);
+  const def = variantOverrides[variant];
+
+  const sizeScale = def.size ?? size;
+  const lhScale = def.lineHeight ?? lineHeight;
+  const fontFamily = def.fontFamily;
+
+  const sampleCard: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: cardTheme.colors.background,
+    borderColor: cardTheme.colors.border,
+    borderWidth: cardTheme.borderWidth.thin,
+    borderRadius: cardTheme.radius.md,
+    padding: 12,
+    ...shadowStyle(cardTheme, "cardElevationSmall"),
+  };
+
+  const badge: ViewStyle = {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: cardTheme.colors.accentPurple,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: cardTheme.borderWidth.thin,
+    borderColor: cardTheme.colors.border,
+  };
+
+  const badgeText: TextStyle = {
+    color: cardTheme.colors.accentPurpleFg,
+    fontSize: sizeScale.sm,
+    fontWeight: "700",
+  };
+
+  const sampleTitle: TextStyle = {
+    fontSize: sizeScale.sm,
+    fontFamily,
+    fontWeight: "700",
+    color: cardTheme.colors.text,
+  };
+
+  const sampleMeta: TextStyle = {
+    fontSize: sizeScale.xs,
+    fontFamily,
+    color: cardTheme.colors.textSecondary,
+  };
+
+  const ctaPill: ViewStyle = {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: cardTheme.radius.sm,
+    backgroundColor: cardTheme.colors.accentPrimary,
+    borderWidth: cardTheme.borderWidth.thin,
+    borderColor: cardTheme.colors.border,
+  };
+
+  const ctaText: TextStyle = {
+    fontSize: sizeScale.xs,
+    fontFamily,
+    fontWeight: "700",
+    color: cardTheme.colors.background,
+    letterSpacing: 0.5,
+  };
+
+  return {
+    sampleCard,
+    badge,
+    badgeText,
+    sampleTitle,
+    sampleMeta,
+    ctaPill,
+    ctaText,
+  };
+}
+
+/**
+ * Display-only preview of a single theme rendered as a miniature "Daily reading"
+ * card. Pure and theme-parametrized — reads from the static `themes` map by
+ * `themeId`, so it needs no ThemeProvider and never mutates the active theme.
+ * Not interactive: no accessibilityRole, no callbacks.
+ */
+export function ThemeSampleCard({ themeId }: ThemeSampleCardProps) {
+  const { t } = useTranslation(["common"]);
+  const preview = previewStyles(themeId);
+
+  return (
+    <View style={preview.sampleCard}>
+      <View style={preview.badge}>
+        <Text style={preview.badgeText}>★</Text>
+      </View>
+      <View style={styles.sampleTextCol}>
+        <Text style={preview.sampleTitle}>
+          {t("common:theme.preview.title")}
+        </Text>
+        <Text style={preview.sampleMeta}>
+          {t("common:theme.preview.progress")}
+        </Text>
+      </View>
+      <View style={preview.ctaPill}>
+        <Text style={preview.ctaText}>{t("common:theme.preview.cta")}</Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.tsx
+++ b/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.tsx
@@ -2,7 +2,7 @@ import { View, Text, type TextStyle, type ViewStyle } from "react-native";
 import { useTranslation } from "react-i18next";
 import { themes, parseThemeName, type ThemeName } from "../../themes/compose";
 import { variantOverrides } from "../../themes/variants";
-import { size, lineHeight } from "../../themes/tokens";
+import { size } from "../../themes/tokens";
 import { shadowStyle } from "../../styles/shadows";
 import { styles } from "./ThemeSampleCard.styles";
 
@@ -23,7 +23,6 @@ function previewStyles(themeId: ThemeName) {
   const def = variantOverrides[variant];
 
   const sizeScale = def.size ?? size;
-  const lhScale = def.lineHeight ?? lineHeight;
   const fontFamily = def.fontFamily;
 
   const sampleCard: ViewStyle = {

--- a/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.tsx
+++ b/apps/native-rd/src/components/ThemeSampleCard/ThemeSampleCard.tsx
@@ -15,7 +15,9 @@ interface ThemeSampleCardProps {
  * the variant's font/scale overrides, and `shadowStyle(..., "cardElevationSmall")`
  * so the card honestly renders each theme's real token output — including its
  * shadow (hard offset, soft blur, vertical drop, or none). Extracted from the
- * preview block in ThemeSwitcher; the per-theme treatment is identical.
+ * preview block in ThemeSwitcher: the per-theme token treatment (colors, scale,
+ * font, shadow) is preserved verbatim, but ThemeSwitcher-only layout chrome
+ * (header styles, marginTop) is intentionally left behind.
  */
 function previewStyles(themeId: ThemeName) {
   const cardTheme = themes[themeId];

--- a/apps/native-rd/src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx
+++ b/apps/native-rd/src/components/ThemeSampleCard/__tests__/ThemeSampleCard.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { renderWithProviders, screen } from "../../../__tests__/test-utils";
+import { themeOptions } from "../../../hooks/useTheme";
+
+import { ThemeSampleCard } from "../ThemeSampleCard";
+
+const themeIds = themeOptions.map((o) => o.id);
+
+describe("ThemeSampleCard", () => {
+  it.each(themeIds)("renders without crashing for %s", (id) => {
+    renderWithProviders(<ThemeSampleCard themeId={id} />);
+    // The title is theme-independent — its presence confirms the card mounted.
+    expect(screen.getByText("Daily reading")).toBeOnTheScreen();
+  });
+
+  it("renders the preview i18n strings", () => {
+    renderWithProviders(<ThemeSampleCard themeId="light-default" />);
+    expect(screen.getByText("Daily reading")).toBeOnTheScreen();
+    expect(screen.getByText("3 of 5 done")).toBeOnTheScreen();
+    expect(screen.getByText("+ ADD")).toBeOnTheScreen();
+  });
+
+  it("is display-only — exposes no interactive a11y role", () => {
+    renderWithProviders(<ThemeSampleCard themeId="light-default" />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("radio")).toBeNull();
+  });
+});

--- a/apps/native-rd/src/components/ThemeSampleCard/index.ts
+++ b/apps/native-rd/src/components/ThemeSampleCard/index.ts
@@ -1,0 +1,1 @@
+export { ThemeSampleCard } from "./ThemeSampleCard";

--- a/apps/native-rd/src/components/ThemeSwatchRail/ThemeSwatchRail.stories.tsx
+++ b/apps/native-rd/src/components/ThemeSwatchRail/ThemeSwatchRail.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import type { ThemeName } from "../../themes/compose";
+import { ThemeSwatchRail } from "./ThemeSwatchRail";
+
+const meta: Meta<typeof ThemeSwatchRail> = {
+  title: "ThemeSwatchRail",
+  component: ThemeSwatchRail,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ThemeSwatchRail>;
+
+// The rail is controlled (D4) — Welcome/Settings own the state. This wrapper
+// supplies that state in Storybook so swatches respond to taps in the gate.
+function InteractiveRail({ initial }: { initial: ThemeName }) {
+  const [selected, setSelected] = useState<ThemeName>(initial);
+  return <ThemeSwatchRail selectedThemeId={selected} onSelect={setSelected} />;
+}
+
+export const Default: Story = {
+  render: () => <InteractiveRail initial="light-default" />,
+};
+
+export const NightRideSelected: Story = {
+  render: () => (
+    <ThemeSwatchRail selectedThemeId="dark-default" onSelect={() => {}} />
+  ),
+};

--- a/apps/native-rd/src/components/ThemeSwatchRail/ThemeSwatchRail.styles.ts
+++ b/apps/native-rd/src/components/ThemeSwatchRail/ThemeSwatchRail.styles.ts
@@ -1,0 +1,50 @@
+import { StyleSheet } from "react-native-unistyles";
+
+const SWATCH_SIZE = 48;
+
+export const styles = StyleSheet.create((theme) => ({
+  rail: {
+    gap: theme.space[3],
+  },
+  scrollContent: {
+    flexDirection: "row",
+    gap: theme.space[3],
+    paddingVertical: theme.space[1],
+  },
+  swatch: {
+    width: SWATCH_SIZE,
+    height: SWATCH_SIZE,
+    borderRadius: SWATCH_SIZE / 2,
+    overflow: "hidden",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // Fills the circle behind the (centered) check overlay. Absolute so it stays
+  // out of the swatch's flow and the check can center over it.
+  stripeRow: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: "row",
+  },
+  check: {
+    fontSize: theme.size.md,
+    fontWeight: theme.fontWeight.bold,
+  },
+  captionLabel: {
+    fontSize: theme.size.lg,
+    lineHeight: theme.lineHeight.lg,
+    fontWeight: theme.fontWeight.bold,
+    fontFamily: theme.fontFamily.body,
+    color: theme.colors.text,
+  },
+  captionDescription: {
+    fontSize: theme.size.sm,
+    lineHeight: theme.lineHeight.sm,
+    fontFamily: theme.fontFamily.body,
+    color: theme.colors.textSecondary,
+    marginTop: 2,
+  },
+}));

--- a/apps/native-rd/src/components/ThemeSwatchRail/ThemeSwatchRail.tsx
+++ b/apps/native-rd/src/components/ThemeSwatchRail/ThemeSwatchRail.tsx
@@ -1,0 +1,107 @@
+import { View, Text, Pressable, ScrollView } from "react-native";
+import { useTranslation } from "react-i18next";
+import { themeOptions } from "../../hooks/useTheme";
+import { themes, type ThemeName } from "../../themes/compose";
+import { themeA11yLabel } from "../../i18n/labels";
+import { getSwatch, stripeWidths } from "../ThemeChipGrid/swatch-utils";
+import { styles } from "./ThemeSwatchRail.styles";
+
+interface ThemeSwatchRailProps {
+  selectedThemeId: ThemeName;
+  onSelect: (id: ThemeName) => void;
+}
+
+/**
+ * Controlled horizontal rail of circular 3-stripe theme swatches. Stateless —
+ * the parent (Welcome #414 / Settings #415) owns the selected theme. Each
+ * swatch extracts its colors via the shared `getSwatch`/`stripeWidths` so it
+ * stays in lockstep with ThemeChipGrid. The selected swatch's name and
+ * description render below the rail.
+ */
+export function ThemeSwatchRail({
+  selectedThemeId,
+  onSelect,
+}: ThemeSwatchRailProps) {
+  const { t } = useTranslation(["common"]);
+
+  // The radiogroup wrapper collapses descendant Pressables into a single
+  // a11y node on iOS, which hides individual swatches from Maestro element
+  // lookup. Drop the grouping in E2E mode; the Pressables retain their own
+  // `accessible+role=radio+label` so screen readers still treat each swatch
+  // as a discrete radio in production. Mirrors ThemeChipGrid / ThemeSwitcher.
+  const isE2E = process.env.EXPO_PUBLIC_E2E_MODE === "true";
+  const groupingA11y = isE2E
+    ? ({ accessible: false } as const)
+    : ({
+        accessible: true,
+        accessibilityRole: "radiogroup" as const,
+        accessibilityLabel: "Theme selection",
+      } as const);
+
+  return (
+    <View style={styles.rail}>
+      <View {...groupingA11y}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.scrollContent}
+        >
+          {themeOptions.map(({ id }) => {
+            const isSelected = selectedThemeId === id;
+            const swatch = getSwatch(id);
+            const [w1, w2] = stripeWidths[id];
+            const { colors } = themes[id];
+
+            return (
+              <Pressable
+                key={id}
+                onPress={() => onSelect(id)}
+                accessible
+                accessibilityRole="radio"
+                accessibilityState={{ checked: isSelected }}
+                accessibilityLabel={themeA11yLabel(t, id)}
+                style={[
+                  styles.swatch,
+                  {
+                    borderWidth: isSelected ? 3 : 1,
+                    borderColor: isSelected
+                      ? colors.accentPurple
+                      : colors.border,
+                  },
+                ]}
+              >
+                <View
+                  style={[
+                    styles.stripeRow,
+                    { backgroundColor: swatch.stripeBg },
+                  ]}
+                >
+                  <View
+                    style={{ width: `${w1}%`, backgroundColor: swatch.stripe1 }}
+                  />
+                  <View
+                    style={{ width: `${w2}%`, backgroundColor: swatch.stripe2 }}
+                  />
+                </View>
+                {isSelected ? (
+                  <Text style={[styles.check, { color: colors.accentPurple }]}>
+                    ✓
+                  </Text>
+                ) : null}
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      <View>
+        <Text style={styles.captionLabel}>
+          {t(`common:theme.options.${selectedThemeId}.label`)}
+        </Text>
+        <Text style={styles.captionDescription}>
+          {t(`common:theme.options.${selectedThemeId}.description`)}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx
+++ b/apps/native-rd/src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from "../../../__tests__/test-utils";
+import { themeOptions } from "../../../hooks/useTheme";
+import type { ThemeName } from "../../../themes/compose";
+import { i18n } from "../../../i18n";
+import { themeA11yLabel } from "../../../i18n/labels";
+
+import { ThemeSwatchRail } from "../ThemeSwatchRail";
+
+const themeLabelOf = (id: ThemeName) => themeA11yLabel(i18n.t.bind(i18n), id);
+
+describe("ThemeSwatchRail", () => {
+  it("renders one radio per theme option with descriptive labels", () => {
+    renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="light-default" onSelect={jest.fn()} />,
+    );
+    const radios = screen.getAllByRole("radio");
+    expect(radios.length).toBe(themeOptions.length);
+
+    for (const option of themeOptions) {
+      expect(screen.getByLabelText(themeLabelOf(option.id))).toBeOnTheScreen();
+    }
+  });
+
+  it("marks only the selected theme as checked", () => {
+    renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="dark-default" onSelect={jest.fn()} />,
+    );
+    const radios = screen.getAllByRole("radio");
+    const checked = radios.filter(
+      (r) => r.props.accessibilityState?.checked === true,
+    );
+    expect(checked.length).toBe(1);
+    expect(checked[0].props.accessibilityLabel).toBe(
+      themeLabelOf("dark-default"),
+    );
+  });
+
+  it("calls onSelect with the correct theme ID when a swatch is pressed", () => {
+    const onSelect = jest.fn();
+    renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="light-default" onSelect={onSelect} />,
+    );
+    const target = themeOptions[2]; // Bold Ink
+    fireEvent.press(screen.getByLabelText(themeLabelOf(target.id)));
+    expect(onSelect).toHaveBeenCalledWith(target.id);
+  });
+
+  it('exposes the rail as accessibilityRole "radiogroup"', () => {
+    renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="light-default" onSelect={jest.fn()} />,
+    );
+    expect(screen.getByRole("radiogroup")).toBeOnTheScreen();
+  });
+
+  describe("E2E mode gating", () => {
+    const originalE2E = process.env.EXPO_PUBLIC_E2E_MODE;
+    beforeAll(() => {
+      process.env.EXPO_PUBLIC_E2E_MODE = "true";
+    });
+    afterAll(() => {
+      if (originalE2E === undefined) {
+        delete process.env.EXPO_PUBLIC_E2E_MODE;
+      } else {
+        process.env.EXPO_PUBLIC_E2E_MODE = originalE2E;
+      }
+    });
+
+    it("drops radiogroup wrapper so descendant swatch labels are reachable", () => {
+      renderWithProviders(
+        <ThemeSwatchRail
+          selectedThemeId="light-default"
+          onSelect={jest.fn()}
+        />,
+      );
+      // Under EXPO_PUBLIC_E2E_MODE=true the outer grouping is disabled so
+      // Maestro can resolve each swatch's composed accessibilityLabel without
+      // colliding with the parent radiogroup's label.
+      expect(screen.queryByRole("radiogroup")).toBeNull();
+      const radios = screen.getAllByRole("radio");
+      expect(radios.length).toBe(themeOptions.length);
+    });
+  });
+});

--- a/apps/native-rd/src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx
+++ b/apps/native-rd/src/components/ThemeSwatchRail/__tests__/ThemeSwatchRail.test.tsx
@@ -11,7 +11,11 @@ import { themeA11yLabel } from "../../../i18n/labels";
 
 import { ThemeSwatchRail } from "../ThemeSwatchRail";
 
-const themeLabelOf = (id: ThemeName) => themeA11yLabel(i18n.t.bind(i18n), id);
+const t = i18n.t.bind(i18n);
+const themeLabelOf = (id: ThemeName) => themeA11yLabel(t, id);
+const captionLabelOf = (id: ThemeName) => t(`common:theme.options.${id}.label`);
+const captionDescriptionOf = (id: ThemeName) =>
+  t(`common:theme.options.${id}.description`);
 
 describe("ThemeSwatchRail", () => {
   it("renders one radio per theme option with descriptive labels", () => {
@@ -55,6 +59,38 @@ describe("ThemeSwatchRail", () => {
       <ThemeSwatchRail selectedThemeId="light-default" onSelect={jest.fn()} />,
     );
     expect(screen.getByRole("radiogroup")).toBeOnTheScreen();
+  });
+
+  it("renders the ✓ overlay on exactly the selected swatch", () => {
+    renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="dark-default" onSelect={jest.fn()} />,
+    );
+    expect(screen.getAllByText("✓")).toHaveLength(1);
+  });
+
+  it("shows the selected theme's name and description in the caption", () => {
+    renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="dark-default" onSelect={jest.fn()} />,
+    );
+    expect(screen.getByText(captionLabelOf("dark-default"))).toBeOnTheScreen();
+    expect(
+      screen.getByText(captionDescriptionOf("dark-default")),
+    ).toBeOnTheScreen();
+  });
+
+  it("updates the caption when the selected theme changes", () => {
+    const { rerender } = renderWithProviders(
+      <ThemeSwatchRail selectedThemeId="light-default" onSelect={jest.fn()} />,
+    );
+    expect(screen.getByText(captionLabelOf("light-default"))).toBeOnTheScreen();
+
+    rerender(
+      <ThemeSwatchRail selectedThemeId="dark-default" onSelect={jest.fn()} />,
+    );
+    expect(screen.getByText(captionLabelOf("dark-default"))).toBeOnTheScreen();
+    expect(
+      screen.queryByText(captionLabelOf("light-default")),
+    ).not.toBeOnTheScreen();
   });
 
   describe("E2E mode gating", () => {

--- a/apps/native-rd/src/components/ThemeSwatchRail/index.ts
+++ b/apps/native-rd/src/components/ThemeSwatchRail/index.ts
@@ -1,0 +1,1 @@
+export { ThemeSwatchRail } from "./ThemeSwatchRail";


### PR DESCRIPTION
## Summary

Adds the two pure, theme-parametrized picker components for the Full Ride redesign (Epic #384, Track E): **`ThemeSampleCard`** (the signature per-theme live-preview card) and **`ThemeSwatchRail`** (a horizontal rail of circular 3-stripe swatches). Both are presentational and **not yet mounted in any screen** — Welcome (#414) and Settings (#415) own that wiring.

The honesty matrix is the point: each card renders its theme's **real** bg, border, shadow on/off, and font via `themes[id]` / `variantOverrides[variant]` / `shadowStyle(...)` — no recolored placeholders.

## Changes

- **`refactor(ThemeChipGrid)`** — extracted `ChipSwatch` + `getSwatch` + `stripeWidths` into a shared `swatch-utils.ts` (verbatim, behavior-preserving) so the rail and the grid single-source their swatch colors and never drift.
- **`feat(ThemeSampleCard)`** — extracted the per-theme preview card subset of `ThemeSwitcher`'s `previewStyles` into a standalone, display-only component (`themeId: ThemeName` prop; no callbacks, no a11y role). Drops the picker-header `label`/`description`/`checkmark` styles and the outer `marginTop` (spacing is the parent's job).
- **`feat(ThemeSwatchRail)`** — controlled (`selectedThemeId` + `onSelect`) horizontal rail of 48pt circular radio swatches, selected theme name/description below. Mirrors ThemeChipGrid's E2E-gated `radiogroup` a11y pattern.
- Stories (incl. `AllThemesMatrix` reviewer visual gate) + unit tests for both.

> **Token/shadow note:** Issue #413's AC claims Night Ride and Clean Signal render shadowless. Verified against the built tokens — that's factually wrong (`lowInfo` never sets `shadows.opacity:0`; Night Ride's `darkShadow` is a real `0px 6px 0` drop). These components honestly render token output; whether those *tokens* should change is a design call tracked in **#429**, not a change here. See plan Decision D7 + Shadow Honesty Matrix.

## Dependencies

- [x] None — independent (Wave 1).

## Test Plan

- [x] Tests pass locally (`bun run test`) — 14/14 in the two new suites; full suite green
- [x] Lint passes (`bun run lint`)
- [x] Type check passes (`bun run type-check`)
- [x] Format check passes (`bun run format:check`)
- [ ] **Storybook visual gate (reviewer, still pending):** load `ThemeSampleCard.AllThemesMatrix` and verify all 7 shadow/font treatments by eye — Night Ride vertical 6px drop; Bold Ink / Still Water / Loud & Clear no shadow; Warm Studio soft shadow + Lexend; Loud & Clear / Clean Signal Atkinson Hyperlegible. **This visual gate _is_ the design check** — green type-check ≠ design verified.
- a11y audit (`test:a11y`): N/A — not mounted in a screen yet; the radio/radiogroup contract is covered by unit tests (incl. the E2E-mode grouping drop).

## Review summary (4 specialized agents — no blockers)

General code review: **clean / ship it.** Type design: props interfaces textbook controlled/display-component, no `any`/casts. The `stripeWidths` `Record<ThemeName, …>` is compiler-enforced exhaustive over the 7 product themes (ThemeName is the 7-member product union, *not* the 14-member `AllThemeName`) — no index-miss crash possible.

Non-blocking follow-ups (recommended, all additive — tracked here per "review findings never chat-only"):

- [ ] Test: assert the selected swatch's `✓` overlay renders (currently only the `accessibilityState.checked` flag is tested, from a different expression).
- [ ] Test: assert the caption below the rail reflects `selectedThemeId` (all 7 strings distinct; a two-render test proves the binding).
- [ ] Test: make `ThemeSampleCard`'s `it.each` loop assert a per-theme style value (e.g. `backgroundColor`) instead of only the theme-independent title.
- [ ] Test: assert `ThemeSampleCard` wires `shadowStyle(...)` onto the card style (`shadowOpacity` 0 for highContrast, >0 for default) — the wiring seam is untested even though token math is.
- [ ] Type: `stripeWidths` → `as const satisfies Record<ThemeName, readonly [number, number]>` (keeps exhaustiveness, adds `readonly`).
- [ ] Comment: tighten "the per-theme treatment is identical" at `ThemeSampleCard.tsx:18` (it drops `marginTop` + header styles).

## Related Issues

Closes #413

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JReic46yUuQHzGF2ujqJ19
