### PR TITLE
feat(evidence-type-picker): capture-mode sheet + stories (#409)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-409-evidence-type-picker-sheet.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-409-evidence-type-picker-sheet.md
@@ -1,0 +1,179 @@
+# Development Plan: Issue #409
+
+## Issue Summary
+
+**Title**: [Storybook] Evidence-type picker sheet
+**Type**: enhancement (re-skin existing component + add missing story)
+**Complexity**: SMALL
+**Estimated Lines**: ~260 lines (incl. story + tests + i18n)
+
+Re-skins `src/components/EvidenceTypePicker/EvidenceTypePicker.tsx` — which already
+owns the canonical 6-type list, labels, icons, and a11y keys — to add a new
+**`mode="capture"`** presentation: the "Add evidence" modal bottom sheet from
+`Add Evidence Nav.dc.html` (type-pick stage only) and `Focus Mode A Prototype.dc.html`'s
+"Evidence type" sheet. Adds the missing `EvidenceTypePicker.stories.tsx` covering the
+capture sheet, the existing authoring chip grid, and the compact variant, across all 7
+product themes. No app wiring — not imported by any screen yet (#377 owns that).
+
+**Canonical flow reference:** `App Shell (token-backed).dc.html` is the end-to-end
+interactive prototype. It shows the picker as a single-select sheet (`focus.openPicker`
+→ pick sets the planned type + closes) opened by an _external_ `[icon label  change]`
+card row (line 165) — which #408's `FocusCurrentTaskCard` already ships. That fixes the
+"change" affordance as external, not an in-sheet control (see D6).
+
+## Intent Verification
+
+- [ ] When `mode="capture"` and `visible`, a modal bottom sheet renders with header
+      "Add evidence", sub-line "Saving to your active step · {activeStepTitle}", and a
+      3-column grid of the 6 `EVIDENCE_OPTIONS` (Photo, Video, Voice, Note, Link, File)
+      using the same icons/labels as the authoring chip grid.
+- [ ] Tapping a type in the sheet calls `onSelectType(type)` — the sheet does not own
+      capture-flow state (no "confirm"/"done" stages; those belong to the screen
+      integration, out of scope here).
+- [ ] When a `selectedType` is passed to the capture sheet, that type renders with a
+      selected/highlighted visual state and "Note" (`EvidenceType.text`) is the type
+      pre-highlighted when no `selectedType` is given (prototype: "Note is the easy
+      default").
+- [ ] The "change" affordance is the sheet **being re-opened with the current type
+      pre-highlighted** — NOT an in-sheet "Change" row. Opening the sheet with a
+      non-default `selectedType`, then tapping a different cell, swaps the pick and fires
+      `onSelectType`. The invokers (the planned-evidence card row shipped in #408, the
+      nav "+") live outside this component (#377 wires them). Confirmed against
+      `App Shell (token-backed).dc.html` (`focus.openPicker`/`closePicker` + the external
+      `[icon label  change]` card row at line 165), which has no in-sheet "Change" control.
+- [ ] The existing authoring chip grid (multi-select, `onToggleType`) and `compact`
+      variant render unchanged — same DOM output, same tests pass, zero behavior
+      regression.
+- [ ] `EvidenceTypePicker.stories.tsx` exposes: the capture sheet (default + a
+      "change" open state), the authoring chip grid, the compact variant, and an
+      `AllThemesMatrix` story rendering the capture sheet across all 7 product themes.
+- [ ] Every color/spacing/radius/shadow value in new code resolves through `theme.*` —
+      `grep -n "#[0-9a-fA-F]\{3,6\}"` on the two edited/added source files (excluding
+      the emoji icon strings already in `EVIDENCE_OPTIONS`) returns nothing.
+- [ ] All interactive targets (6 type cells + close + change) measure ≥44×44pt and
+      carry `accessibilityRole`/`accessibilityLabel`.
+
+## Dependencies
+
+| Issue | Title                                               | Status | Type |
+| ----- | --------------------------------------------------- | ------ | ---- |
+| none  | Issue body states "Dependencies: none — start now." | ✅ Met | —    |
+
+**Status**: ✅ All dependencies met — no blockers.
+
+Not a dependency, but load-bearing context: **#408** (`FocusCurrentTaskCard`, merged in
+`824c1f52`) already ships `onChangeEvidenceType?: () => void` — a bare callback the
+in-progress card wires to a pressable "planned evidence" box + inline "change" text —
+with an explicit comment: `// app plumbing (#377 owns the real wiring; #409 owns the
+type-change sheet)`. This issue's capture-sheet API is what that callback will
+eventually open (wiring itself is #377, not this issue).
+
+## Objective
+
+Add a `mode` prop to the existing `EvidenceTypePicker` that switches its presentation
+between the current inline authoring chip grid (`mode="authoring"`, the default — fully
+backward compatible) and a new modal bottom-sheet capture picker (`mode="capture"`)
+matching the prototype. Both modes read from the same `EVIDENCE_OPTIONS` /
+`evidenceLabel` / `common:a11y.*` source — no second type list. Ship
+`EvidenceTypePicker.stories.tsx` with theme coverage. No screen imports this component
+yet; that lands in #377.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Alternatives Considered                                                                                                                                                                                                                                                                 | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Add `mode="capture"` **to the existing component** (not a thin wrapper).                                                                                                                                                                                                                                                                                                                                                                                                | (a) Thin `EvidenceTypeSheet` wrapper component that imports `EVIDENCE_OPTIONS`/`evidenceLabel` directly and renders its own grid, delegating nothing to `EvidenceTypePicker`. (b) Wrapper that renders `<Modal>` around the existing `EvidenceTypePicker` full-mode chip grid unstyled. | (b) fails the acceptance criterion outright — the prototype's sheet is a 3-column icon-over-label grid with single-select-to-highlight semantics, visually and interactively distinct from the multi-select pill chips; wrapping the existing render output can't reshape it. (a) satisfies "single option/label/icon/a11y source" only by re-importing the same modules a second time, duplicating the render/JSX logic (icon+label cell, a11y hint construction) across two files for one component's two facades — more surface area for the two to drift, and it's a second public component to discover/import correctly. Extending the existing component with a `mode` prop keeps one file owning "how a 6-type option renders," with `mode` only changing selection semantics (multi-toggle vs. single-pick-to-highlight) and container (`View` vs. `Modal` sheet). This matches the issue's own framing ("keep the option/label/icon/a11y source single") most directly. |
+| D2  | Sheet uses RN's built-in `Modal` (`transparent`, `animationType="slide"`, `onRequestClose`, `accessibilityViewIsModal`) — the same primitive as `ConfirmDeleteModal`, `IconPickerModal`, `PhotoViewerModal`, `VideoPlayerModal`, `AudioPlayerModal`, `TextNoteViewerModal`.                                                                                                                                                                                             | `EvidenceDrawer`'s bespoke `Animated.View` + manual overlay + `useSharedValue` height animation (no `Modal`, always mounted, positioned `absolute` inside the screen).                                                                                                                  | `EvidenceDrawer` is legacy pre-redesign code explicitly slated for deletion in #377 ("delete `MiniTimeline`/`ProgressDots`/`CardCarousel`/`EvidenceDrawer` usage" — `docs/plans/2026-06-29-full-ride-redesign-rescope.md`). Every other modal in the app (6 of them) uses RN `Modal`, which also gives free platform a11y behavior (VoiceOver/TalkBack focus containment, Android back-button → `onRequestClose`) satisfying the issue's "focus management + dismiss + a11y roles" acceptance line without hand-rolling it. `Modal` also matches web Storybook's `@storybook/react-native-web-vite` shim, which portals via `react-native-web`'s `Modal` (preserves React context, so `ScopedTheme` in the `AllThemesMatrix` story still resolves correctly through the portal).                                                                                                                                                                                                  |
+| D3  | Capture-sheet API is a **single-select picker**: tapping a cell fires `onSelectType(type)` and the controlled caller sets the planned type + flips `visible` to close (matching the prototype's `pick: () => …{planned:{...o}}, pickerOpen:false`). This component only renders **the type-pick stage** of the prototype sheet (header, sub-line, 6-cell grid) — no confirm/done stages.                                                                                | Building the full 3-stage prototype flow (pick → confirm "Save to step {title}" with a step-swap list → "Saved to {title}" done toast) inside this component.                                                                                                                           | The confirm/done stages operate on **steps**, not evidence types — "Save to step {title}", the step-swap list, and "Your evidence count just ticked up" all require step data and capture-flow state this presentational component has no reason to hold. The issue itself draws this line: "No app wiring — the nav '+' + active-step targeting is #377."                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| D6  | **No in-sheet "change" control.** The "change" affordance is the _external_ planned-evidence card row (`[icon  label  change]`) that opens this sheet — already shipped in #408's `FocusCurrentTaskCard` via `onChangeEvidenceType`. This component satisfies "change" by being re-openable with the current pick pre-highlighted (`selectedType`) so the user can tap a different type. (Supersedes the researcher's earlier optional `onRequestChange` in-sheet row.) | An optional `onRequestChange` prop rendering a "Change" row inside the sheet (earlier draft).                                                                                                                                                                                           | `App Shell (token-backed).dc.html` is the canonical end-to-end flow and has **no** in-sheet "Change" control: line 165 is the external card row (`onClick=focus.openPicker`, with a blue "change" label), and the picker sheet at line 624 (`focus.openPicker`/`closePicker`) is a bare `Evidence type ×` grid that highlights the current planned type (`bg: cs.planned.label === o.label ? …`) and closes on pick. Rendering a "Change" row inside the sheet would duplicate the external affordance and diverge from the prototype.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| D4  | New copy strings ("Add evidence", "Saving to your active step · {title}", "Change") go in the existing `common` namespace (`src/i18n/resources/en/common.json`), nested under a new `evidenceTypePicker` key — not a new namespace.                                                                                                                                                                                                                                     | New `focusMode.json` keys (since the sub-line references "active step") or a brand-new namespace.                                                                                                                                                                                       | `EvidenceTypePicker` already imports only `common` (`useTranslation(["common"])`, `evidenceLabel`/`common:a11y.*`). The component has no screen/feature affinity — it's used from step-authoring today and will be used from Focus Mode later (#377) — so its own copy belongs beside its own `a11y.*` block in `common`, not borrowed into a screen-specific namespace it doesn't otherwise depend on.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| D5  | "Note" (`EvidenceType.text`) is the default highlighted cell in capture mode when the caller passes no `selectedType`, matching `Focus Mode A Prototype.dc.html`'s "Note is the easy default."                                                                                                                                                                                                                                                                          | Requiring callers to always pass an explicit `selectedType`; defaulting to the first `EVIDENCE_OPTIONS` entry (Photo).                                                                                                                                                                  | The issue quotes this prototype line verbatim as a requirement, and `EVIDENCE_OPTIONS[0]` is `photo`, not `text` — so the default has to be an explicit fallback in the component, not "just pick index 0."                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+## Affected Areas
+
+- `src/components/EvidenceTypePicker/EvidenceTypePicker.tsx`: add `mode: "authoring" \| "capture"` prop (default `"authoring"`, preserving current behavior exactly); add capture-mode render path (`Modal` + header + sub-line + 3-col grid, no in-sheet "change" row per D6); add `selectedType`, `onSelectType`, `activeStepTitle`, `visible`, `onClose` props scoped to capture mode. Prop names `visible`/`onClose` match the sibling-modal convention (`IconPickerModal`, `PhotoViewerModal`, `TextNoteViewerModal`, `AudioPlayerModal` all use `visible: boolean` + `onClose: () => void`).
+- `src/components/EvidenceTypePicker/EvidenceTypePicker.styles.ts`: add capture-sheet styles (`overlay`, `sheet`, `handle`, `header`, `subLine`, `grid`, `cell`, `cellSelected`, `cellIcon`, `cellLabel`, `changeAffordance`) using `theme.*` tokens (`theme.radius.xl` for top corners per `EvidenceDrawer` prior art, `theme.shadow.modalElevation`/`shadowStyle` for the sheet, `theme.colors.shadow` + alpha for the overlay per `ConfirmDeleteModal`/`EvidenceDrawer` prior art).
+- `src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx`: extend with a `describe("capture mode")` block; existing `full mode` / `compact mode` blocks untouched (still exercise `mode="authoring"` default, backward compatible — no prop changes needed on existing call sites since `mode` defaults to `"authoring"` and `compact` behavior is unchanged).
+- `src/components/EvidenceTypePicker/EvidenceTypePicker.stories.tsx` (new): capture sheet (default, "Note" highlighted; a second story with a non-default `selectedType`), authoring chip grid, compact variant, `AllThemesMatrix` for the capture sheet across all 7 product themes.
+- `src/i18n/resources/en/common.json`: add `evidenceTypePicker.addEvidence` and `evidenceTypePicker.savingToActiveStep` (`{{title}}` interpolation). Reuse `common:actions.close` for the sheet's close/backdrop a11y label (no new key). No `change` key (D6).
+- `src/i18n/resources/de/common.json`, `src/i18n/resources/pseudo/common.json`: populated by `bun run i18n:sync` after the `en` keys land (not hand-written; doesn't count against the LOC budget per `docs/plans/2026-06-29-full-ride-redesign-rescope.md`, D11 precedent).
+
+## Implementation Plan
+
+### Step 1: Extend types + props for capture mode
+
+**Files**: `src/components/EvidenceTypePicker/EvidenceTypePicker.tsx`
+**Commit**: `feat(evidence-type-picker): add capture mode prop surface`
+**Changes**:
+
+- [ ] Add `mode?: "authoring" | "capture"` (default `"authoring"`) to `EvidenceTypePickerProps`.
+- [ ] Add capture-only props: `visible?: boolean` (Modal visibility — capture mode only), `activeStepTitle?: string`, `selectedType?: EvidenceTypeValue` (defaults to `EvidenceType.text` inside the capture branch per D5), `onSelectType?: (type: EvidenceTypeValue) => void` (fires on cell tap; controlled caller updates selection + closes), `onClose?: () => void` (closes the sheet — wired to `Modal.onRequestClose`, backdrop tap, and the header `×` control). No `onRequestChange` (D6 — the "change" affordance is external).
+- [ ] Guard: when `mode === "capture"`, `compact` and `onToggleType`/`selectedTypes` (the multi-select props) are ignored — keep the existing prop set on the interface as-is (no breaking removal) but branch rendering on `mode` before `compact`.
+- [ ] Import `EvidenceType` from `../../db` (already a test-only import today; promote to a real import for the D5 default) and `Modal`, `Pressable` (already imported) from `react-native`.
+
+### Step 2: Capture-sheet render path + styles
+
+**Files**: `src/components/EvidenceTypePicker/EvidenceTypePicker.tsx`, `src/components/EvidenceTypePicker/EvidenceTypePicker.styles.ts`
+**Commit**: `feat(evidence-type-picker): render capture-mode modal sheet`
+**Changes**:
+
+- [ ] `EvidenceTypePicker.styles.ts`: add `overlay` (absolute fill, backgroundColor built as a template literal on `theme.colors.shadow` with an alpha suffix, directly inside the `StyleSheet.create((theme) => ...)` callback — confirmed working via `EvidenceDrawer.styles.ts:20`'s identical template-literal-alpha-on-`theme.colors.shadow` usage; no inline-style workaround needed), `sheet` (bottom-anchored, `borderTopLeftRadius`/`borderTopRightRadius: theme.radius.xl`, `borderTopWidth: theme.borderWidth.thick`, `borderColor: theme.colors.border`, `backgroundColor: theme.colors.background`, `...shadowStyle(theme, "modalElevation")`), `handle` (small centered bar, `theme.colors.textMuted` or `border`), `sheetHeader` (title row), `sheetTitle`, `subLine` (`theme.colors.textMuted`, `fontFamily: theme.fontFamily.mono` matching the prototype's DM Mono sub-line), `grid` (`flexDirection: row`, `flexWrap: wrap`, 3-up via `width: "31%"` or `flexBasis` — verify against existing grid patterns in the codebase for the exact 3-column technique, e.g. `IconPickerModal.styles`'s `MODAL_GRID_COLUMNS` constant approach), `cell` (`minHeight: 44`, `borderWidth: theme.borderWidth.thick`, `borderColor: theme.colors.border`, `backgroundColor: theme.colors.background`, `...shadowStyle(theme, "cardElevationSmall")`), `cellSelected` (`backgroundColor: theme.colors.accentPrimary` matching the existing `chipSelected` treatment for consistency), `cellIcon`, `cellLabel`, `cellLabelSelected`. (No `changeRow` style — D6.)
+- [ ] `EvidenceTypePicker.tsx`: add the capture branch — checked first in the render function, before the existing `if (compact)` check. Structure: `<Modal transparent animationType="slide" visible={visible} onRequestClose={onClose} accessibilityViewIsModal>` wrapping an overlay `Pressable` (dismiss on backdrop tap, `accessibilityLabel` via reused `common:actions.close`) + the bottom sheet `View` containing: handle bar, header row ("Add evidence" title using `common:evidenceTypePicker.addEvidence` + a `×` close `Pressable` calling `onClose`, matching the prototype's `Evidence type ×` header control), sub-line (`common:evidenceTypePicker.savingToActiveStep` interpolated with `activeStepTitle` — render nothing if `activeStepTitle` is omitted, don't throw), and the 6-cell grid (map `EVIDENCE_OPTIONS`, same icon/label source, `accessibilityRole="radio"` + `accessibilityState={{ checked: opt.type === effectiveSelectedType }}` since this is single-select, not the authoring grid's `checkbox` role). No "Change" row (D6).
+- [ ] Each grid cell's `onPress` calls `onSelectType?.(opt.type)`. No internal `stage` state machine (confirm/done) — pressing a cell is a single synchronous callback; the controlled caller updates the selection and closes the sheet (`visible=false`), mirroring the prototype's `pick` handler (`{planned:{...o}}, pickerOpen:false`). Consistent with D3.
+
+### Step 3: i18n keys (en source + sync)
+
+**Files**: `src/i18n/resources/en/common.json`
+**Commit**: `feat(i18n): add evidence-type picker capture-sheet copy`
+**Changes**:
+
+- [ ] Add `evidenceTypePicker: { addEvidence: "Add evidence", savingToActiveStep: "Saving to your active step · {{title}}" }` to `src/i18n/resources/en/common.json`. (No `change` key — the "change" label lives on #408's already-shipped card, not this sheet; D6.)
+- [ ] Decide close-button a11y label: reuse `common:actions.close` (already exists, generic "Close") rather than minting a new key — apply it directly in Step 2's close/backdrop `accessibilityLabel`.
+- [ ] Run `bun run i18n:sync` to populate `de`/`pseudo` locales (excluded from the LOC budget; verify it completes without manual edits needed, per `docs/plans/2026-06-29-full-ride-redesign-rescope.md` D11 precedent).
+- [ ] Run `bun run i18n:lint-source` if it's part of the standard pre-PR gate (check `package.json` script list at implementation time — it's `bun run scripts/i18n/lintSource.cli.ts`).
+
+### Step 4: Tests
+
+**Files**: `src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx`
+**Commit**: `test(evidence-type-picker): cover capture-mode sheet`
+**Changes**:
+
+- [ ] New `describe("capture mode")` block: renders all 6 options with correct labels/icons when `mode="capture"` and `visible`; defaults to `EvidenceType.text` ("Note") highlighted when `selectedType` omitted (D5); highlights the passed `selectedType` when provided (the "change" re-open scenario — D6); calls `onSelectType` with the correct type on cell press; each cell has `accessibilityRole="radio"` and correct `accessibilityState={{ checked }}`; renders the sub-line with the interpolated `activeStepTitle` when provided, omits it when not; `onClose` fires on backdrop press, on the header `×`, and via `onRequestClose`.
+- [ ] Confirm existing `full mode` / `compact mode` describe blocks pass unmodified (they exercise the default `mode="authoring"` path — no prop changes required on those call sites).
+- [ ] Use `test.each` for the 6-option label/icon assertions where the existing suite already does (mirrors existing `it.each` for hint text).
+
+### Step 5: Storybook stories
+
+**Files**: `src/components/EvidenceTypePicker/EvidenceTypePicker.stories.tsx` (new)
+**Commit**: `docs(evidence-type-picker): add capture sheet, authoring grid, compact stories`
+**Changes**:
+
+- [ ] `CaptureSheet` story: `useState` for `visible`/`selectedType` (mirrors `ConfirmDeleteModal.stories.tsx`'s trigger-button + `useState` pattern), a trigger button, `activeStepTitle="Wire the relay panel"` (prototype's sample step title), Note pre-highlighted.
+- [ ] `CaptureSheetChangeScenario` story: same as above but opened with a non-default `selectedType` (e.g. `photo`) — the "change" re-open case (D6), demonstrating the highlighted cell differs from the Note default. (No `onRequestChange`/in-sheet "Change" row; this story IS the "change" affordance demonstration — the sheet re-opened on an existing pick.)
+- [ ] `AuthoringChipGrid` story: existing full-mode multi-select chip grid (`mode="authoring"` — the default; can omit `mode` entirely to also prove backward compatibility).
+- [ ] `Compact` story: existing compact variant.
+- [ ] `AllThemesMatrix` story: capture sheet only (the newly-added surface), looping `themeNames` from `../../themes/compose` with `ScopedTheme`, following `FocusCurrentTaskCard.stories.tsx`'s `AllThemesMatrix` pattern exactly (same `MOOD_NAMES` map literal, same matrix container/label/card styling approach) — reuse rather than reinvent the per-theme labeling.
+
+## Testing Strategy
+
+- [ ] Unit tests for `EvidenceTypePicker` capture mode (Jest 30, `@testing-library/react-native` v13) — colocated in the existing `src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx` (this component's established convention is a local `__tests__/` dir, not the `src/__tests__/` mirror — keep consistent with the existing file rather than relocating).
+- [ ] `test.each` for the 6-option assertions, matching the existing suite's style.
+- [ ] Manual testing: `bun run storybook:web`, verify the `CaptureSheet`, `CaptureSheetWithChange`, `AuthoringChipGrid`, `Compact`, and `AllThemesMatrix` stories render correctly via the theme toolbar / matrix across all 7 product themes (`light-default`, `dark-default`, `light-highContrast`, `light-dyslexia`, `light-autismFriendly`, `light-lowVision`, `light-lowInfo`); confirm no hardcoded hex via `grep -n "#[0-9a-fA-F]\{3,6\}" src/components/EvidenceTypePicker/EvidenceTypePicker.tsx src/components/EvidenceTypePicker/EvidenceTypePicker.styles.ts` (expect zero matches outside the `EVIDENCE_OPTIONS` emoji icon strings, which live in `src/types/evidence.ts`, not these two files).
+- [ ] `bun run type-check` and `bun run lint` after each commit.
+- [ ] `bun run test --testPathPatterns EvidenceTypePicker` scoped run before the full suite.
+
+## Not in Scope
+
+| Item                                                                                                                                                            | Reason                                                                                                                                               | Follow-up                                |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| Confirm stage ("Save to step {title}", step-swap list) and done stage ("Saved to {title}. Your evidence count just ticked up.") from `Add Evidence Nav.dc.html` | Operates on step-target state, not evidence type; issue explicitly scopes this out ("No app wiring — the nav '+' + active-step targeting is #377")   | #377                                     |
+| Wiring the nav "+" button or #408's `onChangeEvidenceType` callback to actually open this sheet                                                                 | App integration; this issue ships Storybook-only, not imported by any screen                                                                         | #377                                     |
+| Deleting `EvidenceDrawer`/`FABMenu`/`MiniTimeline`/`ProgressDots`/`CardCarousel` (old Focus Mode chrome)                                                        | Tracked separately as part of the Focus Mode rebuild integration                                                                                     | #377 (per rescope plan)                  |
+| Actual evidence capture (photo/video/voice/note/link/file input screens)                                                                                        | Pre-existing capture screens (`CaptureTextNote`, `CapturePhoto`, etc.) already exist independently; this sheet only picks a type, it doesn't capture | none — out of this epic's scope entirely |
+| A dedicated a11y string for the sheet's close affordance                                                                                                        | `common:actions.close` (generic "Close") already covers it; minting a duplicate key adds maintenance surface for no behavioral gain                  | none                                     |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/docs/plans/dev-plans/issue-409-evidence-type-picker-sheet.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-409-evidence-type-picker-sheet.md
@@ -23,35 +23,40 @@ card row (line 165) — which #408's `FocusCurrentTaskCard` already ships. That 
 
 ## Intent Verification
 
-- [ ] When `mode="capture"` and `visible`, a modal bottom sheet renders with header
+- [x] When `mode="capture"` and `visible`, a modal bottom sheet renders with header
       "Add evidence", sub-line "Saving to your active step · {activeStepTitle}", and a
       3-column grid of the 6 `EVIDENCE_OPTIONS` (Photo, Video, Voice, Note, Link, File)
-      using the same icons/labels as the authoring chip grid.
-- [ ] Tapping a type in the sheet calls `onSelectType(type)` — the sheet does not own
+      using the same icons/labels as the authoring chip grid. _(Structure + copy unit-tested;
+      pixel rendering pending the manual `storybook:web` pass below.)_
+- [x] Tapping a type in the sheet calls `onSelectType(type)` — the sheet does not own
       capture-flow state (no "confirm"/"done" stages; those belong to the screen
-      integration, out of scope here).
-- [ ] When a `selectedType` is passed to the capture sheet, that type renders with a
+      integration, out of scope here). _(Tested: `it.each` over all 6 types.)_
+- [x] When a `selectedType` is passed to the capture sheet, that type renders with a
       selected/highlighted visual state and "Note" (`EvidenceType.text`) is the type
       pre-highlighted when no `selectedType` is given (prototype: "Note is the easy
-      default").
-- [ ] The "change" affordance is the sheet **being re-opened with the current type
+      default"). _(Tested: default-Note + explicit-Photo highlight cases.)_
+- [x] The "change" affordance is the sheet **being re-opened with the current type
       pre-highlighted** — NOT an in-sheet "Change" row. Opening the sheet with a
       non-default `selectedType`, then tapping a different cell, swaps the pick and fires
       `onSelectType`. The invokers (the planned-evidence card row shipped in #408, the
       nav "+") live outside this component (#377 wires them). Confirmed against
       `App Shell (token-backed).dc.html` (`focus.openPicker`/`closePicker` + the external
       `[icon label  change]` card row at line 165), which has no in-sheet "Change" control.
-- [ ] The existing authoring chip grid (multi-select, `onToggleType`) and `compact`
+      _(No `onRequestChange`/Change row in the API; `CaptureSheetChangeScenario` story demos it.)_
+- [x] The existing authoring chip grid (multi-select, `onToggleType`) and `compact`
       variant render unchanged — same DOM output, same tests pass, zero behavior
-      regression.
-- [ ] `EvidenceTypePicker.stories.tsx` exposes: the capture sheet (default + a
+      regression. _(14 pre-existing tests pass unmodified.)_
+- [x] `EvidenceTypePicker.stories.tsx` exposes: the capture sheet (default + a
       "change" open state), the authoring chip grid, the compact variant, and an
       `AllThemesMatrix` story rendering the capture sheet across all 7 product themes.
-- [ ] Every color/spacing/radius/shadow value in new code resolves through `theme.*` —
+      _(Matrix tiles `CaptureSheetBody` inline per D7; visual confirmation pending below.)_
+- [x] Every color/spacing/radius/shadow value in new code resolves through `theme.*` —
       `grep -n "#[0-9a-fA-F]\{3,6\}"` on the two edited/added source files (excluding
-      the emoji icon strings already in `EVIDENCE_OPTIONS`) returns nothing.
-- [ ] All interactive targets (6 type cells + close + change) measure ≥44×44pt and
-      carry `accessibilityRole`/`accessibilityLabel`.
+      the emoji icon strings already in `EVIDENCE_OPTIONS`) returns nothing. _(Only match
+      is `#377`, an issue reference in a doc comment — not a color.)_
+- [x] All interactive targets (6 type cells + close + change) measure ≥44×44pt and
+      carry `accessibilityRole`/`accessibilityLabel`. _(Cells `minHeight:44` + ~⅓ sheet width;
+      close `44×44`; each cell `role="radio"`+label, close `role="button"`+label.)_
 
 ## Dependencies
 
@@ -88,6 +93,8 @@ yet; that lands in #377.
 | D6  | **No in-sheet "change" control.** The "change" affordance is the _external_ planned-evidence card row (`[icon  label  change]`) that opens this sheet — already shipped in #408's `FocusCurrentTaskCard` via `onChangeEvidenceType`. This component satisfies "change" by being re-openable with the current pick pre-highlighted (`selectedType`) so the user can tap a different type. (Supersedes the researcher's earlier optional `onRequestChange` in-sheet row.) | An optional `onRequestChange` prop rendering a "Change" row inside the sheet (earlier draft).                                                                                                                                                                                           | `App Shell (token-backed).dc.html` is the canonical end-to-end flow and has **no** in-sheet "Change" control: line 165 is the external card row (`onClick=focus.openPicker`, with a blue "change" label), and the picker sheet at line 624 (`focus.openPicker`/`closePicker`) is a bare `Evidence type ×` grid that highlights the current planned type (`bg: cs.planned.label === o.label ? …`) and closes on pick. Rendering a "Change" row inside the sheet would duplicate the external affordance and diverge from the prototype.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | D4  | New copy strings ("Add evidence", "Saving to your active step · {title}", "Change") go in the existing `common` namespace (`src/i18n/resources/en/common.json`), nested under a new `evidenceTypePicker` key — not a new namespace.                                                                                                                                                                                                                                     | New `focusMode.json` keys (since the sub-line references "active step") or a brand-new namespace.                                                                                                                                                                                       | `EvidenceTypePicker` already imports only `common` (`useTranslation(["common"])`, `evidenceLabel`/`common:a11y.*`). The component has no screen/feature affinity — it's used from step-authoring today and will be used from Focus Mode later (#377) — so its own copy belongs beside its own `a11y.*` block in `common`, not borrowed into a screen-specific namespace it doesn't otherwise depend on.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | D5  | "Note" (`EvidenceType.text`) is the default highlighted cell in capture mode when the caller passes no `selectedType`, matching `Focus Mode A Prototype.dc.html`'s "Note is the easy default."                                                                                                                                                                                                                                                                          | Requiring callers to always pass an explicit `selectedType`; defaulting to the first `EVIDENCE_OPTIONS` entry (Photo).                                                                                                                                                                  | The issue quotes this prototype line verbatim as a requirement, and `EVIDENCE_OPTIONS[0]` is `photo`, not `text` — so the default has to be an explicit fallback in the component, not "just pick index 0."                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+| D7 | Extract the sheet body (handle + header + sub-line + 3-up grid) into an internal `CaptureSheetBody` component in the same file — rendered inside the `Modal` by the capture branch, and rendered **without** the Modal by the `AllThemesMatrix` story. **Not** exported from the barrel `index.ts`. (Added during implementation.) | (a) Keep the body inline and have `AllThemesMatrix` render seven full `mode="capture"` modals. (b) Drop `AllThemesMatrix`, verify themes via Storybook's global theme toolbar on the single `CaptureSheet` story. | (a) doesn't work: react-native-web 0.21.2 (the `@storybook/react-native-web-vite` runtime) renders `Modal` via `ModalPortal` (`createPortal` to a `<body>`-appended div) with `position: fixed` — seven live modals stack full-screen, so the "matrix" would show only the last theme. A stacked-modal matrix is a fake visual gate. (b) drops an explicit acceptance criterion. Extracting an internal presentational body keeps **one** source of the grid JSX (Modal branch and matrix render the same component — no duplication, so D1's single-source intent still holds) and lets the matrix tile real per-theme sheets inline. Kept out of the barrel so it isn't a second _public_ picker (the D1 concern); the story imports it directly from the `.tsx`. |
 
 ## Affected Areas
 
@@ -174,6 +181,28 @@ yet; that lands in #377.
 
 ## Discovery Log
 
-<!-- Entries added by implement skill:
-- [YYYY-MM-DD HH:MM] <discovery description>
--->
+- [2026-07-01 20:20] **Commit order swapped (i18n before render).** `src/i18n/i18next.d.ts`
+  strictly types translation keys against `typeof en/common.json`, so referencing
+  `common:evidenceTypePicker.*` before the key exists is a compile error, not a
+  runtime miss. Step 3 (i18n keys) therefore landed as commit `4240770` _before_
+  Step 2's render commit `849a20a`. Each still type-checks in isolation (unused
+  keys are fine). Correspondingly, the `EvidenceType` / `Modal` / `SafeAreaView`
+  imports the plan listed under Step 1 were deferred to the render commit where
+  they're actually used (importing them unused fails `no-unused-vars`); Step 1 is
+  interface-only and lint-clean.
+- [2026-07-01 20:20] **Pseudo locale is regenerated by `gen:pseudo`, not `i18n:sync`.**
+  `scripts/i18n/syncCore.ts` has `SUPPORTED_TARGETS = ["de"]` — `bun run i18n:sync`
+  only writes `de/common.json`. The `pseudo/*.json` files are committed static
+  snapshots regenerated by `bun run gen:pseudo` (`scripts/generate-pseudo-locale.ts`).
+  Ran both. `gen:pseudo` also rewrote three unrelated, already-stale pseudo files
+  (`completion`, `editGoal`, `focusMode`); reverted those to keep this PR scoped to
+  #409 (pre-existing drift is a separate concern).
+- [2026-07-01 20:20] **Sub-line/title use `fontFamily.headline`.** There is no
+  `fontFamily.heading` token — the headline face (Anybody) is `headline`; the
+  DM Mono sub-line uses `fontFamily.mono` as planned.
+- [2026-07-01 20:20] **Extracted `CaptureSheetBody` (D7).** See Decisions. The
+  `AllThemesMatrix` story could not tile seven live `Modal`s (react-native-web
+  0.21.2 portals each Modal to `<body>` with `position: fixed`, so they stack).
+  Extracted the sheet body into an internal component (not exported from the
+  barrel) rendered by both the Modal branch and the matrix story — one source of
+  the grid JSX, no duplication.

--- a/apps/native-rd/docs/plans/dev-plans/issue-409-evidence-type-picker-sheet.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-409-evidence-type-picker-sheet.md
@@ -27,7 +27,7 @@ card row (line 165) — which #408's `FocusCurrentTaskCard` already ships. That 
       "Add evidence", sub-line "Saving to your active step · {activeStepTitle}", and a
       3-column grid of the 6 `EVIDENCE_OPTIONS` (Photo, Video, Voice, Note, Link, File)
       using the same icons/labels as the authoring chip grid. _(Structure + copy unit-tested;
-      pixel rendering pending the manual `storybook:web` pass below.)_
+      rendering verified in `storybook:web` — Note pre-highlighted, DM-Mono sub-line, 3-up grid.)_
 - [x] Tapping a type in the sheet calls `onSelectType(type)` — the sheet does not own
       capture-flow state (no "confirm"/"done" stages; those belong to the screen
       integration, out of scope here). _(Tested: `it.each` over all 6 types.)_
@@ -49,7 +49,8 @@ card row (line 165) — which #408's `FocusCurrentTaskCard` already ships. That 
 - [x] `EvidenceTypePicker.stories.tsx` exposes: the capture sheet (default + a
       "change" open state), the authoring chip grid, the compact variant, and an
       `AllThemesMatrix` story rendering the capture sheet across all 7 product themes.
-      _(Matrix tiles `CaptureSheetBody` inline per D7; visual confirmation pending below.)_
+      _(Matrix tiles `CaptureSheetBody` inline per D7; verified in `storybook:web` — all 7
+      themes render with correct per-theme tokens, no modal stacking.)_
 - [x] Every color/spacing/radius/shadow value in new code resolves through `theme.*` —
       `grep -n "#[0-9a-fA-F]\{3,6\}"` on the two edited/added source files (excluding
       the emoji icon strings already in `EVIDENCE_OPTIONS`) returns nothing. _(Only match
@@ -200,6 +201,16 @@ yet; that lands in #377.
 - [2026-07-01 20:20] **Sub-line/title use `fontFamily.headline`.** There is no
   `fontFamily.heading` token — the headline face (Anybody) is `headline`; the
   DM Mono sub-line uses `fontFamily.mono` as planned.
+- [2026-07-01 20:35] **Visual pass done (`storybook:web`).** Ran Storybook web and
+  eyeballed `CaptureSheet` (Note pre-highlighted, DM-Mono sub-line, 3-up grid),
+  `CaptureSheetChangeScenario` (Photo highlighted — the D6 re-open case), and
+  `AllThemesMatrix`. The matrix tiles all 7 product themes correctly (no modal
+  stacking, per D7) with faithful per-theme tokens: Note's highlight tracks each
+  theme's `accentPrimary` (blue/teal/black/slate), highContrast/autismFriendly drop
+  shadows, dyslexia uses Lexend on cream, lowVision enlarges type + wraps the
+  sub-line. One benign `Unistyles: no theme selected yet` console error fires once
+  on first paint (global Storybook+Unistyles startup race, not component-specific;
+  render is correct).
 - [2026-07-01 20:20] **Extracted `CaptureSheetBody` (D7).** See Decisions. The
   `AllThemesMatrix` story could not tile seven live `Modal`s (react-native-web
   0.21.2 portals each Modal to `<body>` with `position: fixed`, so they stack).

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.stories.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.stories.tsx
@@ -40,7 +40,6 @@ function CaptureSheetDemo({
       <Button label="Add evidence" onPress={() => setVisible(true)} />
       <EvidenceTypePicker
         mode="capture"
-        selectedTypes={[]}
         visible={visible}
         activeStepTitle="Wire the relay panel"
         selectedType={selectedType}

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.stories.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.stories.tsx
@@ -1,0 +1,200 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { ScrollView, View } from "react-native";
+import { ScopedTheme, StyleSheet } from "react-native-unistyles";
+import { Text } from "../Text";
+import { Button } from "../Button";
+import { EvidenceTypePicker, CaptureSheetBody } from "./EvidenceTypePicker";
+import { EvidenceType } from "../../db";
+import type { EvidenceTypeValue } from "../../types/evidence";
+import { themes, themeNames, type ThemeName } from "../../themes/compose";
+
+const meta: Meta<typeof EvidenceTypePicker> = {
+  title: "EvidenceTypePicker",
+  component: EvidenceTypePicker,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EvidenceTypePicker>;
+
+const noop = () => {};
+
+// --- Capture sheet (mode="capture") ---
+
+// Controlled wrapper: the sheet owns no selection state (D3), so the story holds
+// it — a tapped cell sets the pick and closes, mirroring the prototype's `pick`
+// handler. The trigger button re-opens the sheet on its current pick.
+function CaptureSheetDemo({
+  initialType,
+}: {
+  initialType?: EvidenceTypeValue;
+}) {
+  const [visible, setVisible] = useState(true);
+  const [selectedType, setSelectedType] = useState<
+    EvidenceTypeValue | undefined
+  >(initialType);
+
+  return (
+    <View style={storyStyles.triggerStage}>
+      <Button label="Add evidence" onPress={() => setVisible(true)} />
+      <EvidenceTypePicker
+        mode="capture"
+        selectedTypes={[]}
+        visible={visible}
+        activeStepTitle="Wire the relay panel"
+        selectedType={selectedType}
+        onSelectType={(type) => {
+          setSelectedType(type);
+          setVisible(false);
+        }}
+        onClose={() => setVisible(false)}
+      />
+    </View>
+  );
+}
+
+// Note pre-highlighted — the easy default (D5).
+export const CaptureSheet: Story = {
+  render: () => <CaptureSheetDemo />,
+};
+
+// The "change" re-open case (D6): opened with a non-default pick (Photo) already
+// highlighted. There is no in-sheet "Change" row — re-opening the sheet on the
+// current pick IS the change affordance; the invoker lives outside this component
+// (#408's card row / the nav "+", wired by #377). This story IS that demonstration.
+export const CaptureSheetChangeScenario: Story = {
+  render: () => (
+    <CaptureSheetDemo initialType={EvidenceType.photo as EvidenceTypeValue} />
+  ),
+};
+
+// --- Authoring modes (default — unchanged, backward compatible) ---
+
+function AuthoringChipGridDemo() {
+  const [selectedTypes, setSelectedTypes] = useState<EvidenceTypeValue[]>([
+    EvidenceType.text as EvidenceTypeValue,
+  ]);
+  return (
+    <View style={storyStyles.padded}>
+      {/* `mode` omitted → defaults to "authoring", proving backward compatibility. */}
+      <EvidenceTypePicker
+        selectedTypes={selectedTypes}
+        label="Evidence types"
+        onToggleType={(type) =>
+          setSelectedTypes((prev) =>
+            prev.includes(type)
+              ? prev.filter((t) => t !== type)
+              : [...prev, type],
+          )
+        }
+      />
+    </View>
+  );
+}
+
+export const AuthoringChipGrid: Story = {
+  render: () => <AuthoringChipGridDemo />,
+};
+
+export const Compact: Story = {
+  render: () => (
+    <View style={storyStyles.padded}>
+      <EvidenceTypePicker
+        compact
+        selectedTypes={
+          [
+            EvidenceType.photo,
+            EvidenceType.text,
+            EvidenceType.link,
+          ] as EvidenceTypeValue[]
+        }
+      />
+    </View>
+  ),
+};
+
+// --- Theme matrix ---
+// The capture sheet across all 7 product themes. We tile `CaptureSheetBody`
+// directly rather than the full picker because on web every RN Modal portals to
+// <body> with position:fixed — seven live sheets would stack, not tile. Same
+// ScopedTheme-per-theme approach as FocusCurrentTaskCard.stories' AllThemesMatrix.
+const MOOD_NAMES: Record<ThemeName, string> = {
+  "light-default": "Full Ride",
+  "dark-default": "Night Ride",
+  "light-highContrast": "Bold Ink",
+  "light-dyslexia": "Warm Studio",
+  "light-autismFriendly": "Still Water",
+  "light-lowVision": "Loud & Clear",
+  "light-lowInfo": "Clean Signal",
+};
+
+export const AllThemesMatrix: Story = {
+  render: () => (
+    <ScrollView contentContainerStyle={storyStyles.matrixContainer}>
+      {themeNames.map((name) => (
+        <View key={name} style={storyStyles.matrixThemeBlock}>
+          <View style={storyStyles.matrixThemeLabel}>
+            <Text style={storyStyles.matrixThemeName}>{MOOD_NAMES[name]}</Text>
+            <Text style={storyStyles.matrixThemeKey}>{name}</Text>
+          </View>
+          <ScopedTheme name={name}>
+            <View
+              style={[
+                storyStyles.matrixCard,
+                { backgroundColor: themes[name].colors.background },
+              ]}
+            >
+              <CaptureSheetBody
+                activeStepTitle="Wire the relay panel"
+                selectedType={EvidenceType.text as EvidenceTypeValue}
+                onSelectType={noop}
+                onClose={noop}
+              />
+            </View>
+          </ScopedTheme>
+        </View>
+      ))}
+    </ScrollView>
+  ),
+};
+
+const storyStyles = StyleSheet.create((theme) => ({
+  triggerStage: {
+    flex: 1,
+    padding: theme.space[4],
+    gap: theme.space[3],
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  padded: {
+    padding: theme.space[4],
+    backgroundColor: theme.colors.background,
+  },
+  matrixContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "flex-start",
+    padding: theme.space[4],
+    gap: theme.space[6],
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  matrixThemeBlock: {
+    gap: theme.space[2],
+  },
+  matrixThemeLabel: {
+    gap: theme.space[1],
+  },
+  matrixThemeName: {
+    fontWeight: theme.fontWeight.semibold,
+    color: theme.colors.text,
+  },
+  matrixThemeKey: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+  },
+  // Prototype phone width so the tiled sheet reads like the real bottom sheet.
+  matrixCard: {
+    width: 344,
+  },
+}));

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.styles.ts
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.styles.ts
@@ -71,4 +71,105 @@ export const styles = StyleSheet.create((theme) => ({
     fontFamily: theme.fontFamily.body,
     color: theme.colors.textSecondary,
   },
+
+  // --- Capture mode (mode="capture") bottom sheet ---
+  // Scrim fills the screen and anchors the sheet to the bottom. Alpha suffix on
+  // theme.colors.shadow mirrors EvidenceDrawer.styles.ts's overlay treatment.
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: `${theme.colors.shadow}cc`,
+  },
+  // Full-screen backdrop behind the sheet; tapping the exposed area dismisses.
+  // Rendered before the sheet so the sheet sits on top and absorbs its own taps.
+  backdrop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  // Neo-brutalist bottom sheet: hard top border + rounded top corners + hard shadow.
+  sheet: {
+    borderTopLeftRadius: theme.radius.xl,
+    borderTopRightRadius: theme.radius.xl,
+    borderTopWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: theme.space[4],
+    paddingTop: theme.space[3],
+    paddingBottom: theme.space[4],
+    gap: theme.space[3],
+    ...shadowStyle(theme, "modalElevation"),
+  },
+  handle: {
+    alignSelf: "center",
+    width: 40,
+    height: 4,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.border,
+  },
+  sheetHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  sheetTitle: {
+    fontSize: theme.size.lg,
+    fontWeight: theme.fontWeight.bold,
+    fontFamily: theme.fontFamily.headline,
+    color: theme.colors.text,
+  },
+  // 44x44 tap target for the × dismiss control.
+  closeButton: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  closeIcon: {
+    fontSize: theme.size.lg,
+    color: theme.colors.text,
+  },
+  // Prototype renders the sub-line in DM Mono.
+  subLine: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.sm,
+    color: theme.colors.textMuted,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.space[2],
+  },
+  // flexBasis ~30% + grow yields a stable 3-up grid for the 6 options.
+  cell: {
+    flexBasis: "30%",
+    flexGrow: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.space[1],
+    minHeight: 44,
+    paddingVertical: theme.space[3],
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.background,
+    ...shadowStyle(theme, "cardElevationSmall"),
+  },
+  cellSelected: {
+    backgroundColor: theme.colors.accentPrimary,
+  },
+  cellIcon: {
+    fontSize: 24,
+  },
+  cellLabel: {
+    fontSize: theme.size.sm,
+    fontFamily: theme.fontFamily.body,
+    fontWeight: theme.fontWeight.bold,
+    color: theme.colors.text,
+  },
+  cellLabelSelected: {
+    color: theme.colors.background,
+  },
 }));

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
@@ -6,14 +6,32 @@ import { evidenceLabel } from "../../i18n/labels";
 import { styles } from "./EvidenceTypePicker.styles";
 
 export interface EvidenceTypePickerProps {
-  /** Currently selected evidence types */
+  /**
+   * Presentation mode. `"authoring"` (default) is the inline multi-select chip
+   * grid used in step creation/editing. `"capture"` is the modal bottom sheet
+   * used to pick a single evidence type before capturing (Focus Mode, #377).
+   */
+  mode?: "authoring" | "capture";
+  /** Currently selected evidence types (authoring mode) */
   selectedTypes: EvidenceTypeValue[];
   /** Called when user toggles a type on/off (required in interactive mode, unused in compact) */
   onToggleType?: (type: EvidenceTypeValue) => void;
-  /** Compact mode for inline display below step titles */
+  /** Compact mode for inline display below step titles (authoring mode only) */
   compact?: boolean;
-  /** Optional label to show above chips */
+  /** Optional label to show above chips (authoring mode) */
   label?: string;
+
+  // --- Capture mode (mode="capture") ---
+  /** Whether the capture sheet is visible (drives the Modal). Capture mode only. */
+  visible?: boolean;
+  /** Active step title shown in the sheet sub-line; omit to hide the sub-line. */
+  activeStepTitle?: string;
+  /** Pre-highlighted type in the sheet; defaults to `text` ("Note") when omitted. */
+  selectedType?: EvidenceTypeValue;
+  /** Called when a type cell is tapped. Caller updates its selection and closes the sheet. */
+  onSelectType?: (type: EvidenceTypeValue) => void;
+  /** Closes the sheet — wired to backdrop tap, header × control, and Android back. */
+  onClose?: () => void;
 }
 
 /**

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { View, Pressable, Text as RNText } from "react-native";
+import { View, Pressable, Modal, Text as RNText } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { EVIDENCE_OPTIONS, type EvidenceTypeValue } from "../../types/evidence";
+import { EvidenceType } from "../../db";
 import { evidenceLabel } from "../../i18n/labels";
 import { styles } from "./EvidenceTypePicker.styles";
 
@@ -39,12 +41,92 @@ export interface EvidenceTypePickerProps {
  * Used in step creation/editing to let users choose what evidence they plan to capture.
  */
 export function EvidenceTypePicker({
+  mode = "authoring",
   selectedTypes,
   onToggleType,
   compact = false,
   label,
+  visible = false,
+  activeStepTitle,
+  selectedType,
+  onSelectType,
+  onClose,
 }: EvidenceTypePickerProps) {
   const { t } = useTranslation(["common"]);
+
+  if (mode === "capture") {
+    // "Note" is the easy default when the caller hasn't picked a type yet (D5).
+    const effectiveSelected = selectedType ?? EvidenceType.text;
+    return (
+      <Modal
+        visible={visible}
+        transparent
+        animationType="slide"
+        onRequestClose={onClose}
+        accessibilityViewIsModal
+      >
+        <View style={styles.overlay}>
+          {/* Backdrop — tapping the exposed scrim dismisses the sheet. */}
+          <Pressable
+            style={styles.backdrop}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel={t("common:actions.close")}
+          />
+          <SafeAreaView edges={["bottom"]} style={styles.sheet}>
+            <View style={styles.handle} />
+            <View style={styles.sheetHeader}>
+              <RNText style={styles.sheetTitle} accessibilityRole="header">
+                {t("common:evidenceTypePicker.addEvidence")}
+              </RNText>
+              <Pressable
+                style={styles.closeButton}
+                onPress={onClose}
+                accessibilityRole="button"
+                accessibilityLabel={t("common:actions.close")}
+                hitSlop={8}
+              >
+                <RNText style={styles.closeIcon}>{"✕"}</RNText>
+              </Pressable>
+            </View>
+            {activeStepTitle ? (
+              <RNText style={styles.subLine}>
+                {t("common:evidenceTypePicker.savingToActiveStep", {
+                  title: activeStepTitle,
+                })}
+              </RNText>
+            ) : null}
+            <View style={styles.grid}>
+              {EVIDENCE_OPTIONS.map((opt) => {
+                const isSelected = opt.type === effectiveSelected;
+                const optLabel = evidenceLabel(t, opt.type);
+                return (
+                  <Pressable
+                    key={opt.type}
+                    style={[styles.cell, isSelected && styles.cellSelected]}
+                    onPress={() => onSelectType?.(opt.type)}
+                    accessibilityRole="radio"
+                    accessibilityState={{ checked: isSelected }}
+                    accessibilityLabel={optLabel}
+                  >
+                    <RNText style={styles.cellIcon}>{opt.icon}</RNText>
+                    <RNText
+                      style={[
+                        styles.cellLabel,
+                        isSelected && styles.cellLabelSelected,
+                      ]}
+                    >
+                      {optLabel}
+                    </RNText>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </SafeAreaView>
+        </View>
+      </Modal>
+    );
+  }
 
   if (compact) {
     return (

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
@@ -55,8 +55,6 @@ export function EvidenceTypePicker({
   const { t } = useTranslation(["common"]);
 
   if (mode === "capture") {
-    // "Note" is the easy default when the caller hasn't picked a type yet (D5).
-    const effectiveSelected = selectedType ?? EvidenceType.text;
     return (
       <Modal
         visible={visible}
@@ -73,56 +71,12 @@ export function EvidenceTypePicker({
             accessibilityRole="button"
             accessibilityLabel={t("common:actions.close")}
           />
-          <SafeAreaView edges={["bottom"]} style={styles.sheet}>
-            <View style={styles.handle} />
-            <View style={styles.sheetHeader}>
-              <RNText style={styles.sheetTitle} accessibilityRole="header">
-                {t("common:evidenceTypePicker.addEvidence")}
-              </RNText>
-              <Pressable
-                style={styles.closeButton}
-                onPress={onClose}
-                accessibilityRole="button"
-                accessibilityLabel={t("common:actions.close")}
-                hitSlop={8}
-              >
-                <RNText style={styles.closeIcon}>{"✕"}</RNText>
-              </Pressable>
-            </View>
-            {activeStepTitle ? (
-              <RNText style={styles.subLine}>
-                {t("common:evidenceTypePicker.savingToActiveStep", {
-                  title: activeStepTitle,
-                })}
-              </RNText>
-            ) : null}
-            <View style={styles.grid}>
-              {EVIDENCE_OPTIONS.map((opt) => {
-                const isSelected = opt.type === effectiveSelected;
-                const optLabel = evidenceLabel(t, opt.type);
-                return (
-                  <Pressable
-                    key={opt.type}
-                    style={[styles.cell, isSelected && styles.cellSelected]}
-                    onPress={() => onSelectType?.(opt.type)}
-                    accessibilityRole="radio"
-                    accessibilityState={{ checked: isSelected }}
-                    accessibilityLabel={optLabel}
-                  >
-                    <RNText style={styles.cellIcon}>{opt.icon}</RNText>
-                    <RNText
-                      style={[
-                        styles.cellLabel,
-                        isSelected && styles.cellLabelSelected,
-                      ]}
-                    >
-                      {optLabel}
-                    </RNText>
-                  </Pressable>
-                );
-              })}
-            </View>
-          </SafeAreaView>
+          <CaptureSheetBody
+            activeStepTitle={activeStepTitle}
+            selectedType={selectedType}
+            onSelectType={onSelectType}
+            onClose={onClose}
+          />
         </View>
       </Modal>
     );
@@ -197,5 +151,85 @@ export function EvidenceTypePicker({
         })}
       </View>
     </View>
+  );
+}
+
+export interface CaptureSheetBodyProps {
+  activeStepTitle?: string;
+  selectedType?: EvidenceTypeValue;
+  onSelectType?: (type: EvidenceTypeValue) => void;
+  onClose?: () => void;
+}
+
+/**
+ * Presentational body of the capture sheet — handle, header, sub-line, and the
+ * single-select 3-up grid. Rendered inside the Modal by `EvidenceTypePicker`'s
+ * capture branch, and directly (no Modal) by the `AllThemesMatrix` story: on web
+ * each `Modal` portals to `<body>` with `position: fixed`, so seven full sheets
+ * can't tile — the story tiles this body instead. One source of the grid JSX; not
+ * exported from the barrel, so it stays an internal helper rather than a second
+ * public picker (D7).
+ */
+export function CaptureSheetBody({
+  activeStepTitle,
+  selectedType,
+  onSelectType,
+  onClose,
+}: CaptureSheetBodyProps) {
+  const { t } = useTranslation(["common"]);
+  // "Note" is the easy default when the caller hasn't picked a type yet (D5).
+  const effectiveSelected = selectedType ?? EvidenceType.text;
+
+  return (
+    <SafeAreaView edges={["bottom"]} style={styles.sheet}>
+      <View style={styles.handle} />
+      <View style={styles.sheetHeader}>
+        <RNText style={styles.sheetTitle} accessibilityRole="header">
+          {t("common:evidenceTypePicker.addEvidence")}
+        </RNText>
+        <Pressable
+          style={styles.closeButton}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={t("common:actions.close")}
+          hitSlop={8}
+        >
+          <RNText style={styles.closeIcon}>{"✕"}</RNText>
+        </Pressable>
+      </View>
+      {activeStepTitle ? (
+        <RNText style={styles.subLine}>
+          {t("common:evidenceTypePicker.savingToActiveStep", {
+            title: activeStepTitle,
+          })}
+        </RNText>
+      ) : null}
+      <View style={styles.grid}>
+        {EVIDENCE_OPTIONS.map((opt) => {
+          const isSelected = opt.type === effectiveSelected;
+          const optLabel = evidenceLabel(t, opt.type);
+          return (
+            <Pressable
+              key={opt.type}
+              style={[styles.cell, isSelected && styles.cellSelected]}
+              onPress={() => onSelectType?.(opt.type)}
+              accessibilityRole="radio"
+              accessibilityState={{ checked: isSelected }}
+              accessibilityLabel={optLabel}
+            >
+              <RNText style={styles.cellIcon}>{opt.icon}</RNText>
+              <RNText
+                style={[
+                  styles.cellLabel,
+                  isSelected && styles.cellLabelSelected,
+                ]}
+              >
+                {optLabel}
+              </RNText>
+            </Pressable>
+          );
+        })}
+      </View>
+    </SafeAreaView>
   );
 }

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
@@ -167,10 +167,17 @@ export function EvidenceTypePicker(props: EvidenceTypePickerProps) {
 }
 
 export interface CaptureSheetBodyProps {
+  /** Active step title shown in the sub-line; omit to hide the sub-line. */
   activeStepTitle?: string;
+  /** Pre-highlighted type; defaults to `text` ("Note") when omitted. */
   selectedType?: EvidenceTypeValue;
-  onSelectType?: (type: EvidenceTypeValue) => void;
-  onClose?: () => void;
+  /**
+   * Called when a type cell is tapped. Required — mirrors the public
+   * `mode="capture"` contract so a body can't render interactive-but-inert.
+   */
+  onSelectType: (type: EvidenceTypeValue) => void;
+  /** Closes the sheet — wired to the header × control. Required (see above). */
+  onClose: () => void;
 }
 
 /**
@@ -224,7 +231,7 @@ export function CaptureSheetBody({
             <Pressable
               key={opt.type}
               style={[styles.cell, isSelected && styles.cellSelected]}
-              onPress={() => onSelectType?.(opt.type)}
+              onPress={() => onSelectType(opt.type)}
               accessibilityRole="radio"
               accessibilityState={{ checked: isSelected }}
               accessibilityLabel={optLabel}

--- a/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/EvidenceTypePicker.tsx
@@ -7,54 +7,63 @@ import { EvidenceType } from "../../db";
 import { evidenceLabel } from "../../i18n/labels";
 import { styles } from "./EvidenceTypePicker.styles";
 
-export interface EvidenceTypePickerProps {
-  /**
-   * Presentation mode. `"authoring"` (default) is the inline multi-select chip
-   * grid used in step creation/editing. `"capture"` is the modal bottom sheet
-   * used to pick a single evidence type before capturing (Focus Mode, #377).
-   */
-  mode?: "authoring" | "capture";
-  /** Currently selected evidence types (authoring mode) */
+/**
+ * Authoring mode (default): inline multi-select chip grid used in step
+ * creation/editing to choose which evidence types are planned.
+ */
+export interface AuthoringEvidenceTypePickerProps {
+  /** Presentation mode. Omit or pass `"authoring"` for the chip grid. */
+  mode?: "authoring";
+  /** Currently selected evidence types. */
   selectedTypes: EvidenceTypeValue[];
-  /** Called when user toggles a type on/off (required in interactive mode, unused in compact) */
+  /** Called when the user toggles a type on/off (unused in `compact`). */
   onToggleType?: (type: EvidenceTypeValue) => void;
-  /** Compact mode for inline display below step titles (authoring mode only) */
+  /** Compact, read-only inline display below step titles. */
   compact?: boolean;
-  /** Optional label to show above chips (authoring mode) */
+  /** Optional label shown above the chips. */
   label?: string;
+}
 
-  // --- Capture mode (mode="capture") ---
-  /** Whether the capture sheet is visible (drives the Modal). Capture mode only. */
-  visible?: boolean;
+/**
+ * Capture mode: modal bottom sheet for single-selecting one evidence type
+ * before capturing (Focus Mode, #377).
+ */
+export interface CaptureEvidenceTypePickerProps {
+  mode: "capture";
+  /** Whether the capture sheet is visible (drives the Modal). */
+  visible: boolean;
   /** Active step title shown in the sheet sub-line; omit to hide the sub-line. */
   activeStepTitle?: string;
   /** Pre-highlighted type in the sheet; defaults to `text` ("Note") when omitted. */
   selectedType?: EvidenceTypeValue;
   /** Called when a type cell is tapped. Caller updates its selection and closes the sheet. */
-  onSelectType?: (type: EvidenceTypeValue) => void;
+  onSelectType: (type: EvidenceTypeValue) => void;
   /** Closes the sheet — wired to backdrop tap, header × control, and Android back. */
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 /**
- * Multi-select chip picker for evidence types.
- * Used in step creation/editing to let users choose what evidence they plan to capture.
+ * Props for {@link EvidenceTypePicker}: a discriminated union on `mode`. The
+ * authoring chip grid and the capture bottom sheet have disjoint prop sets, so
+ * the compiler enforces that a capture sheet supplies `onSelectType`/`onClose`
+ * and never carries a meaningless `selectedTypes` (and vice versa).
  */
-export function EvidenceTypePicker({
-  mode = "authoring",
-  selectedTypes,
-  onToggleType,
-  compact = false,
-  label,
-  visible = false,
-  activeStepTitle,
-  selectedType,
-  onSelectType,
-  onClose,
-}: EvidenceTypePickerProps) {
+export type EvidenceTypePickerProps =
+  | AuthoringEvidenceTypePickerProps
+  | CaptureEvidenceTypePickerProps;
+
+/**
+ * Evidence-type picker with two presentation modes (see {@link EvidenceTypePickerProps}):
+ * `"authoring"` (default) renders an inline multi-select chip grid for step
+ * creation/editing; `"capture"` renders a modal bottom sheet for single-selecting
+ * one type before capturing (Focus Mode, #377).
+ */
+export function EvidenceTypePicker(props: EvidenceTypePickerProps) {
   const { t } = useTranslation(["common"]);
 
-  if (mode === "capture") {
+  if (props.mode === "capture") {
+    const { visible, activeStepTitle, selectedType, onSelectType, onClose } =
+      props;
     return (
       <Modal
         visible={visible}
@@ -66,6 +75,7 @@ export function EvidenceTypePicker({
         <View style={styles.overlay}>
           {/* Backdrop — tapping the exposed scrim dismisses the sheet. */}
           <Pressable
+            testID="capture-sheet-backdrop"
             style={styles.backdrop}
             onPress={onClose}
             accessibilityRole="button"
@@ -81,6 +91,8 @@ export function EvidenceTypePicker({
       </Modal>
     );
   }
+
+  const { selectedTypes, onToggleType, compact = false, label } = props;
 
   if (compact) {
     return (

--- a/apps/native-rd/src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx
@@ -146,4 +146,119 @@ describe("EvidenceTypePicker", () => {
       }
     });
   });
+
+  describe("capture mode", () => {
+    const captureProps = {
+      mode: "capture" as const,
+      visible: true,
+      selectedTypes: [] as EvidenceTypeValue[],
+      onSelectType: jest.fn(),
+      onClose: jest.fn(),
+    };
+
+    const closeLabel = i18n.t("common:actions.close");
+
+    it("renders all six evidence options with labels and icons", () => {
+      renderWithProviders(<EvidenceTypePicker {...captureProps} />);
+
+      for (const opt of EVIDENCE_OPTIONS) {
+        expect(screen.getByText(labelFor(opt.type))).toBeOnTheScreen();
+        expect(screen.getByText(opt.icon)).toBeOnTheScreen();
+      }
+    });
+
+    it("highlights Note (text) by default when no selectedType is given (D5)", () => {
+      renderWithProviders(<EvidenceTypePicker {...captureProps} />);
+
+      const noteCell = screen.getByLabelText(labelFor(EvidenceType.text));
+      expect(noteCell.props.accessibilityState).toEqual({ checked: true });
+
+      const photoCell = screen.getByLabelText(labelFor(EvidenceType.photo));
+      expect(photoCell.props.accessibilityState).toEqual({ checked: false });
+    });
+
+    it("highlights the provided selectedType — the change re-open case (D6)", () => {
+      renderWithProviders(
+        <EvidenceTypePicker
+          {...captureProps}
+          selectedType={EvidenceType.photo as EvidenceTypeValue}
+        />,
+      );
+
+      const photoCell = screen.getByLabelText(labelFor(EvidenceType.photo));
+      expect(photoCell.props.accessibilityState).toEqual({ checked: true });
+
+      const noteCell = screen.getByLabelText(labelFor(EvidenceType.text));
+      expect(noteCell.props.accessibilityState).toEqual({ checked: false });
+    });
+
+    it("gives each cell a radio accessibilityRole", () => {
+      renderWithProviders(<EvidenceTypePicker {...captureProps} />);
+
+      for (const opt of EVIDENCE_OPTIONS) {
+        const cell = screen.getByLabelText(labelFor(opt.type));
+        expect(cell.props.accessibilityRole).toBe("radio");
+      }
+    });
+
+    it.each(EVIDENCE_OPTIONS.map((opt) => opt.type))(
+      "calls onSelectType with %s when its cell is pressed",
+      (type) => {
+        const onSelectType = jest.fn();
+        renderWithProviders(
+          <EvidenceTypePicker {...captureProps} onSelectType={onSelectType} />,
+        );
+
+        fireEvent.press(screen.getByLabelText(labelFor(type)));
+        expect(onSelectType).toHaveBeenCalledWith(type);
+      },
+    );
+
+    it("renders the sub-line with the interpolated active step title", () => {
+      renderWithProviders(
+        <EvidenceTypePicker
+          {...captureProps}
+          activeStepTitle="Wire the relay panel"
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          i18n.t("common:evidenceTypePicker.savingToActiveStep", {
+            title: "Wire the relay panel",
+          }),
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it("omits the sub-line when no active step title is given", () => {
+      renderWithProviders(<EvidenceTypePicker {...captureProps} />);
+
+      expect(screen.queryByText(/Saving to your active step/)).toBeNull();
+    });
+
+    it("calls onClose when the header close button is pressed", () => {
+      const onClose = jest.fn();
+      renderWithProviders(
+        <EvidenceTypePicker {...captureProps} onClose={onClose} />,
+      );
+
+      // The header × bubbles its press to the labelled close Pressable.
+      fireEvent.press(screen.getByText("✕"));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("calls onClose when the backdrop is pressed", () => {
+      const onClose = jest.fn();
+      renderWithProviders(
+        <EvidenceTypePicker {...captureProps} onClose={onClose} />,
+      );
+
+      // Backdrop is rendered before the sheet, so it is the first close target
+      // (the header × is the second). Both share the generic "Close" label.
+      const closeTargets = screen.getAllByLabelText(closeLabel);
+      fireEvent.press(closeTargets[0]);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/native-rd/src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx
+++ b/apps/native-rd/src/components/EvidenceTypePicker/__tests__/EvidenceTypePicker.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Modal } from "react-native";
 import {
   renderWithProviders,
   screen,
@@ -151,7 +152,6 @@ describe("EvidenceTypePicker", () => {
     const captureProps = {
       mode: "capture" as const,
       visible: true,
-      selectedTypes: [] as EvidenceTypeValue[],
       onSelectType: jest.fn(),
       onClose: jest.fn(),
     };
@@ -254,11 +254,34 @@ describe("EvidenceTypePicker", () => {
         <EvidenceTypePicker {...captureProps} onClose={onClose} />,
       );
 
-      // Backdrop is rendered before the sheet, so it is the first close target
-      // (the header × is the second). Both share the generic "Close" label.
-      const closeTargets = screen.getAllByLabelText(closeLabel);
-      fireEvent.press(closeTargets[0]);
+      // Target the backdrop by testID rather than by position among the
+      // shared-"Close"-label controls, so a z-order refactor can't silently
+      // repoint this assertion at the header ✕ instead.
+      const backdrop = screen.getByTestId("capture-sheet-backdrop");
+      expect(backdrop.props.accessibilityLabel).toBe(closeLabel);
+      fireEvent.press(backdrop);
       expect(onClose).toHaveBeenCalled();
+    });
+
+    it("calls onClose on Modal onRequestClose (Android back / gesture dismiss)", () => {
+      const onClose = jest.fn();
+      renderWithProviders(
+        <EvidenceTypePicker {...captureProps} onClose={onClose} />,
+      );
+
+      // The sole dismissal route for Android hardware/gesture back — distinct
+      // from the backdrop and header-✕ Pressables.
+      fireEvent(screen.UNSAFE_getByType(Modal), "requestClose");
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("renders nothing when visible is false", () => {
+      renderWithProviders(
+        <EvidenceTypePicker {...captureProps} visible={false} />,
+      );
+
+      expect(screen.queryByText("✕")).toBeNull();
+      expect(screen.queryByText(labelFor(EvidenceType.text))).toBeNull();
     });
   });
 });

--- a/apps/native-rd/src/i18n/resources/de/common.json
+++ b/apps/native-rd/src/i18n/resources/de/common.json
@@ -44,6 +44,10 @@
       "shortLabel": "Datei"
     }
   },
+  "evidenceTypePicker": {
+    "addEvidence": "Beweis hinzufügen",
+    "savingToActiveStep": "Speichern in deinem aktiven Schritt · {{title}}"
+  },
   "theme": {
     "options": {
       "light-default": {

--- a/apps/native-rd/src/i18n/resources/en/common.json
+++ b/apps/native-rd/src/i18n/resources/en/common.json
@@ -26,6 +26,10 @@
     "link": { "label": "Link", "shortLabel": "Link" },
     "file": { "label": "File", "shortLabel": "File" }
   },
+  "evidenceTypePicker": {
+    "addEvidence": "Add evidence",
+    "savingToActiveStep": "Saving to your active step · {{title}}"
+  },
   "theme": {
     "options": {
       "light-default": {

--- a/apps/native-rd/src/i18n/resources/pseudo/common.json
+++ b/apps/native-rd/src/i18n/resources/pseudo/common.json
@@ -44,6 +44,10 @@
       "shortLabel": "[Ƒïĺê··]"
     }
   },
+  "evidenceTypePicker": {
+    "addEvidence": "[Àđđ êṽïđêñçê·····]",
+    "savingToActiveStep": "[Šàṽïñğ ţø ýøüŕ àçţïṽê šţêþ · {{title}}···············]"
+  },
   "theme": {
     "options": {
       "light-default": {


### PR DESCRIPTION
## Summary

Adds a `mode="capture"` modal bottom-sheet presentation to the existing `EvidenceTypePicker` — the prototype's "Add evidence" sheet (single-select, Note default) — and ships the missing `EvidenceTypePicker.stories.tsx`. **Storybook-only: no screen imports it yet (#377 owns the wiring.)** Part of Epic #384 (Full Ride redesign, Track C), milestone _native-rd: Iteration B_.

## Changes

- **Capture render path** — RN `Modal` bottom sheet: header _"Add evidence"_, DM-Mono _"Saving to your active step · {title}"_ sub-line, and a 3-up radio grid of the 6 `EVIDENCE_OPTIONS`. Reuses the existing option/label/icon/a11y source — **no duplicate 6-type list.**
- **Single-select semantics** — tapping a cell fires `onSelectType(type)`; the "change" affordance is re-opening the sheet on the current pick (external invokers per #408/#377). No in-sheet "Change" row (plan **D6**). Note (`text`) is the default highlight (**D5**).
- **Discriminated-union props** — `AuthoringEvidenceTypePickerProps | CaptureEvidenceTypePickerProps` so capture mode requires `visible`/`onSelectType`/`onClose` and cannot carry a meaningless `selectedTypes` (a no-op capture sheet no longer type-checks).
- **Styles** — new capture-sheet styles, all `theme.*` tokens (neo-brutalist: hard top border, rounded top corners, hard shadow); backdrop scrim reuses `EvidenceDrawer`'s alpha-overlay pattern.
- **Stories** — `CaptureSheet` (Note default), `CaptureSheetChangeScenario` (Photo pre-highlighted), `AuthoringChipGrid`, `Compact`, and `AllThemesMatrix` (tiles the internal `CaptureSheetBody` across all 7 product themes — RN-web portals each Modal to `<body>`, so live modals can't tile; **D7**).
- **i18n** — `common:evidenceTypePicker.{addEvidence,savingToActiveStep}` (en + de/pseudo synced); close reuses `common:actions.close`.
- **Tests** — capture-mode block: labels/icons, D5 default + D6 re-open highlight, radio a11y, per-type `onSelectType`, sub-line present/absent, all three close paths (header ✕, backdrop-by-testID, Modal `onRequestClose`), and the `visible={false}` hidden state.

## Dependencies

- [x] None — issue states "start now."

_Not a dependency, but load-bearing:_ #408 (`FocusCurrentTaskCard`, merged) ships the external `onChangeEvidenceType` callback this sheet's API will serve; #377 does the actual screen wiring.

## Test Plan

- [x] Tests pass locally (`bun run test`) — `EvidenceTypePicker` 26/26; `StepList`/`DraggableStepItem` 58/58 (backward-compat: authoring callers untouched)
- [x] Lint passes (`bun run lint`) — 0 errors
- [x] Type check passes (`bun run type-check`)
- [x] Format check passes (`bun run format:check`)
- [x] Visual: `storybook:web` — all 5 stories + 7-theme matrix verified (see the plan's discovery log). The self-review commit (discriminated union + backdrop `testID`) is render-invariant, so that pass still holds.

**Negative space (what won't show the effect):** nothing in the running app changes — the component isn't imported by any screen, so the capture sheet is reachable only via Storybook (#377 wires it). `test:a11y` audits rendered screens, not isolated Storybook components, so it does not exercise the new sheet; the a11y contract (roles, labels, 44pt targets) is covered by the unit tests instead.

## Related Issues

Closes #409

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVapCkjMv3jV5fjnGDbRcF
