### PR TITLE
chore(workspace): use Bun's global install cache instead of in-repo .bun-cache

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -17,10 +17,11 @@ exact = false
 registry = "https://registry.npmjs.org"
 
 [install.cache]
-# Cache directory for faster subsequent installs
-dir = ".bun-cache"
-
-# Don't disable cache (useful for local dev)
+# Use Bun's global cache (~/.bun/install/cache) — do NOT set a repo-local dir.
+# An in-repo cache (the old `.bun-cache`) gets crawled by workspace-root tools
+# (Storybook's vite-tsconfig-paths errors on cached packages' tsconfig.json)
+# and costs ~2.4 GB per checkout/worktree, while a shared global cache makes
+# installs across worktrees faster.
 disable = false
 
 [test]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -17,7 +17,8 @@ exact = false
 registry = "https://registry.npmjs.org"
 
 [install.cache]
-# Use Bun's global cache (~/.bun/install/cache) — do NOT set a repo-local dir.
+# Use Bun's default global cache (`$BUN_INSTALL/install/cache`, typically
+# ~/.bun/install/cache) — do NOT set a repo-local dir.
 # An in-repo cache (the old `.bun-cache`) gets crawled by workspace-root tools
 # (Storybook's vite-tsconfig-paths errors on cached packages' tsconfig.json)
 # and costs ~2.4 GB per checkout/worktree, while a shared global cache makes


### PR DESCRIPTION
## Summary

- Removes the `[install.cache] dir = ".bun-cache"` override from `bunfig.toml` so Bun falls back to its global cache (`~/.bun/install/cache`).
- The in-repo cache held unpacked copies of packages, and workspace-root crawlers walk it: Storybook web's bundled `vite-tsconfig-paths` tries to parse the **175** `tsconfig.json` files inside `.bun-cache/` and prints a `TSConfckParseError` for cached packages whose `extends` target can't resolve there (e.g. `expo-sharing@56.0.18/plugin/tsconfig.json` → `expo-module-scripts/tsconfig.plugin`). The error is non-fatal but loud, and the crawl is wasted work.
- The in-repo cache also costs ~2.4 GB per checkout — multiplied across git worktrees, each of which grew its own copy. One shared global cache makes installs across worktrees faster, not slower.

## Changes

- `bunfig.toml`: drop the repo-local cache dir; comment documents why a repo-local dir must not come back.
- `.gitignore`'s `.bun-cache/` entry and `.coderabbit.yaml`'s `!**/.bun-cache/**` exclusion are intentionally kept as defense against stale caches in existing checkouts.

## Test Plan

- [x] CI grep: no workflow references `.bun-cache` — nothing depends on the in-repo location.
- [x] The tsconfig-paths failure mode is confirmed non-fatal today (Storybook still serves); this PR removes the noise at the root.
- [ ] After merge, each existing checkout/worktree needs a one-time `rm -rf .bun-cache` — until then, that worktree keeps its stale cache and the Storybook warning. Fresh clones are correct immediately.

**What won't show the effect:** nothing in CI or app behavior changes — this only affects where `bun install` caches locally. The Storybook error disappears per-worktree only once its stale `.bun-cache/` is deleted.

---

Generated with [Claude Code](https://claude.ai/code)