### PR TITLE
refactor(edit-goal): extract EditGoalStepList from EditGoalView (#489)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-489-extract-editgoalsteplist.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-489-extract-editgoalsteplist.md
@@ -1,0 +1,100 @@
+# Development Plan: Issue #489
+
+## Issue Summary
+
+**Title**: [Refactor] Extract EditGoalStepList — reusable step-editor row/list layer from EditGoalView
+**Type**: refactor
+**Complexity**: SMALL
+**Estimated Lines**: ~150-250 lines moved (net new/changed lines much smaller — mostly cut-and-paste plus prop plumbing)
+
+## Intent Verification
+
+- [ ] `EditGoalStepList.tsx` exists and exports a component that renders the step rows, sub-step blocks, and add-step affordance, with all of the editing/drag/pendingDelete state that used to live in `EditGoalView` now local to it.
+- [ ] `EditGoalView.test.tsx` passes with zero changes to its assertions/queries/testIDs — only import-path edits are permitted (and per D2 below, even those should be zero, since the types and `EditGoalView` component keep their current file/path).
+- [ ] `EditGoalView.stories.tsx` renders identically in Storybook (same testIDs, same interaction behavior for drag/reorder, inline rename, evidence picker, and delete-confirm flows) with at most import-path edits.
+- [ ] `EditGoalView` barrel (`index.ts`) exports `EditGoalStepList` and its props type alongside the existing exports, so issue #490 (New Goal build-step swap) can `import { EditGoalStepList } from ".../EditGoalView"` without reaching into a non-barrel path.
+- [ ] No new props exist on `EditGoalStepList` beyond what `EditGoalView` already threads down today (no props added "for the wizard" — that's #490's job).
+- [ ] `git diff` on `EditGoalView.tsx` shows only removals (state/handlers/JSX that moved out) plus the new composition calling `EditGoalStepList` — no rewritten logic, no behavior changes.
+
+## Dependencies
+
+| Issue | Title                                                                   | Status                     | Type                                                         |
+| ----- | ----------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------ |
+| #384  | Epic: redesigned step editor                                            | Open (epic, tracking only) | Context                                                      |
+| #445  | EditGoalView (original row/drag implementation)                         | ✅ Merged                  | Context (prior art)                                          |
+| #459  | Edit Goal sub-step reorder (`EditGoalSubStepList` extraction precedent) | ✅ Merged                  | Prior art                                                    |
+| #460  | Edit Goal per-row delete (confirm-delete modal, `pendingDelete` state)  | ✅ Merged                  | Context                                                      |
+| #490  | [Storybook] New Goal build step — swap in `EditGoalStepList`            | Open                       | Downstream consumer (blocked BY this issue, not the reverse) |
+
+**Status**: ✅ All dependencies met. #489 has `dep:independent` — nothing blocks starting it. It is itself a blocker for #490, but that is a downstream direction and doesn't affect this plan.
+
+## Objective
+
+Cut the top-level step-row rendering, drag/reorder orchestration wiring, inline-rename state, evidence-picker state, and delete-confirm state out of `EditGoalView.tsx` into a new sibling component `EditGoalStepList.tsx`, so `EditGoalView` becomes a thin composition (header, goal-title card, optional description, `EditGoalStepList`, dates info banner, Done footer) and the row/list layer becomes independently reusable by the New Goal wizard (#490). Zero behavior change; only file organization changes.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                                                                                                                         | Alternatives Considered                                                                                                                        | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Everything driven by `editingId`/`editText`/`editingEvidenceId`/`pendingDelete`/`newStepTitle`/the `useEditGoalDrag` instance/`screenReaderActive`/`animationPref` moves into `EditGoalStepList`, including the evidence-picker `Modal` and the `ConfirmDeleteModal` (the "those two" the issue leaves to implementer judgment). | Leave the two modals in `EditGoalView` and thread picker/delete state back up via callbacks.                                                   | Modals are driven entirely by state that's moving anyway (`editingEvidenceId`, `pendingDelete`); lifting them back to `EditGoalView` would mean either duplicating that state in both files or adding new callback props "for the modals" — which contradicts "no new props for the wizard yet." Keeping them with their state is the seam with the smallest prop surface.                                                                                                  |
+| D2  | All exported types (`EditGoalStep`, `EditGoalSubStep`, `EditGoalChipTone`, `EditGoalDateDepChip`, `EditGoalViewProps`) **stay defined in `EditGoalView.tsx`**; `EditGoalStepList.tsx` does `import type { ... } from "./EditGoalView"` — the same pattern `EditGoalStepRow.tsx` already uses today.                              | Move step/sub-step types into `EditGoalStepList.tsx` (arguably "belongs" there now) and have `EditGoalView.tsx` re-export or import them back. | `EditGoalView.test.tsx` and `EditGoalView.stories.tsx` import `EditGoalStep`/`EditGoalSubStep`/`EditGoalViewProps` from `../EditGoalView` / `./EditGoalView` today. Keeping the types where they are means those two files need **zero** import-path changes, not just "changes limited to import paths" — the strongest possible reading of the issue's zero-behavior-change bar. Type-only imports don't create a runtime circular-dependency risk between the two files. |
+| D3  | `EditGoalStepList` does **not** get the "Steps" section label + count row folded in as a separate prop-free responsibility — it owns rendering `stepsSectionLabel` + `stepCountLabel(steps.length)` above the rows, matching where that JSX already sits immediately above the step-row loop.                                    | Leave the "Steps" header + count in `EditGoalView` and only move the row loop itself.                                                          | The header text is derived from `steps.length`, which is exactly the data `EditGoalStepList` now owns; splitting the label from the count it describes across two files/components adds a prop (`stepCount` or duplicate `steps`) for no behavior benefit. `EditGoalView` keeps the surrounding `stepsHeader`/`stepsLabel` _style_ only insofar as `EditGoalStepList` reuses the same shared `EditGoalView.styles.ts` object (D4).                                          |
+| D4  | Keep a single shared `EditGoalView.styles.ts` for `EditGoalView`, `EditGoalStepRow`, `EditGoalSubStepList`, and the new `EditGoalStepList` — do not split into a per-component styles file.                                                                                                                                      | Split out `EditGoalStepList.styles.ts` per the issue's "possibly styles" hedge.                                                                | The three existing files in this directory already share one styles module with no reported friction; splitting adds a file and import-path churn for zero functional gain in a change explicitly scoped as cut-and-move. Revisit only if a future issue's diff shows the shared file becoming unwieldy.                                                                                                                                                                    |
+| D5  | `useAnimationPref()` and the `screenReaderActive` `AccessibilityInfo` effect move into `EditGoalStepList` wholesale (not left in `EditGoalView` and passed down as props).                                                                                                                                                       | Keep the hook call in `EditGoalView` and pass `animationPref`/`showAccessibleControls` down as new props.                                      | Grep of `EditGoalView.tsx` confirms `animationPref` and `screenReaderActive` are read _only_ to compute `showAccessibleControls`, which is used _only_ inside the step-row/sub-step JSX that is moving. Nothing else in the file's returned tree depends on them, so there's no reason for `EditGoalView` to keep the subscription.                                                                                                                                         |
+
+## Affected Areas
+
+- `apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx` (new): step-row list, sub-step block rendering, add-step affordance, drag orchestration wiring (`useEditGoalDrag`), inline-rename state, evidence-picker state + `Modal`, delete-confirm state + `ConfirmDeleteModal`, screen-reader/animation-pref subscriptions.
+- `apps/native-rd/src/components/EditGoalView/EditGoalView.tsx`: slimmed to header, optional description block, goal-title card, `EditGoalStepList`, dates info banner, Done footer. `EditGoalViewProps` unchanged (same external callback surface); internally most props now pass straight through to `EditGoalStepList`.
+- `apps/native-rd/src/components/EditGoalView/index.ts`: add `export { EditGoalStepList } from "./EditGoalStepList";` and `export type { EditGoalStepListProps } from "./EditGoalStepList";`.
+- `apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts`: unchanged (shared, D4) — verify no styles were scoped in a way that assumes single-file usage (none found; `styles.rowCard`, `styles.dropLine`, etc. are already imported cross-file by `EditGoalStepRow`/`EditGoalSubStepList`).
+- `apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx`: expected zero changes (D2) — re-run to confirm; do not edit unless the test run surfaces a real gap.
+- `apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx`: expected zero changes (D2) — re-run Storybook to confirm; do not edit unless it breaks.
+
+## Implementation Plan
+
+### Step 1: Extract `EditGoalStepList` and slim `EditGoalView`
+
+**Files**: `apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx` (new), `apps/native-rd/src/components/EditGoalView/EditGoalView.tsx`
+**Commit**: `refactor(edit-goal): extract EditGoalStepList from EditGoalView`
+**Changes**:
+
+- [ ] Create `EditGoalStepList.tsx` with `EditGoalStepListProps` covering: `steps`, `onReorderSteps`, `onReorderSubSteps`, `onAddStep`, `onStepTitleChange`, `onStepEvidenceChange`, `onAddSubStep`, `onSubStepTitleChange`, `onSubStepEvidenceChange`, `onDeleteSubStep`, `onDeleteStep`, `dragScrollController`, plus the copy props that only the list/rows use today: `stepsSectionLabel`, `addStepPlaceholder`, `evidencePickerTitle`, `evidenceTypesLabel`, `stepCountLabel`, `addSubStepLabel`, `breakIntoSubStepsLabel`, `newSubStepTitle`, `addStepButtonLabel`, `closeLabel`, `breakIntoSubStepsA11yLabel`, `addSubStepA11yLabel`, `announceReorder`, `deleteStepConfirmTitle`, `deleteStepConfirmMessage`, `deleteSubStepConfirmTitle`, `deleteSubStepConfirmMessage`.
+- [ ] Move into `EditGoalStepList`: `newStepTitle`/`editingId`/`editText`/`editingEvidenceId`/`screenReaderActive`/`pendingDelete` state, the `useEditGoalDrag` call, the `useAnimationPref` call, the `screenReaderActive` effect, `handleAddStep`, `findSubStep`, `beginEdit`, `commitEditing`, `handleAddSubStep`, `handleToggleEvidence`, `renderSubStepBlock`, and the JSX block from `stepsHeader` through the evidence-picker `Modal` and `ConfirmDeleteModal` (per D1/D3).
+- [ ] Import shared types (`EditGoalStep`, `EditGoalSubStep`, `EditGoalChipTone`) via `import type { ... } from "./EditGoalView"` (D2) — do not redefine them.
+- [ ] Slim `EditGoalView.tsx`: remove the moved state/handlers/JSX; render `<EditGoalStepList {...forwarded props} />` in their place; keep `goalTitle`/`onGoalTitleChange`/`description`/`onDescriptionChange`/header/footer/`onOverflowPress`/`onBack`/`onDone` local.
+- [ ] Update both files' top-of-file doc comments to describe the new split (mirror the existing "Drag orchestration lives in useEditGoalDrag; the row anatomy in EditGoalStepRow" convention already in `EditGoalView.tsx`'s header comment).
+- [ ] Run `bun run test --testPathPatterns EditGoalView` and confirm `EditGoalView.test.tsx` passes with no edits.
+- [ ] Load Storybook (`Iteration B/Goals/EditGoalView`) and manually verify: drag reorder, ↑/↓ fallback, inline rename, evidence picker toggle, sub-step add/reorder/delete, top-level step delete-confirm — all unchanged, across at least one light and one dark/high-contrast theme.
+
+### Step 2: Barrel export + typecheck/lint pass
+
+**Files**: `apps/native-rd/src/components/EditGoalView/index.ts`
+**Commit**: `refactor(edit-goal): export EditGoalStepList from the barrel`
+**Changes**:
+
+- [ ] Add `EditGoalStepList` component + `EditGoalStepListProps` type exports to `index.ts`, following the existing ordering (component, then its props type, matching the `EditGoalStepRow`/`EditGoalOverflowMenu` pattern already there).
+- [ ] `bun run type-check` and `bun run lint` clean.
+- [ ] `bun run test --testPathPatterns EditGoalView` clean (repeat, post-barrel-change, to catch any import cycle typecheck-only issue).
+
+## Testing Strategy
+
+- [ ] No new test file for this issue — `EditGoalView.test.tsx` is the existing coverage for this exact behavior (D12, #459, #460 blocks) and must pass unmodified.
+- [ ] `bun run test --testPathPatterns EditGoalView` (Jest 30, `@testing-library/react-native` v13) — full run, not just a subset, since the moved code paths (drag, rename, evidence, delete) are all exercised here.
+- [ ] Manual Storybook pass on `Iteration B/Goals/EditGoalView` per Step 1's checklist, across themes (at minimum `light-default` and one high-contrast/dark variant) — this is the visual gate, not just green CI (project memory: green type-check/lint/tests ≠ right design).
+- [ ] Confirm `EditGoalView.stories.tsx`'s standalone `EditGoalStepRow` story (line ~246) still renders — it imports `EditGoalStepRow` directly and is unaffected by this extraction, but is a cheap regression check since it shares `EditGoalView.styles.ts`.
+
+## Not in Scope
+
+| Item                                                                                       | Reason                                                               | Follow-up                                |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- | ---------------------------------------- |
+| Wiring `EditGoalStepList` into the New Goal wizard's build-step tier                       | That's the actual swap; this issue only makes the component reusable | #490                                     |
+| New props for wizard-specific needs (e.g., a step-count cap, wizard-flavored copy)         | Explicitly "must not do" in the issue body                           | #490 (or a follow-up if #490 needs more) |
+| Splitting `EditGoalView.styles.ts` into per-component files                                | No current pain point; would add churn without benefit (D4)          | none                                     |
+| Any visual/interaction change to drag, rename, evidence picker, or delete-confirm behavior | Issue is a pure cut-and-move refactor                                | none                                     |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
@@ -12,10 +12,10 @@
  * subscriptions that decide whether the ↑/↓ fallback shows (D5). EditGoalView
  * became a thin composition around this; the New Goal wizard (#490) reuses it.
  *
- * Types (EditGoalStep/EditGoalSubStep/EditGoalChipTone) stay defined in
- * EditGoalView and are imported here type-only (D2). Styles are the shared
- * EditGoalView.styles module (D4). Drag orchestration lives in useEditGoalDrag;
- * the row anatomy in EditGoalStepRow.
+ * The shared step types stay defined in EditGoalView (D2); the two this file
+ * needs — EditGoalStep/EditGoalSubStep — are imported here type-only. Styles
+ * are the shared EditGoalView.styles module (D4). Drag orchestration lives in
+ * useEditGoalDrag; the row anatomy in EditGoalStepRow.
  */
 import React, { useEffect, useState } from "react";
 import {

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
@@ -1,0 +1,535 @@
+/**
+ * EditGoalStepList — the reusable step-editor row/list layer extracted from
+ * EditGoalView (issue #489, Track of Epic #384). It owns the "Steps" section
+ * label + count, the drag-reorderable step rows (via useEditGoalDrag), each
+ * parent's one-level sub-step block (EditGoalSubStepList), the inline "Add
+ * step..." affordance, and the two local modals its state drives: the
+ * evidence-type picker and the ConfirmDeleteModal (D1).
+ *
+ * All editing state lives here — inline-rename (editingId/editText),
+ * evidence-picker (editingEvidenceId), delete-confirm (pendingDelete), the
+ * new-step draft (newStepTitle) — plus the screen-reader/animation-pref
+ * subscriptions that decide whether the ↑/↓ fallback shows (D5). EditGoalView
+ * became a thin composition around this; the New Goal wizard (#490) reuses it.
+ *
+ * Types (EditGoalStep/EditGoalSubStep/EditGoalChipTone) stay defined in
+ * EditGoalView and are imported here type-only (D2). Styles are the shared
+ * EditGoalView.styles module (D4). Drag orchestration lives in useEditGoalDrag;
+ * the row anatomy in EditGoalStepRow.
+ */
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text as RNText,
+  TextInput,
+  Pressable,
+  Modal,
+  AccessibilityInfo,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useUnistyles } from "react-native-unistyles";
+import { useAnimationPref } from "../../hooks/useAnimationPref";
+import { Text } from "../Text";
+import { EvidenceTypePicker } from "../EvidenceTypePicker";
+import type { EvidenceTypeValue } from "../../types/evidence";
+import type { DragScrollController } from "../StepList/dragAutoScroll";
+import { ConfirmDeleteModal } from "../ConfirmDeleteModal";
+import { EditGoalStepRow } from "./EditGoalStepRow";
+import { EditGoalSubStepList } from "./EditGoalSubStepList";
+import { useEditGoalDrag } from "./useEditGoalDrag";
+import { styles } from "./EditGoalView.styles";
+import type { EditGoalStep, EditGoalSubStep } from "./EditGoalView";
+
+export interface EditGoalStepListProps {
+  steps: EditGoalStep[];
+  /** Fired on drop with the full new step order. Not wired to persistence. */
+  onReorderSteps: (orderedStepIds: string[]) => void;
+  /**
+   * Fired on drop / ↑↓ with a parent's new sub-step order (#459). Scoped to one
+   * parent — siblings under other parents never move. Not wired to persistence.
+   */
+  onReorderSubSteps: (
+    parentStepId: string,
+    orderedSubStepIds: string[],
+  ) => void;
+  onAddStep: (title: string) => void;
+  onStepTitleChange: (stepId: string, title: string) => void;
+  /** Fired when the row's evidence picker toggles a step's planned types (D8). */
+  onStepEvidenceChange: (stepId: string, types: EvidenceTypeValue[]) => void;
+  /**
+   * Adds a sub-step under `parentStepId` (D12). Called with `newSubStepTitle`
+   * — the new sub-row is then renameable inline. Not wired to persistence.
+   */
+  onAddSubStep: (parentStepId: string, title: string) => void;
+  onSubStepTitleChange: (subStepId: string, title: string) => void;
+  /** Fired when a sub-step's evidence picker toggles its planned types (D12/D8). */
+  onSubStepEvidenceChange: (
+    subStepId: string,
+    types: EvidenceTypeValue[],
+  ) => void;
+  onDeleteSubStep: (subStepId: string) => void;
+  /** Deletes a top-level step (#460). Fired only after the user confirms (D1). */
+  onDeleteStep: (stepId: string) => void;
+  /**
+   * Optional auto-scroll controller for drags near the viewport edge, supplied
+   * by the screen that owns the ScrollView ([Integrate]). Omitted in Storybook
+   * (short lists don't scroll); reorder still works without it.
+   */
+  dragScrollController?: DragScrollController;
+
+  // --- Copy (i18n-free per D9; English defaults; [Integrate] passes t()). ---
+  stepsSectionLabel?: string;
+  addStepPlaceholder?: string;
+  evidencePickerTitle?: string;
+  evidenceTypesLabel?: string;
+  /** Pluralized step-count label. Default: "N step" / "N steps". */
+  stepCountLabel?: (count: number) => string;
+  /** "add a sub-step" affordance under a step that already has some (D12). */
+  addSubStepLabel?: string;
+  /** "break into sub-steps" prompt on a step with none (D12). */
+  breakIntoSubStepsLabel?: string;
+  /** Default title for a freshly-added sub-step, renamed inline after (D12). */
+  newSubStepTitle?: string;
+  /** a11y label for the "add step" + button. */
+  addStepButtonLabel?: string;
+  /** a11y label for the evidence-picker close affordances (backdrop + ✕). */
+  closeLabel?: string;
+  /** a11y label for the "break into sub-steps" prompt on a step (D12). */
+  breakIntoSubStepsA11yLabel?: (stepTitle: string) => string;
+  /** a11y label for the "add a sub-step" affordance under a step (D12). */
+  addSubStepA11yLabel?: (stepTitle: string) => string;
+  /**
+   * Builds the screen-reader announcement after a reorder (drag drop or ↑/↓
+   * fallback). `position` is 1-based. Defaults to `Moved "<title>" to position
+   * N` inside {@link useEditGoalDrag}.
+   */
+  announceReorder?: (stepTitle: string, position: number) => string;
+
+  // --- Confirm-delete copy (D5; English defaults; [Integrate] passes t()).
+  // The modal's own Delete/Cancel button labels come from ConfirmDeleteModal's
+  // internal i18n — only the title + message are threaded here. ---
+  /** Confirm-modal title when deleting a step. */
+  deleteStepConfirmTitle?: string;
+  /** Confirm-modal message when deleting a step (receives the step title). */
+  deleteStepConfirmMessage?: (title: string) => string;
+  /** Confirm-modal title when deleting a sub-step. */
+  deleteSubStepConfirmTitle?: string;
+  /** Confirm-modal message when deleting a sub-step (receives the sub-step title). */
+  deleteSubStepConfirmMessage?: (title: string) => string;
+}
+
+const defaultStepCountLabel = (count: number) =>
+  `${count} ${count === 1 ? "step" : "steps"}`;
+
+export function EditGoalStepList({
+  steps,
+  onReorderSteps,
+  onReorderSubSteps,
+  onAddStep,
+  onStepTitleChange,
+  onStepEvidenceChange,
+  onAddSubStep,
+  onSubStepTitleChange,
+  onSubStepEvidenceChange,
+  onDeleteSubStep,
+  onDeleteStep,
+  dragScrollController,
+  stepsSectionLabel = "Steps",
+  addStepPlaceholder = "Add step...",
+  evidencePickerTitle = "Planned evidence",
+  evidenceTypesLabel = "Evidence types",
+  stepCountLabel = defaultStepCountLabel,
+  addSubStepLabel = "add a sub-step",
+  breakIntoSubStepsLabel = "break into sub-steps",
+  newSubStepTitle = "New sub-step",
+  addStepButtonLabel = "Add step",
+  closeLabel = "Close",
+  breakIntoSubStepsA11yLabel = (stepTitle) =>
+    `Break "${stepTitle}" into sub-steps`,
+  addSubStepA11yLabel = (stepTitle) => `Add a sub-step to "${stepTitle}"`,
+  announceReorder,
+  deleteStepConfirmTitle = "Delete step?",
+  deleteStepConfirmMessage = (title) =>
+    `Delete "${title}"? Its evidence and any sub-steps will be removed too.`,
+  deleteSubStepConfirmTitle = "Delete sub-step?",
+  deleteSubStepConfirmMessage = (title) =>
+    `Delete "${title}"? Its evidence will be removed too.`,
+}: EditGoalStepListProps) {
+  const { theme } = useUnistyles();
+  const { animationPref } = useAnimationPref();
+
+  const [newStepTitle, setNewStepTitle] = useState("");
+  // A single "which id is being renamed" source, keyed by step OR sub-step id
+  // (ids are unique across both). commitEditing routes to the right callback.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState("");
+  // Which step or sub-step's evidence picker is open (D8/D12). Internal state —
+  // the chip tap opens it locally; onStepEvidenceChange / onSubStepEvidenceChange
+  // are the only outward evidence events.
+  const [editingEvidenceId, setEditingEvidenceId] = useState<string | null>(
+    null,
+  );
+  const [screenReaderActive, setScreenReaderActive] = useState(false);
+  // Which row-level delete is awaiting confirmation (#460, D1/D2). One modal
+  // instance below is driven by this; the rows only signal intent.
+  const [pendingDelete, setPendingDelete] = useState<{
+    kind: "step" | "subStep";
+    id: string;
+    title: string;
+  } | null>(null);
+
+  const drag = useEditGoalDrag({
+    steps,
+    onReorderSteps,
+    dragScrollController,
+    announceReorder,
+  });
+
+  useEffect(() => {
+    AccessibilityInfo.isScreenReaderEnabled()
+      .then(setScreenReaderActive)
+      .catch(() => {
+        // Fail open: show the ↑/↓ fallback if we can't determine SR status.
+        setScreenReaderActive(true);
+      });
+    const sub = AccessibilityInfo.addEventListener(
+      "screenReaderChanged",
+      setScreenReaderActive,
+    );
+    return () => sub.remove();
+  }, []);
+
+  const showAccessibleControls = screenReaderActive || animationPref === "none";
+  const canDrag = steps.length > 1 && editingId === null;
+
+  function handleAddStep() {
+    const trimmed = newStepTitle.trim();
+    if (!trimmed) return;
+    onAddStep(trimmed);
+    setNewStepTitle("");
+  }
+
+  // Find the sub-step with `id` across every parent (one-level, D12).
+  function findSubStep(id: string): EditGoalSubStep | undefined {
+    for (const s of steps) {
+      const sub = s.subSteps?.find((ss) => ss.id === id);
+      if (sub) return sub;
+    }
+    return undefined;
+  }
+
+  function beginEdit(id: string, title: string) {
+    setEditingId(id);
+    setEditText(title);
+  }
+
+  function commitEditing() {
+    if (editingId) {
+      const trimmed = editText.trim();
+      const step = steps.find((s) => s.id === editingId);
+      if (step) {
+        if (trimmed && trimmed !== step.title) {
+          onStepTitleChange(editingId, trimmed);
+        }
+      } else {
+        const sub = findSubStep(editingId);
+        if (sub && trimmed && trimmed !== sub.title) {
+          onSubStepTitleChange(editingId, trimmed);
+        }
+      }
+    }
+    setEditingId(null);
+    setEditText("");
+  }
+
+  function handleAddSubStep(parentStepId: string) {
+    onAddSubStep(parentStepId, newSubStepTitle);
+  }
+
+  // Evidence-picker toggle (D8/D12). Guards the "every step requires evidence"
+  // invariant: the last remaining type can't be deselected (no-op), so a step or
+  // sub-step never lands in a 0-selected state. Routes to the step or sub-step
+  // callback depending on which id opened the picker.
+  function handleToggleEvidence(type: EvidenceTypeValue) {
+    if (editingEvidenceId === null) return;
+    const step = steps.find((s) => s.id === editingEvidenceId);
+    const sub = step ? undefined : findSubStep(editingEvidenceId);
+    const current = step?.plannedEvidenceTypes ?? sub?.plannedEvidenceTypes;
+    if (!current) return;
+    const isSelected = current.includes(type);
+    if (isSelected && current.length === 1) return;
+    const next = isSelected
+      ? current.filter((t) => t !== type)
+      : [...current, type];
+    if (step) {
+      onStepEvidenceChange(editingEvidenceId, next);
+    } else {
+      onSubStepEvidenceChange(editingEvidenceId, next);
+    }
+  }
+
+  const editingEvidenceStep =
+    editingEvidenceId !== null
+      ? steps.find((s) => s.id === editingEvidenceId)
+      : undefined;
+  const editingEvidenceSub =
+    editingEvidenceId !== null && !editingEvidenceStep
+      ? findSubStep(editingEvidenceId)
+      : undefined;
+  const editingEvidenceTypes =
+    editingEvidenceStep?.plannedEvidenceTypes ??
+    editingEvidenceSub?.plannedEvidenceTypes;
+
+  // Sub-steps block (D12), rendered inside each parent's card. A parent with
+  // no sub-steps shows the "break into sub-steps" prompt; one with some
+  // shows the indented green-rail block of sub-rows plus "add a sub-step".
+  // Both add affordances seed a default-titled sub-step (renamed inline after).
+  function renderSubStepBlock(step: EditGoalStep) {
+    const subs = step.subSteps ?? [];
+    if (subs.length === 0) {
+      return (
+        <Pressable
+          style={styles.breakIntoRow}
+          onPress={() => handleAddSubStep(step.id)}
+          accessibilityRole="button"
+          accessibilityLabel={breakIntoSubStepsA11yLabel(step.title)}
+          hitSlop={6}
+          testID={`edit-goal-break-into-${step.id}`}
+        >
+          <RNText
+            style={styles.breakIntoGlyph}
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+          >
+            {"⚊"}
+          </RNText>
+          <RNText style={styles.breakIntoText}>{breakIntoSubStepsLabel}</RNText>
+        </Pressable>
+      );
+    }
+    return (
+      <View style={styles.subStepBlock}>
+        <EditGoalSubStepList
+          subSteps={subs}
+          onReorder={(ids) => onReorderSubSteps(step.id, ids)}
+          editingId={editingId}
+          editText={editText}
+          onEditTextChange={setEditText}
+          onStartEditing={(id, title) => beginEdit(id, title)}
+          onCommitEditing={commitEditing}
+          onEvidenceChipPress={(id) => setEditingEvidenceId(id)}
+          onDelete={(id) =>
+            setPendingDelete({
+              kind: "subStep",
+              id,
+              title: subs.find((s) => s.id === id)?.title ?? "",
+            })
+          }
+          showAccessibleControls={showAccessibleControls}
+          animationPref={animationPref}
+          dragScrollController={dragScrollController}
+          announceReorder={announceReorder}
+        />
+        <Pressable
+          style={styles.addSubStepRow}
+          onPress={() => handleAddSubStep(step.id)}
+          accessibilityRole="button"
+          accessibilityLabel={addSubStepA11yLabel(step.title)}
+          hitSlop={6}
+          testID={`edit-goal-add-substep-${step.id}`}
+        >
+          <RNText
+            style={styles.addSubStepGlyph}
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+          >
+            {"+"}
+          </RNText>
+          <RNText style={styles.addSubStepText}>{addSubStepLabel}</RNText>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <View style={styles.stepsHeader}>
+        <Text
+          variant="headline"
+          style={styles.stepsLabel}
+          accessibilityRole="header"
+        >
+          {stepsSectionLabel}
+        </Text>
+        <RNText style={styles.stepCount}>{stepCountLabel(steps.length)}</RNText>
+      </View>
+
+      <GestureHandlerRootView style={styles.stepList}>
+        {steps.map((step, index) => (
+          <View
+            key={step.id}
+            onLayout={(e) =>
+              drag.registerRowLayout(index, {
+                y: e.nativeEvent.layout.y,
+                height: e.nativeEvent.layout.height,
+              })
+            }
+          >
+            <EditGoalStepRow
+              step={step}
+              index={index}
+              stepNumber={index + 1}
+              isBeingDragged={drag.draggedIndex === index}
+              isEditing={editingId === step.id}
+              editText={editText}
+              onEditTextChange={setEditText}
+              onStartEditing={() => beginEdit(step.id, step.title)}
+              onCommitEditing={commitEditing}
+              onEvidenceChipPress={() => setEditingEvidenceId(step.id)}
+              onDragStart={drag.handleDragStart}
+              onDragMove={drag.handleDragMove}
+              onDragEnd={drag.handleDragEnd}
+              dragScrollCompensation={
+                drag.draggedIndex === index
+                  ? drag.dragScrollCompensation
+                  : undefined
+              }
+              onMoveUp={() => drag.moveStep(index, -1)}
+              onMoveDown={() => drag.moveStep(index, 1)}
+              showAccessibleControls={showAccessibleControls}
+              animationPref={animationPref}
+              isFirst={index === 0}
+              isLast={index === steps.length - 1}
+              canDrag={canDrag}
+              onDelete={() =>
+                setPendingDelete({
+                  kind: "step",
+                  id: step.id,
+                  title: step.title,
+                })
+              }
+            >
+              {/* Sub-steps block (D12), rendered inside the parent card so
+                  it drags with the parent. See renderSubStepBlock. */}
+              {renderSubStepBlock(step)}
+            </EditGoalStepRow>
+          </View>
+        ))}
+        {drag.isDragging && drag.dropSlot && (
+          <View
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+            style={[styles.dropLine, { top: drag.dropSlot.top }]}
+          />
+        )}
+      </GestureHandlerRootView>
+
+      <View style={styles.addRow}>
+        <View style={styles.addInputCard}>
+          <TextInput
+            style={styles.addInput}
+            value={newStepTitle}
+            onChangeText={setNewStepTitle}
+            onSubmitEditing={handleAddStep}
+            placeholder={addStepPlaceholder}
+            placeholderTextColor={theme.colors.textMuted}
+            returnKeyType="done"
+            blurOnSubmit={false}
+            testID="edit-goal-add-step-input"
+            accessibilityLabel={addStepPlaceholder}
+          />
+        </View>
+        <Pressable
+          style={styles.addButton}
+          onPress={handleAddStep}
+          testID="edit-goal-add-step-button"
+          accessibilityRole="button"
+          accessibilityLabel={addStepButtonLabel}
+        >
+          <RNText style={styles.addButtonText}>+</RNText>
+        </Pressable>
+      </View>
+
+      {/* Evidence-type picker (D8/D12): the reused multi-select authoring grid
+          in a local bottom-sheet Modal (mirrors the capture branch + nest
+          picker). Opened by a step OR a sub-step's chip; toggling updates that
+          row's pills via onStepEvidenceChange / onSubStepEvidenceChange; the last
+          remaining type can't be deselected (handleToggleEvidence guard). */}
+      <Modal
+        visible={editingEvidenceTypes !== undefined}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setEditingEvidenceId(null)}
+        accessibilityViewIsModal
+      >
+        <View style={styles.pickerOverlay}>
+          <Pressable
+            style={styles.pickerBackdrop}
+            onPress={() => setEditingEvidenceId(null)}
+            accessibilityRole="button"
+            accessibilityLabel={closeLabel}
+            testID="edit-goal-evidence-backdrop"
+          />
+          <SafeAreaView edges={["bottom"]} style={styles.pickerSheet}>
+            <View style={styles.pickerHandle} />
+            <View style={styles.pickerHeader}>
+              <RNText style={styles.pickerTitle} accessibilityRole="header">
+                {evidencePickerTitle}
+              </RNText>
+              <Pressable
+                style={styles.pickerClose}
+                onPress={() => setEditingEvidenceId(null)}
+                accessibilityRole="button"
+                accessibilityLabel={closeLabel}
+                hitSlop={8}
+                testID="edit-goal-evidence-close"
+              >
+                <RNText style={styles.pickerCloseIcon}>{"✕"}</RNText>
+              </Pressable>
+            </View>
+            {editingEvidenceTypes ? (
+              <EvidenceTypePicker
+                selectedTypes={editingEvidenceTypes}
+                onToggleType={handleToggleEvidence}
+                label={evidenceTypesLabel}
+              />
+            ) : null}
+          </SafeAreaView>
+        </View>
+      </Modal>
+
+      {/* Confirm-delete modal (#460, D1/D2): one instance for both row-level
+          deletions. The main-step × and the sub-step × both open it via
+          pendingDelete; onDeleteStep / onDeleteSubStep fire only on Confirm.
+          The modal supplies its own themed, i18n-aware Delete/Cancel buttons. */}
+      <ConfirmDeleteModal
+        visible={pendingDelete !== null}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => {
+          if (pendingDelete) {
+            if (pendingDelete.kind === "step") {
+              onDeleteStep(pendingDelete.id);
+            } else {
+              onDeleteSubStep(pendingDelete.id);
+            }
+          }
+          setPendingDelete(null);
+        }}
+        title={
+          pendingDelete?.kind === "subStep"
+            ? deleteSubStepConfirmTitle
+            : deleteStepConfirmTitle
+        }
+        message={
+          pendingDelete
+            ? pendingDelete.kind === "subStep"
+              ? deleteSubStepConfirmMessage(pendingDelete.title)
+              : deleteStepConfirmMessage(pendingDelete.title)
+            : ""
+        }
+      />
+    </>
+  );
+}

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
@@ -214,7 +214,7 @@ export function EditGoalView({
   doneLabel = "Done",
   overflowAccessibilityLabel = "More options",
   // Copy consumed only by the step-row list layer — forwarded straight to
-  // EditGoalStepList, which owns their English defaults (D2). Not defaulted
+  // EditGoalStepList, which owns their English defaults. Not defaulted
   // here so there's a single source of truth per prop.
   stepsSectionLabel,
   addStepPlaceholder,

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
@@ -17,34 +17,26 @@
  * be verified before the screen is wired.
  * `grep -rn "EditGoalView" src/screens` stays empty until then.
  *
+ * This component is a thin composition (header, goal-title card, optional
+ * description, EditGoalStepList, dates info banner, Done footer). The step-row
+ * list layer — rows, sub-step blocks, add-step affordance, inline-rename /
+ * evidence-picker / delete-confirm state, and the two modals those drive —
+ * lives in EditGoalStepList (issue #489), which the New Goal wizard reuses
+ * (#490). The shared step/sub-step types stay defined here (D2).
+ *
  * Drag orchestration lives in useEditGoalDrag; the row anatomy in
  * EditGoalStepRow; the ⋯ menu content in EditGoalOverflowMenu.
  */
-import React, { useEffect, useState } from "react";
-import {
-  View,
-  Text as RNText,
-  TextInput,
-  Pressable,
-  Modal,
-  AccessibilityInfo,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
+import React from "react";
+import { View, Text as RNText, TextInput } from "react-native";
 import { DotsThree, Pencil } from "phosphor-react-native";
 import { useUnistyles } from "react-native-unistyles";
-import { useAnimationPref } from "../../hooks/useAnimationPref";
-import { Text } from "../Text";
 import { IconButton } from "../IconButton";
 import { Button } from "../Button";
 import { ScreenSubHeader } from "../ScreenHeader/ScreenSubHeader";
-import { EvidenceTypePicker } from "../EvidenceTypePicker";
 import type { EvidenceTypeValue } from "../../types/evidence";
 import type { DragScrollController } from "../StepList/dragAutoScroll";
-import { ConfirmDeleteModal } from "../ConfirmDeleteModal";
-import { EditGoalStepRow } from "./EditGoalStepRow";
-import { EditGoalSubStepList } from "./EditGoalSubStepList";
-import { useEditGoalDrag } from "./useEditGoalDrag";
+import { EditGoalStepList } from "./EditGoalStepList";
 import { styles } from "./EditGoalView.styles";
 
 /** Tone of a display-only date/dependency chip on a step row (D5). */
@@ -194,9 +186,6 @@ export interface EditGoalViewProps {
   deleteSubStepConfirmMessage?: (title: string) => string;
 }
 
-const defaultStepCountLabel = (count: number) =>
-  `${count} ${count === 1 ? "step" : "steps"}`;
-
 export function EditGoalView({
   goalTitle,
   onGoalTitleChange,
@@ -219,227 +208,33 @@ export function EditGoalView({
   dragScrollController,
   headerLabel = "Edit goal",
   goalSectionLabel = "Goal",
-  stepsSectionLabel = "Steps",
-  addStepPlaceholder = "Add step...",
   descriptionPlaceholder,
   descriptionSectionLabel = "Goal description",
   datesInfoText = 'Dates & dependencies live on each step — tap a step in the full planner to set "after" / "waiting on".',
   doneLabel = "Done",
   overflowAccessibilityLabel = "More options",
-  evidencePickerTitle = "Planned evidence",
-  evidenceTypesLabel = "Evidence types",
-  stepCountLabel = defaultStepCountLabel,
-  addSubStepLabel = "add a sub-step",
-  breakIntoSubStepsLabel = "break into sub-steps",
-  newSubStepTitle = "New sub-step",
-  addStepButtonLabel = "Add step",
-  closeLabel = "Close",
-  breakIntoSubStepsA11yLabel = (stepTitle) =>
-    `Break "${stepTitle}" into sub-steps`,
-  addSubStepA11yLabel = (stepTitle) => `Add a sub-step to "${stepTitle}"`,
+  // Copy consumed only by the step-row list layer — forwarded straight to
+  // EditGoalStepList, which owns their English defaults (D2). Not defaulted
+  // here so there's a single source of truth per prop.
+  stepsSectionLabel,
+  addStepPlaceholder,
+  evidencePickerTitle,
+  evidenceTypesLabel,
+  stepCountLabel,
+  addSubStepLabel,
+  breakIntoSubStepsLabel,
+  newSubStepTitle,
+  addStepButtonLabel,
+  closeLabel,
+  breakIntoSubStepsA11yLabel,
+  addSubStepA11yLabel,
   announceReorder,
-  deleteStepConfirmTitle = "Delete step?",
-  deleteStepConfirmMessage = (title) =>
-    `Delete "${title}"? Its evidence and any sub-steps will be removed too.`,
-  deleteSubStepConfirmTitle = "Delete sub-step?",
-  deleteSubStepConfirmMessage = (title) =>
-    `Delete "${title}"? Its evidence will be removed too.`,
+  deleteStepConfirmTitle,
+  deleteStepConfirmMessage,
+  deleteSubStepConfirmTitle,
+  deleteSubStepConfirmMessage,
 }: EditGoalViewProps) {
   const { theme } = useUnistyles();
-  const { animationPref } = useAnimationPref();
-
-  const [newStepTitle, setNewStepTitle] = useState("");
-  // A single "which id is being renamed" source, keyed by step OR sub-step id
-  // (ids are unique across both). commitEditing routes to the right callback.
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editText, setEditText] = useState("");
-  // Which step or sub-step's evidence picker is open (D8/D12). Internal state —
-  // the chip tap opens it locally; onStepEvidenceChange / onSubStepEvidenceChange
-  // are the only outward evidence events.
-  const [editingEvidenceId, setEditingEvidenceId] = useState<string | null>(
-    null,
-  );
-  const [screenReaderActive, setScreenReaderActive] = useState(false);
-  // Which row-level delete is awaiting confirmation (#460, D1/D2). One modal
-  // instance below is driven by this; the rows only signal intent.
-  const [pendingDelete, setPendingDelete] = useState<{
-    kind: "step" | "subStep";
-    id: string;
-    title: string;
-  } | null>(null);
-
-  const drag = useEditGoalDrag({
-    steps,
-    onReorderSteps,
-    dragScrollController,
-    announceReorder,
-  });
-
-  useEffect(() => {
-    AccessibilityInfo.isScreenReaderEnabled()
-      .then(setScreenReaderActive)
-      .catch(() => {
-        // Fail open: show the ↑/↓ fallback if we can't determine SR status.
-        setScreenReaderActive(true);
-      });
-    const sub = AccessibilityInfo.addEventListener(
-      "screenReaderChanged",
-      setScreenReaderActive,
-    );
-    return () => sub.remove();
-  }, []);
-
-  const showAccessibleControls = screenReaderActive || animationPref === "none";
-  const canDrag = steps.length > 1 && editingId === null;
-
-  function handleAddStep() {
-    const trimmed = newStepTitle.trim();
-    if (!trimmed) return;
-    onAddStep(trimmed);
-    setNewStepTitle("");
-  }
-
-  // Find the sub-step with `id` across every parent (one-level, D12).
-  function findSubStep(id: string): EditGoalSubStep | undefined {
-    for (const s of steps) {
-      const sub = s.subSteps?.find((ss) => ss.id === id);
-      if (sub) return sub;
-    }
-    return undefined;
-  }
-
-  function beginEdit(id: string, title: string) {
-    setEditingId(id);
-    setEditText(title);
-  }
-
-  function commitEditing() {
-    if (editingId) {
-      const trimmed = editText.trim();
-      const step = steps.find((s) => s.id === editingId);
-      if (step) {
-        if (trimmed && trimmed !== step.title) {
-          onStepTitleChange(editingId, trimmed);
-        }
-      } else {
-        const sub = findSubStep(editingId);
-        if (sub && trimmed && trimmed !== sub.title) {
-          onSubStepTitleChange(editingId, trimmed);
-        }
-      }
-    }
-    setEditingId(null);
-    setEditText("");
-  }
-
-  function handleAddSubStep(parentStepId: string) {
-    onAddSubStep(parentStepId, newSubStepTitle);
-  }
-
-  // Evidence-picker toggle (D8/D12). Guards the "every step requires evidence"
-  // invariant: the last remaining type can't be deselected (no-op), so a step or
-  // sub-step never lands in a 0-selected state. Routes to the step or sub-step
-  // callback depending on which id opened the picker.
-  function handleToggleEvidence(type: EvidenceTypeValue) {
-    if (editingEvidenceId === null) return;
-    const step = steps.find((s) => s.id === editingEvidenceId);
-    const sub = step ? undefined : findSubStep(editingEvidenceId);
-    const current = step?.plannedEvidenceTypes ?? sub?.plannedEvidenceTypes;
-    if (!current) return;
-    const isSelected = current.includes(type);
-    if (isSelected && current.length === 1) return;
-    const next = isSelected
-      ? current.filter((t) => t !== type)
-      : [...current, type];
-    if (step) {
-      onStepEvidenceChange(editingEvidenceId, next);
-    } else {
-      onSubStepEvidenceChange(editingEvidenceId, next);
-    }
-  }
-
-  const editingEvidenceStep =
-    editingEvidenceId !== null
-      ? steps.find((s) => s.id === editingEvidenceId)
-      : undefined;
-  const editingEvidenceSub =
-    editingEvidenceId !== null && !editingEvidenceStep
-      ? findSubStep(editingEvidenceId)
-      : undefined;
-  const editingEvidenceTypes =
-    editingEvidenceStep?.plannedEvidenceTypes ??
-    editingEvidenceSub?.plannedEvidenceTypes;
-
-  // Sub-steps block (D12), rendered inside each parent's card. A parent with
-  // no sub-steps shows the "break into sub-steps" prompt; one with some
-  // shows the indented green-rail block of sub-rows plus "add a sub-step".
-  // Both add affordances seed a default-titled sub-step (renamed inline after).
-  function renderSubStepBlock(step: EditGoalStep) {
-    const subs = step.subSteps ?? [];
-    if (subs.length === 0) {
-      return (
-        <Pressable
-          style={styles.breakIntoRow}
-          onPress={() => handleAddSubStep(step.id)}
-          accessibilityRole="button"
-          accessibilityLabel={breakIntoSubStepsA11yLabel(step.title)}
-          hitSlop={6}
-          testID={`edit-goal-break-into-${step.id}`}
-        >
-          <RNText
-            style={styles.breakIntoGlyph}
-            accessibilityElementsHidden
-            importantForAccessibility="no"
-          >
-            {"⚊"}
-          </RNText>
-          <RNText style={styles.breakIntoText}>{breakIntoSubStepsLabel}</RNText>
-        </Pressable>
-      );
-    }
-    return (
-      <View style={styles.subStepBlock}>
-        <EditGoalSubStepList
-          subSteps={subs}
-          onReorder={(ids) => onReorderSubSteps(step.id, ids)}
-          editingId={editingId}
-          editText={editText}
-          onEditTextChange={setEditText}
-          onStartEditing={(id, title) => beginEdit(id, title)}
-          onCommitEditing={commitEditing}
-          onEvidenceChipPress={(id) => setEditingEvidenceId(id)}
-          onDelete={(id) =>
-            setPendingDelete({
-              kind: "subStep",
-              id,
-              title: subs.find((s) => s.id === id)?.title ?? "",
-            })
-          }
-          showAccessibleControls={showAccessibleControls}
-          animationPref={animationPref}
-          dragScrollController={dragScrollController}
-          announceReorder={announceReorder}
-        />
-        <Pressable
-          style={styles.addSubStepRow}
-          onPress={() => handleAddSubStep(step.id)}
-          accessibilityRole="button"
-          accessibilityLabel={addSubStepA11yLabel(step.title)}
-          hitSlop={6}
-          testID={`edit-goal-add-substep-${step.id}`}
-        >
-          <RNText
-            style={styles.addSubStepGlyph}
-            accessibilityElementsHidden
-            importantForAccessibility="no"
-          >
-            {"+"}
-          </RNText>
-          <RNText style={styles.addSubStepText}>{addSubStepLabel}</RNText>
-        </Pressable>
-      </View>
-    );
-  }
 
   return (
     <View style={styles.container}>
@@ -489,105 +284,40 @@ export function EditGoalView({
           <Pencil size={16} weight="bold" color={theme.colors.textSecondary} />
         </View>
 
-        <View style={styles.stepsHeader}>
-          <Text
-            variant="headline"
-            style={styles.stepsLabel}
-            accessibilityRole="header"
-          >
-            {stepsSectionLabel}
-          </Text>
-          <RNText style={styles.stepCount}>
-            {stepCountLabel(steps.length)}
-          </RNText>
-        </View>
-
-        <GestureHandlerRootView style={styles.stepList}>
-          {steps.map((step, index) => (
-            <View
-              key={step.id}
-              onLayout={(e) =>
-                drag.registerRowLayout(index, {
-                  y: e.nativeEvent.layout.y,
-                  height: e.nativeEvent.layout.height,
-                })
-              }
-            >
-              <EditGoalStepRow
-                step={step}
-                index={index}
-                stepNumber={index + 1}
-                isBeingDragged={drag.draggedIndex === index}
-                isEditing={editingId === step.id}
-                editText={editText}
-                onEditTextChange={setEditText}
-                onStartEditing={() => beginEdit(step.id, step.title)}
-                onCommitEditing={commitEditing}
-                onEvidenceChipPress={() => setEditingEvidenceId(step.id)}
-                onDragStart={drag.handleDragStart}
-                onDragMove={drag.handleDragMove}
-                onDragEnd={drag.handleDragEnd}
-                dragScrollCompensation={
-                  drag.draggedIndex === index
-                    ? drag.dragScrollCompensation
-                    : undefined
-                }
-                onMoveUp={() => drag.moveStep(index, -1)}
-                onMoveDown={() => drag.moveStep(index, 1)}
-                showAccessibleControls={showAccessibleControls}
-                animationPref={animationPref}
-                isFirst={index === 0}
-                isLast={index === steps.length - 1}
-                canDrag={canDrag}
-                onDelete={() =>
-                  setPendingDelete({
-                    kind: "step",
-                    id: step.id,
-                    title: step.title,
-                  })
-                }
-              >
-                {/* Sub-steps block (D12), rendered inside the parent card so
-                    it drags with the parent. See renderSubStepBlock. */}
-                {renderSubStepBlock(step)}
-              </EditGoalStepRow>
-            </View>
-          ))}
-          {drag.isDragging && drag.dropSlot && (
-            <View
-              pointerEvents="none"
-              accessibilityElementsHidden
-              importantForAccessibility="no"
-              style={[styles.dropLine, { top: drag.dropSlot.top }]}
-            />
-          )}
-        </GestureHandlerRootView>
-
-        <View style={styles.addRow}>
-          <View style={styles.addInputCard}>
-            <TextInput
-              style={styles.addInput}
-              value={newStepTitle}
-              onChangeText={setNewStepTitle}
-              onSubmitEditing={handleAddStep}
-              placeholder={addStepPlaceholder}
-              placeholderTextColor={theme.colors.textMuted}
-              returnKeyType="done"
-              blurOnSubmit={false}
-              testID="edit-goal-add-step-input"
-              accessibilityLabel={addStepPlaceholder}
-            />
-          </View>
-          <Pressable
-            style={styles.addButton}
-            onPress={handleAddStep}
-            testID="edit-goal-add-step-button"
-            accessibilityRole="button"
-            accessibilityLabel={addStepButtonLabel}
-          >
-            <RNText style={styles.addButtonText}>+</RNText>
-          </Pressable>
-        </View>
+        {/* Step-row list layer (#489): "Steps" header + count, drag-reorderable
+            rows, sub-step blocks, add-step affordance, and the evidence-picker /
+            confirm-delete modals. All editing state lives inside it. */}
+        <EditGoalStepList
+          steps={steps}
+          onReorderSteps={onReorderSteps}
+          onReorderSubSteps={onReorderSubSteps}
+          onAddStep={onAddStep}
+          onStepTitleChange={onStepTitleChange}
+          onStepEvidenceChange={onStepEvidenceChange}
+          onAddSubStep={onAddSubStep}
+          onSubStepTitleChange={onSubStepTitleChange}
+          onSubStepEvidenceChange={onSubStepEvidenceChange}
+          onDeleteSubStep={onDeleteSubStep}
+          onDeleteStep={onDeleteStep}
+          dragScrollController={dragScrollController}
+          stepsSectionLabel={stepsSectionLabel}
+          addStepPlaceholder={addStepPlaceholder}
+          evidencePickerTitle={evidencePickerTitle}
+          evidenceTypesLabel={evidenceTypesLabel}
+          stepCountLabel={stepCountLabel}
+          addSubStepLabel={addSubStepLabel}
+          breakIntoSubStepsLabel={breakIntoSubStepsLabel}
+          newSubStepTitle={newSubStepTitle}
+          addStepButtonLabel={addStepButtonLabel}
+          closeLabel={closeLabel}
+          breakIntoSubStepsA11yLabel={breakIntoSubStepsA11yLabel}
+          addSubStepA11yLabel={addSubStepA11yLabel}
+          announceReorder={announceReorder}
+          deleteStepConfirmTitle={deleteStepConfirmTitle}
+          deleteStepConfirmMessage={deleteStepConfirmMessage}
+          deleteSubStepConfirmTitle={deleteSubStepConfirmTitle}
+          deleteSubStepConfirmMessage={deleteSubStepConfirmMessage}
+        />
 
         <View style={styles.infoBanner}>
           <RNText
@@ -609,85 +339,6 @@ export function EditGoalView({
           testID="edit-goal-done-button"
         />
       </View>
-
-      {/* Evidence-type picker (D8/D12): the reused multi-select authoring grid
-          in a local bottom-sheet Modal (mirrors the capture branch + nest
-          picker). Opened by a step OR a sub-step's chip; toggling updates that
-          row's pills via onStepEvidenceChange / onSubStepEvidenceChange; the last
-          remaining type can't be deselected (handleToggleEvidence guard). */}
-      <Modal
-        visible={editingEvidenceTypes !== undefined}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setEditingEvidenceId(null)}
-        accessibilityViewIsModal
-      >
-        <View style={styles.pickerOverlay}>
-          <Pressable
-            style={styles.pickerBackdrop}
-            onPress={() => setEditingEvidenceId(null)}
-            accessibilityRole="button"
-            accessibilityLabel={closeLabel}
-            testID="edit-goal-evidence-backdrop"
-          />
-          <SafeAreaView edges={["bottom"]} style={styles.pickerSheet}>
-            <View style={styles.pickerHandle} />
-            <View style={styles.pickerHeader}>
-              <RNText style={styles.pickerTitle} accessibilityRole="header">
-                {evidencePickerTitle}
-              </RNText>
-              <Pressable
-                style={styles.pickerClose}
-                onPress={() => setEditingEvidenceId(null)}
-                accessibilityRole="button"
-                accessibilityLabel={closeLabel}
-                hitSlop={8}
-                testID="edit-goal-evidence-close"
-              >
-                <RNText style={styles.pickerCloseIcon}>{"✕"}</RNText>
-              </Pressable>
-            </View>
-            {editingEvidenceTypes ? (
-              <EvidenceTypePicker
-                selectedTypes={editingEvidenceTypes}
-                onToggleType={handleToggleEvidence}
-                label={evidenceTypesLabel}
-              />
-            ) : null}
-          </SafeAreaView>
-        </View>
-      </Modal>
-
-      {/* Confirm-delete modal (#460, D1/D2): one instance for both row-level
-          deletions. The main-step × and the sub-step × both open it via
-          pendingDelete; onDeleteStep / onDeleteSubStep fire only on Confirm.
-          The modal supplies its own themed, i18n-aware Delete/Cancel buttons. */}
-      <ConfirmDeleteModal
-        visible={pendingDelete !== null}
-        onCancel={() => setPendingDelete(null)}
-        onConfirm={() => {
-          if (pendingDelete) {
-            if (pendingDelete.kind === "step") {
-              onDeleteStep(pendingDelete.id);
-            } else {
-              onDeleteSubStep(pendingDelete.id);
-            }
-          }
-          setPendingDelete(null);
-        }}
-        title={
-          pendingDelete?.kind === "subStep"
-            ? deleteSubStepConfirmTitle
-            : deleteStepConfirmTitle
-        }
-        message={
-          pendingDelete
-            ? pendingDelete.kind === "subStep"
-              ? deleteSubStepConfirmMessage(pendingDelete.title)
-              : deleteStepConfirmMessage(pendingDelete.title)
-            : ""
-        }
-      />
     </View>
   );
 }

--- a/apps/native-rd/src/components/EditGoalView/index.ts
+++ b/apps/native-rd/src/components/EditGoalView/index.ts
@@ -6,6 +6,8 @@ export type {
   EditGoalDateDepChip,
   EditGoalChipTone,
 } from "./EditGoalView";
+export { EditGoalStepList } from "./EditGoalStepList";
+export type { EditGoalStepListProps } from "./EditGoalStepList";
 export { EditGoalStepRow } from "./EditGoalStepRow";
 export type { EditGoalStepRowProps } from "./EditGoalStepRow";
 export { EditGoalSubStepRow } from "./EditGoalSubStepRow";


### PR DESCRIPTION
Closes #489 · Epic #384 · unblocks the New Goal build-step swap (#490).

## What

Pure extraction refactor. The step-row **list layer** — the "Steps" header + count, drag-reorderable step rows (`useEditGoalDrag`), each parent's sub-step block (`EditGoalSubStepList`), the inline "Add step…" affordance, all editing state (inline-rename, evidence-picker, confirmed-delete, new-step draft, SR/animation-pref subscriptions), and the two modals that state drives (evidence-type picker + `ConfirmDeleteModal`) — moves out of `EditGoalView` into a new **`EditGoalStepList`** component. `EditGoalView` is now a thin composition (header, goal-title card, optional description, `EditGoalStepList`, dates banner, Done footer).

The New Goal wizard (#490) reuses this layer; extracting it first as a no-behavior-change refactor is the blocker for that swap.

## Decisions (per dev plan)

- **D1** — the evidence-picker `Modal` and `ConfirmDeleteModal` move *with* their state into the child (smallest prop surface; no new "modal" callbacks).
- **D2** — all shared types (`EditGoalStep`, `EditGoalSubStep`, `EditGoalChipTone`, `EditGoalDateDepChip`, `EditGoalViewProps`) **stay defined in `EditGoalView.tsx`**; the child imports the two it needs type-only. Keeps `EditGoalView.test.tsx` / `.stories.tsx` import paths **unchanged**.
- **D4** — single shared `EditGoalView.styles.ts` (no per-component split).
- **D5** — `useAnimationPref` + the `AccessibilityInfo` screen-reader effect move wholesale into the child.

## Zero behavior change

- All logic is a verbatim cut — same defaults (17 copy/i18n props migrated with no drift), same callback surface, same testIDs, same a11y roles/labels.
- Type-only circular import (`EditGoalStepList` ← types; `EditGoalView` ← component) — erased at compile, same pattern `EditGoalStepRow` already uses.
- The two modals are RN-portaled, so their new tree position is inert to layout.

## Test plan

- ✅ `bun run type-check` — clean
- ✅ `bun run lint` — 0 errors (warnings pre-existing, unrelated files)
- ✅ `bun run test --testPathPatterns EditGoalView` — **53/53 pass, `EditGoalView.test.tsx` unmodified** (the zero-behavior-change bar per D2)
- ⏳ Manual Storybook glance (light + a dark/high-contrast theme) before merge — verbatim portaled-modal cut, low risk, but green CI ≠ right design.

## Review

Ran code-reviewer, silent-failure-hunter, comment-analyzer. Code + failure handling came back clean (handlers byte-for-byte identical to `main`); two comment inaccuracies the comment-analyzer found are fixed in the `docs(edit-goal)` commit here (docblock type list + a misattributed `(D2)` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNVZDcactCk3TKPcHHqoxQ