### PR TITLE
feat(native-rd): preserve Edit Goal reparent behavior (#496)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-496-edit-goal-reparent.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-496-edit-goal-reparent.md
@@ -158,19 +158,19 @@ i18n resources.
 
 **Commit**: `feat(editgoal): add flatten + applyReparent pure helpers`
 
-- [ ] `flattenEditGoalSteps(steps: EditGoalStep[]): ClassifyStep[]` — each
+- [x] `flattenEditGoalSteps(steps: EditGoalStep[]): ClassifyStep[]` — each
       parent emits `{ id, parentStepId: null }` then its `subSteps[]` as
       `{ id, parentStepId: parent.id }`, in render order.
-- [ ] `applyReparent(steps, stepId, newParentId): EditGoalStep[]` — removes the
+- [x] `applyReparent(steps, stepId, newParentId): EditGoalStep[]` — removes the
       step (root or sub-step) from its source location and appends it to the
       destination: `newParentId === null` → append to the root array; otherwise
       append to that parent's `subSteps[]`. Returns a new array (immutable).
       Refuses (returns input unchanged) when the move would violate the one-
       level cap (a parent-with-children demoted) — mirroring `classifyDrop`'s
       guard, for story safety.
-- [ ] `flattenEditGoalSteps` tests: flat list; one parent + 3 sub-steps; two
+- [x] `flattenEditGoalSteps` tests: flat list; one parent + 3 sub-steps; two
       parents each with children; empty; parent with `subSteps: []`.
-- [ ] `applyReparent` tests (review #5): promote a child → appended to root
+- [x] `applyReparent` tests (review #5): promote a child → appended to root
       array, source parent's `subSteps` loses it; demote a leaf root → appended
       to target parent's `subSteps`, root array loses it; move-between-parents
       → removed from source parent, appended to destination parent's
@@ -218,7 +218,7 @@ i18n resources.
       hovered-row-id change, armed only on root header bands that are valid
       `classifyDrop` dwell targets (leaf dragged, target is a root, not self).
 - [ ] `handleDragEnd` calls `classifyDrop(flatSteps, draggedFlatIndex,
-    hoverFlatIndex, armedTargetIdRef.current)` and dispatches: - `reorder` + `parentStepId === null` → `onReorderSteps(orderedIds)` - `reorder` + `parentStepId !== null` → `onReorderSubSteps(parent, ids)` - `reparent` → `onReparentStep?.(stepId, newParentStepId)` (no-op if
+  hoverFlatIndex, armedTargetIdRef.current)` and dispatches: - `reorder` + `parentStepId === null` → `onReorderSteps(orderedIds)` - `reorder` + `parentStepId !== null` → `onReorderSubSteps(parent, ids)` - `reparent` → `onReparentStep?.(stepId, newParentStepId)` (no-op if
       omitted) - `none` → snap-back.
 - [ ] **R13 `canDrag` derivation**: the coordinator exposes a
       `canDragRow(rowId)` (and the list derives `canDrag` per row) from the

--- a/apps/native-rd/docs/plans/dev-plans/issue-496-edit-goal-reparent.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-496-edit-goal-reparent.md
@@ -29,20 +29,20 @@ real `t()` + persistence through the contract this issue lands.
 Observable criteria derived from the issue acceptance checklist. Verifiable by
 running Storybook / Jest component tests.
 
-- [ ] A child can be promoted to a root (`onReparentStep(id, null)` fires from
+- [x] A child can be promoted to a root (`onReparentStep(id, null)` fires from
       the redesigned list, via drag-above-parent and via the Un-nest button).
-- [ ] A leaf root can be nested under a valid root (`onReparentStep(id, target)`
+- [x] A leaf root can be nested under a valid root (`onReparentStep(id, target)`
       fires; ineligible targets are refused).
-- [ ] A child can move between valid parents with correct sibling ordinals.
-- [ ] A parent-with-children and any depth>1 operation is refused (no callback
+- [x] A child can move between valid parents with correct sibling ordinals.
+- [x] A parent-with-children and any depth>1 operation is refused (no callback
       fires; snap-back; no Nest-under control renders).
-- [ ] Equivalent non-gesture controls (Nest-under picker + Un-nest button) are
+- [x] Equivalent non-gesture controls (Nest-under picker + Un-nest button) are
       available to screen-reader / reduced-motion users.
-- [ ] A child row is wired to the shared hierarchy drag coordinator (component
+- [x] A child row is wired to the shared hierarchy drag coordinator (component
       test proves a sub-step drag dispatches through the unified hook, not a
       parent-local hook).
-- [ ] Component tests cover callback payloads and hierarchy guards.
-- [ ] New Goal wizard can reuse the same step-editor contract — `onReparentStep`
+- [x] Component tests cover callback payloads and hierarchy guards.
+- [x] New Goal wizard can reuse the same step-editor contract — `onReparentStep`
       is a real `NewGoalWizardProps` member, forwarded to `EditGoalStepList`,
       and tested both enabled and omitted.
 
@@ -218,7 +218,7 @@ i18n resources.
       hovered-row-id change, armed only on root header bands that are valid
       `classifyDrop` dwell targets (leaf dragged, target is a root, not self).
 - [ ] `handleDragEnd` calls `classifyDrop(flatSteps, draggedFlatIndex,
-  hoverFlatIndex, armedTargetIdRef.current)` and dispatches: - `reorder` + `parentStepId === null` → `onReorderSteps(orderedIds)` - `reorder` + `parentStepId !== null` → `onReorderSubSteps(parent, ids)` - `reparent` → `onReparentStep?.(stepId, newParentStepId)` (no-op if
+hoverFlatIndex, armedTargetIdRef.current)` and dispatches: - `reorder` + `parentStepId === null` → `onReorderSteps(orderedIds)` - `reorder` + `parentStepId !== null` → `onReorderSubSteps(parent, ids)` - `reparent` → `onReparentStep?.(stepId, newParentStepId)` (no-op if
       omitted) - `none` → snap-back.
 - [ ] **R13 `canDrag` derivation**: the coordinator exposes a
       `canDragRow(rowId)` (and the list derives `canDrag` per row) from the
@@ -432,18 +432,18 @@ i18n resources.
 
 ## Testing Strategy
 
-- [ ] Unit tests for `flattenEditGoalSteps` (Step 1).
-- [ ] Unit tests for `applyReparent` append ordering (Step 1, review #5).
-- [ ] Unit tests for `useEditGoalHierarchyDrag` dispatch wiring + omitted-prop
+- [x] Unit tests for `flattenEditGoalSteps` (Step 1).
+- [x] Unit tests for `applyReparent` append ordering (Step 1, review #5).
+- [x] Unit tests for `useEditGoalHierarchyDrag` dispatch wiring + omitted-prop
       collapse + R13 `canDrag` derivation / lone-child promote (Step 2). No
       `classifyDrop` guard duplication (review #6).
-- [ ] Pure unit tests for geometry normalization (absolute→local outline
+- [x] Pure unit tests for geometry normalization (absolute→local outline
       conversion + scroll-delta pointer normalization) (Step 2, R14).
-- [ ] Component tests for `EditGoalView` reparent contract + SR controls +
+- [x] Component tests for `EditGoalView` reparent contract + SR controls +
       child-wired-to-coordinator integration (Step 7, review #6).
-- [ ] Component tests for `NewGoalWizard` forwarding (enabled + omitted)
+- [x] Component tests for `NewGoalWizard` forwarding (enabled + omitted)
       (Step 7, review #3).
-- [ ] `reorderStepIds` (existing) and `classifyDrop` (existing, 13 cases) are
+- [x] `reorderStepIds` (existing) and `classifyDrop` (existing, 13 cases) are
       reused unchanged — no new tests there.
 - [ ] `bun run type-check` + `bun run lint` after each commit; component tests
       via `bash apps/native-rd/scripts/jest-node.sh` (Bun segfaults on RN

--- a/apps/native-rd/docs/plans/dev-plans/issue-496-edit-goal-reparent.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-496-edit-goal-reparent.md
@@ -1,0 +1,485 @@
+# Development Plan: Issue #496
+
+## Issue Summary
+
+**Title**: [Storybook] Edit Goal — preserve reparent, promote, and demote
+**Type**: feature (Storybook-first)
+**Complexity**: MEDIUM–LARGE
+**Estimated Lines**: ~750 changed LOC (incl. stories/tests)
+**Branch**: `feat/issue-496-edit-goal-reparent`
+
+Part of **Epic #384 — Full Ride redesign**. Storybook prerequisite for #446 (the
+[Integrate] issue that wires the redesigned editor to Evolu). The existing
+`EditModeScreen` + `StepList` support full reparent (drag/dwell + accessible
+"Nest under…" / "Un-nest"); the redesigned `EditGoalView` / `EditGoalStepList`
+currently exposes sibling reorder only, using **one root `useEditGoalDrag`
+instance plus one independent `useEditGoalDrag` per parent** (each scoped to its
+own sibling group). That architecture cannot receive a child drag gesture at the
+root level, so promote / move-between-parents by drag is impossible today.
+
+Per Joe's product decision the redesign must **retain full functionality** —
+promote, demote, and move-between-parents — with the same one-level hierarchy
+guard and destination-ordinal rules. This issue is **Storybook + component-test
+only**. No screen integration, no Evolu writes, no i18n resource additions
+beyond forwarding optional copy props. The [Integrate] issue (#446) will thread
+real `t()` + persistence through the contract this issue lands.
+
+## Intent Verification
+
+Observable criteria derived from the issue acceptance checklist. Verifiable by
+running Storybook / Jest component tests.
+
+- [ ] A child can be promoted to a root (`onReparentStep(id, null)` fires from
+      the redesigned list, via drag-above-parent and via the Un-nest button).
+- [ ] A leaf root can be nested under a valid root (`onReparentStep(id, target)`
+      fires; ineligible targets are refused).
+- [ ] A child can move between valid parents with correct sibling ordinals.
+- [ ] A parent-with-children and any depth>1 operation is refused (no callback
+      fires; snap-back; no Nest-under control renders).
+- [ ] Equivalent non-gesture controls (Nest-under picker + Un-nest button) are
+      available to screen-reader / reduced-motion users.
+- [ ] A child row is wired to the shared hierarchy drag coordinator (component
+      test proves a sub-step drag dispatches through the unified hook, not a
+      parent-local hook).
+- [ ] Component tests cover callback payloads and hierarchy guards.
+- [ ] New Goal wizard can reuse the same step-editor contract — `onReparentStep`
+      is a real `NewGoalWizardProps` member, forwarded to `EditGoalStepList`,
+      and tested both enabled and omitted.
+
+## Dependencies
+
+| Issue | Title                                           | Status | Type    |
+| ----- | ----------------------------------------------- | ------ | ------- |
+| #445  | EditGoalView redesign host                      | ✅     | Context |
+| #489  | Extract EditGoalStepList                        | ✅     | Context |
+| #459  | Sub-step reorder in EditGoalStepList            | ✅     | Context |
+| #460  | Step delete in EditGoalStepList                 | ✅     | Context |
+| #490  | NewGoalWizard reuses EditGoalStepList           | ✅     | Context |
+| #330  | StepList drag-reparent gesture (reference impl) | ✅     | Pattern |
+
+`classifyDrop` (StepList) and `useEditGoalDrag` are already live and tested.
+No blockers.
+
+## Objective
+
+Replace the per-parent independent drag-hook architecture with a **single
+flattened hierarchy coordinator** (`useEditGoalHierarchyDrag`) that owns one flat
+index space, one shared row-geometry registry (absolute coordinates), dwell-arm
+state, and `classifyDrop` dispatch for reorder + reparent. Thread its handlers
+and flat indices through `EditGoalStepList` → both `EditGoalStepRow` (root) and
+`EditGoalSubStepList` → `EditGoalSubStepRow` (children). Add the reparent
+contract prop (`onReparentStep`) to `EditGoalView`, `EditGoalStepList`, and
+`NewGoalWizard` (forwarded). Add an accessible "Nest under…" picker + "Un-nest"
+button to the redesigned rows. Add a small pure `applyReparent` helper for
+stateful stories/tests and a nested-reparent unit test for append ordering. Add
+component tests proving a child row is wired to the shared coordinator. No
+`EditModeScreen`, no Evolu, no `StepList` changes, `classifyDrop` unchanged.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Alternatives Considered                            | Rationale                                                                                                                                                                                                 |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | Reuse `classifyDrop` **unchanged** as the drag-reparent decision layer                                                                                                                                                                                                                                                                                                                                                                                              | Reimplement a flatter classifier                   | It encodes the one-level cap, parent-with-children refusal, positional promote, dwell-demote — already unit-tested (13 cases); no duplication (review #6).                                                |
+| R2  | **One unified coordinator hook** `useEditGoalHierarchyDrag` replaces both the root `useEditGoalDrag` and every per-parent instance. Always called.                                                                                                                                                                                                                                                                                                                  | Root-only reparent hook; conditional hook calls    | A root-only hook cannot receive child drag gestures (review #1). Conditional hooks violate the rules of hooks (review #2). One flat index space is required for cross-group promote/move-between-parents. |
+| R3  | Row geometry is registered by **row id** into a single `Map<rowId, {absoluteY, height}>` measured via `onLayout` + `measureInWindow`, shared by all rows (root + sub-step).                                                                                                                                                                                                                                                                                         | Nested `onLayout` `y` values compared directly     | Nested `y` is relative to the parent card, not the list — comparing them across groups is invalid (review #1). Absolute geometry gives one coordinate space for `classifyDrop` hover math.                |
+| R4  | The **root row header** (drag handle + title + chips) is the hit/geometry target; the **animated drag surface** still moves the whole parent+children group (the existing `children`-slot transform in `EditGoalStepRow`). The registered geometry covers the root header band only.                                                                                                                                                                                | Register the whole group height as the root target | The drag starts on the header; `classifyDrop` needs the header band to decide promote/demote/reorder. The group moves together visually but the classifier sees header bands (review #1).                 |
+| R5  | `onReparentStep(stepId, newParentStepId \| null)` is the single reparent contract prop on `EditGoalView`, `EditGoalStepList`, and `NewGoalWizard`. Optional; when omitted the coordinator collapses to local sibling reorder only (handlers no-op on reparent results).                                                                                                                                                                                             | Separate promote/demote callbacks                  | Mirrors `StepList`/`EditModeScreen`; the [Integrate] issue already has a working `handleReparentStep`. Optional preserves the reorder-only wizard path (review #2).                                       |
+| R6  | `EditGoalStep` and `EditGoalSubStep` shapes are **unchanged** — no `parentStepId` added. The adapter owns the flat `ClassifyStep[]` shape.                                                                                                                                                                                                                                                                                                                          | Add `parentStepId` to `EditGoalStep`               | Review #4: the adapter owns the flat shape; adding the field is redundant and pollutes the redesigned model.                                                                                              |
+| R7  | `flattenEditGoalSteps()` flattens `EditGoalStep[]` → `ClassifyStep[]` (parent `{id, parentStepId: null}` then its `subSteps` `{id, parentStepId: parent.id}`) in render order. The coordinator maps flat indices ↔ row ids via the same order.                                                                                                                                                                                                                      | Make `classifyDrop` aware of the nested shape      | Keeps `classifyDrop` untouched and shared between both list implementations (R1).                                                                                                                         |
+| R8  | Accessible controls: "Nest under…" picker of eligible roots + "Un-nest" button, gated on `showAccessibleControls`. ↑/↓ fallback stays **sibling-reorder only** — never reparent.                                                                                                                                                                                                                                                                                    | ↑/↓ implicitly promote/demote; drag-only           | Q1/Q2 from #330 stand: any eligible root reachable, no O(n²) buttons; predictable for SR/reduced-motion users (WCAG 3.2).                                                                                 |
+| R9  | A pure `applyReparent(steps, stepId, newParentId)` helper removes the step from its source sibling group and appends it to the destination group (root group for promote, target parent's `subSteps` for demote). Used by stateful stories/tests. Production emits only the existing callback (R5).                                                                                                                                                                 | Stories mutate state ad hoc                        | Review #5: destination append ordering must be evidenced. Production persistence (ordinal normalization) is #446's job.                                                                                   |
+| R10 | Copy props (nest-under trigger/picker title/a11y, un-nest a11y, reparent announce) are optional with English defaults — i18n-free per D9 of #445.                                                                                                                                                                                                                                                                                                                   | Hardcode `t()` calls                               | The redesigned editor is i18n-free; the [Integrate] issue passes `t()`-backed builders.                                                                                                                   |
+| R11 | `NewGoalWizard` gains `onReparentStep?` on its props and forwards it to `EditGoalStepList`, plus the nest/un-nest copy props (forwarded). Tested both enabled and omitted.                                                                                                                                                                                                                                                                                          | Claim the wizard forwards it without code change   | Review #3: the wizard renders `EditGoalStepList` internally; the prop must be added explicitly.                                                                                                           |
+| R12 | Dwell-arm `armedTargetId` + `DWELL_ARM_MS = 220` live in the unified coordinator (JS state + ref mirror), disarmed on hovered-row-id change, arming only on root headers that are valid `classifyDrop` dwell targets.                                                                                                                                                                                                                                               | Per-parent dwell state                             | One coordinator owns all drag state; matches #330/D14 with the shared row-id geometry registry from R3.                                                                                                   |
+| R13 | **`canDrag` is derived from the flattened hierarchy + edit state + available actions**, not local sibling count. When reparent is enabled: a lone child is draggable (it can promote / move between parents), and a lone leaf root is draggable when ≥1 other valid root target exists. When reparent is omitted, the old simple sibling-count behavior is retained (`steps.length > 1` for roots, `subSteps.length > 1` within a parent).                          | Keep `canDrag = siblingCount > 1` always           | The per-parent hook made lone children undraggable, blocking promote/move-between-parents — a correctness gap once reparent is enabled (review: canDrag).                                                 |
+| R14 | Row geometry is **screen-absolute** (`measureInWindow`). During edge auto-scroll the pointer is normalized by the current scroll delta (or rows are remeasured at drag-start) so the registry never goes stale. Drop-outline `top` values rendered inside the list are converted from absolute `y` to **list-local** coordinates via a measured list origin (`measureInWindow` on the list container); an absolute `y` is never rendered directly as a local `top`. | Render absolute y directly; trust onLayout y       | Screen-absolute geometry drifts under programmatic scroll; nested onLayout y is parent-relative. Both must be normalized to one list-local space for hover math and outline rendering (review: geometry). |
+| R15 | Row refs call `measureInWindow` from `onLayout` **and** on drag-start refresh; `onLayout` alone reports parent-relative `y` and does not provide absolute coordinates. A `refreshGeometry(rowId)` is exposed so the coordinator can remeasure the dragged row (and, if needed, neighbors) when a drag begins.                                                                                                                                                       | onLayout-only measurement                          | Explicit: onLayout is relative + fires only on layout change; absolute coordinates require an imperative measure (review: geometry).                                                                      |
+
+## Affected Areas
+
+- `src/components/EditGoalView/EditGoalView.tsx` — add `onReparentStep` + copy
+  props; forward to `EditGoalStepList`.
+- `src/components/EditGoalView/EditGoalStepList.tsx` — replace the root +
+  per-parent `useEditGoalDrag` calls with **one** `useEditGoalHierarchyDrag`;
+  thread flat indices + shared handlers into both root rows and
+  `EditGoalSubStepList`; compute `rootTargets` / `canNestUnder` / `canUnNest`;
+  render dwell-arm + drop outlines.
+- `src/components/EditGoalView/EditGoalSubStepList.tsx` — stop instantiating its
+  own `useEditGoalDrag`; instead receive the coordinator's handlers + the
+  sub-step's flat index + shared `registerRowLayout` and forward them to
+  `EditGoalSubStepRow`.
+- `src/components/EditGoalView/EditGoalStepRow.tsx` — accept `flatIndex`,
+  `isArmedTarget`, `canNestUnder`, `nestTargets`, `onNestUnder`, `canUnNest`,
+  `onUnNest`, shared `onDragStart/onDragMove/onDragEnd` + `registerRowLayout`
+  (absolute geometry), + copy props. The root header is the registered hit
+  target; the `children` slot still transforms with the card during drag.
+- `src/components/EditGoalView/EditGoalSubStepRow.tsx` — accept `flatIndex`,
+  shared drag handlers + `registerRowLayout`, `canUnNest` + `onUnNest` + copy
+  props. No nest-under control (one-level cap).
+- `src/components/EditGoalView/useEditGoalHierarchyDrag.ts` — **new** unified
+  coordinator: flat index space, shared row-geometry registry keyed by row id
+  (absolute `y`/`height`), dwell-arm, `classifyDrop` dispatch via
+  `flattenEditGoalSteps`. Always called; reparent path no-ops when
+  `onReparentStep` is omitted.
+- `src/components/EditGoalView/flattenEditGoalSteps.ts` — **new** pure adapter
+  (`EditGoalStep[]` → `ClassifyStep[]`).
+- `src/components/EditGoalView/applyReparent.ts` — **new** pure nested reparent
+  helper for stateful stories/tests.
+- `src/components/EditGoalView/EditGoalView.styles.ts` — add `armedTargetItem`
+  (sustained dashed `success` border, static, all motion settings) and
+  nested/group drop-outline styles; picker Modal styles adapted to the mint rail.
+- `src/components/NewGoalWizard/NewGoalWizard.tsx` — add `onReparentStep?` +
+  nest/un-nest copy props to `NewGoalWizardProps`; forward to `EditGoalStepList`.
+- `src/components/EditGoalView/EditGoalView.stories.tsx` — reparent stories using
+  `applyReparent` for stateful local state.
+- `src/components/NewGoalWizard/NewGoalWizard.stories.tsx` — add a
+  `BuildStepReparent` story exercising the forwarded `onReparentStep`.
+- `src/components/EditGoalView/__tests__/EditGoalView.test.tsx` — reparent
+  contract + SR-control + child-wired-to-coordinator component tests.
+- `src/components/EditGoalView/__tests__/flattenEditGoalSteps.test.ts` — **new**.
+- `src/components/EditGoalView/__tests__/applyReparent.test.ts` — **new**
+  promote/demote/move-between-parents append-ordering tests.
+- `src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx` — extend with
+  `onReparentStep` forwarded (enabled + omitted).
+- `src/components/EditGoalView/__tests__/geometryNormalize.test.ts` — **new**
+  pure tests for absolute→local outline conversion and scroll-delta pointer
+  normalization (R14).
+
+**Not touched**: `EditModeScreen`, `StepList`, `classifyDrop.ts`, `db/queries.ts`,
+i18n resources.
+
+## Implementation Plan
+
+### Step 1 — Pure helpers: `flattenEditGoalSteps` + `applyReparent`
+
+**Files**: `flattenEditGoalSteps.ts` (new), `applyReparent.ts` (new),
+`__tests__/flattenEditGoalSteps.test.ts` (new),
+`__tests__/applyReparent.test.ts` (new).
+
+**Commit**: `feat(editgoal): add flatten + applyReparent pure helpers`
+
+- [ ] `flattenEditGoalSteps(steps: EditGoalStep[]): ClassifyStep[]` — each
+      parent emits `{ id, parentStepId: null }` then its `subSteps[]` as
+      `{ id, parentStepId: parent.id }`, in render order.
+- [ ] `applyReparent(steps, stepId, newParentId): EditGoalStep[]` — removes the
+      step (root or sub-step) from its source location and appends it to the
+      destination: `newParentId === null` → append to the root array; otherwise
+      append to that parent's `subSteps[]`. Returns a new array (immutable).
+      Refuses (returns input unchanged) when the move would violate the one-
+      level cap (a parent-with-children demoted) — mirroring `classifyDrop`'s
+      guard, for story safety.
+- [ ] `flattenEditGoalSteps` tests: flat list; one parent + 3 sub-steps; two
+      parents each with children; empty; parent with `subSteps: []`.
+- [ ] `applyReparent` tests (review #5): promote a child → appended to root
+      array, source parent's `subSteps` loses it; demote a leaf root → appended
+      to target parent's `subSteps`, root array loses it; move-between-parents
+      → removed from source parent, appended to destination parent's
+      `subSteps` at the end; refused parent-with-children demote → unchanged.
+
+**~110 LOC.**
+
+---
+
+### Step 2 — `useEditGoalHierarchyDrag` unified coordinator
+
+**Files**: `useEditGoalHierarchyDrag.ts` (new),
+`__tests__/useEditGoalHierarchyDrag.test.ts` (new).
+
+**Commit**: `feat(editgoal): unified hierarchy drag coordinator hook`
+
+- [ ] **Always called** (review #2). Params: `steps: EditGoalStep[]`,
+      `onReorderSteps`, `onReorderSubSteps`, `onReparentStep?`,
+      `dragScrollController?`, `announceReorder`, reparent announce builders.
+- [ ] Maintains the **flat index space** via `flattenEditGoalSteps`; exposes a
+      `flatIndexForRowId(rowId)` and `rowIdForFlatIndex(i)` map so root and
+      sub-step rows can register and receive handlers by flat index.
+- [ ] **Shared row-geometry registry**: `Map<rowId, { absoluteY, height }>`.
+      `registerRowLayout(rowId, layout)` is called by every row's `onLayout` +
+      `measureInWindow` (review #1/R3). Hover math (`rowIndexAtY`) uses absolute
+      `y` from this registry, so nested `onLayout` `y` values are never compared
+      directly. **R15**: `onLayout` alone reports parent-relative `y`; rows must
+      call `measureInWindow` (from `onLayout` and on drag-start refresh) to
+      populate `absoluteY`. The coordinator exposes `refreshGeometry(rowId)` so
+      drag-start remeasures the dragged row (and neighbors if needed) — the
+      registry never goes stale.
+- [ ] **R14 geometry normalization**: the list container measures its own
+      screen-absolute origin (`measureInWindow` → `listOriginY`). Drop-outline
+      `top` values are computed as `absoluteY - listOriginY` before rendering
+      inside the list — an absolute `y` is never rendered directly as a local
+      `top`. During edge auto-scroll, the pointer `absoluteY` used for hover
+      math is normalized by the current scroll delta
+      (`pointerListY = absoluteY + scrollDelta`) or rows are remeasured, so the
+      screen-absolute registry stays correct while content scrolls.
+- [ ] Root header geometry (R4): a root row registers the **header band**
+      (`absoluteY`/`height` of the header, not the whole parent+children group).
+      The animated drag surface (the `children` slot transform in
+      `EditGoalStepRow`) still moves the whole group visually.
+- [ ] Dwell-arm: `armedTargetId` state + ref, `DWELL_ARM_MS = 220`, disarmed on
+      hovered-row-id change, armed only on root header bands that are valid
+      `classifyDrop` dwell targets (leaf dragged, target is a root, not self).
+- [ ] `handleDragEnd` calls `classifyDrop(flatSteps, draggedFlatIndex,
+    hoverFlatIndex, armedTargetIdRef.current)` and dispatches: - `reorder` + `parentStepId === null` → `onReorderSteps(orderedIds)` - `reorder` + `parentStepId !== null` → `onReorderSubSteps(parent, ids)` - `reparent` → `onReparentStep?.(stepId, newParentStepId)` (no-op if
+      omitted) - `none` → snap-back.
+- [ ] **R13 `canDrag` derivation**: the coordinator exposes a
+      `canDragRow(rowId)` (and the list derives `canDrag` per row) from the
+      flattened hierarchy + `editingId` + available actions: - reparent **omitted**: a root is draggable when `rootCount > 1` and no
+      row is being edited; a sub-step is draggable when its parent has
+      `> 1` sub-step and no row is being edited (old sibling-count
+      behavior). - reparent **enabled**: a root is draggable when (`rootCount > 1` **or**
+      it is a leaf with ≥1 other valid root target) and no row is being
+      edited; a sub-step is draggable when (its parent has `> 1` sub-step
+      **or** reparent is enabled — a lone child can promote / move) and no
+      row is being edited.
+      A row being inline-edited disables drag for every row (existing
+      invariant), so a lone child can promote only when not editing.
+- [ ] `moveStep(flatIndex, direction)` stays **sibling-scoped** (R8): resolves
+      the sibling group from the flat step's `parentStepId`, swaps within it,
+      dispatches the right reorder callback; at a group boundary it is a no-op
+      (never reparent).
+- [ ] Exposes: `draggedRowId`, `isDragging`, `armedTargetId`, `dropOutline`
+      (`{top,height,kind}` for insertion-line / nested-outline / group-outline,
+      computed from the shared absolute geometry), `dragScrollCompensation`,
+      `registerRowLayout`, `handleDragStart(rowId)`, `handleDragMove`,
+      `handleDragEnd`, `moveStep(rowId, dir)`.
+- [ ] Unit tests: sibling reorder (root + sub-step); promote (child → root via
+      positional drop); demote via armed target; move-between-parents
+      (positional demote into another group); refused parent-with-children;
+      refused depth>1; refused armed-target-equals-dragged; reparent path is a
+      no-op when `onReparentStep` is omitted (reorder still works). **Do not
+      re-test `classifyDrop`'s own guards** (review #6) — only the dispatch
+      wiring + the omitted-prop collapse.
+- [ ] **R13 `canDrag` regression test**: with reparent enabled and a parent
+      that has a **single** sub-step, that lone child is draggable and a
+      promote (`onReparentStep(id, null)`) can be dispatched through the
+      coordinator — guards against the old sibling-count gate blocking the
+      single-child promotion path. Also: a lone leaf root with another valid
+      root target is draggable when reparent is enabled; the same lone root is
+      **not** draggable when reparent is omitted (old behavior).
+- [ ] **R14 geometry normalization unit test**: given a registry of absolute
+      `y`/`height` and a `listOriginY`, drop-outline `top` equals
+      `absoluteY - listOriginY` (never the raw absolute `y`); and given a
+      pointer `absoluteY` plus a scroll delta, the normalized list-local
+      pointer is `absoluteY + scrollDelta`. Keep these as pure functions
+      tested in `__tests__/geometryNormalize.test.ts`.
+
+**~230 LOC.**
+
+---
+
+### Step 3 — Thread the coordinator through the list + rows
+
+**Files**: `EditGoalStepList.tsx`, `EditGoalSubStepList.tsx`,
+`EditGoalStepRow.tsx`, `EditGoalSubStepRow.tsx`, `EditGoalView.styles.ts`.
+
+**Commit**: `feat(editgoal): thread unified hierarchy drag through rows`
+
+- [ ] `EditGoalStepList`:
+  - Add `onReparentStep?` + nest/un-nest copy props to `EditGoalStepListProps`.
+  - Call `useEditGoalHierarchyDrag` **once** (replacing the root
+    `useEditGoalDrag` call). Always called (review #2).
+  - Stop passing a per-parent `useEditGoalDrag` to `EditGoalSubStepList`;
+    instead pass the coordinator's shared `handleDragStart/Move/End`,
+    `registerRowLayout`, `dragScrollCompensation`, `dropOutline`, and the
+    sub-step's `flatIndex`, plus `armedTargetId`/`canUnNest`/`onUnNest`.
+  - Compute `rootTargets` (all parent ids+titles), `canNestUnder` (leaf root
+    with ≥1 other root), `canUnNest` (is a sub-step) per row.
+  - Render `armedTargetItem` on the armed root header; render drop outlines from
+    `dropOutline`.
+- [ ] `EditGoalSubStepList`: remove its own `useEditGoalDrag` instantiation
+      (review #1). Receive and forward the coordinator's handlers + `flatIndex` per
+      sub-step + shared `registerRowLayout`. It becomes a thin mapping over
+      `EditGoalSubStepRow`.
+- [ ] `EditGoalStepRow`:
+  - Accept `flatIndex`, shared `onDragStart/Move/End` (keyed by row id, not
+    local index), `registerRowLayout` (absolute geometry for the header band),
+    `isArmedTarget`, `canNestUnder`, `nestTargets`, `onNestUnder`, `canUnNest`,
+    `onUnNest`, + copy props.
+  - `onLayout` + `measureInWindow` register the **header band** into the shared
+    registry (R4/R15): `onLayout` provides relative `y`/`height`; an imperative
+    `measureInWindow` (called from `onLayout` and on drag-start refresh via the
+    coordinator's `refreshGeometry`) provides the screen-absolute `y`. The
+    `children` slot still transforms with the card during drag (whole group
+    moves).
+  - **R13**: `canDrag` is received from the list (derived from the flattened
+    hierarchy + edit state + available actions), not computed from local
+    sibling count. The row renders its drag gesture only when `canDrag` is true.
+  - **R14**: drop-outline `top` values consumed by the list are list-local
+    (absolute `y` minus the measured list origin); the row never renders an
+    absolute `y` as a local `top`.
+  - Accessible controls render inside `rowControls` when
+    `showAccessibleControls`: "Nest under…" IconButton opens a `Modal` picker
+    (reusing `DraggableStepItem`'s picker pattern, adapted to mint-rail tokens)
+    listing eligible roots; "Un-nest" IconButton calls `onUnNest`.
+- [ ] `EditGoalSubStepRow`: accept `flatIndex`, shared drag handlers +
+      `registerRowLayout` (absolute geometry, R15: `measureInWindow` from
+      `onLayout` + drag-start refresh), `canDrag` (R13: derived from the flattened
+      hierarchy — a lone child is draggable when reparent is enabled), `canUnNest`
+  - `onUnNest` + copy props. No nest-under control (one-level cap). Its
+    `onLayout` + `measureInWindow` register its absolute band into the shared
+    registry.
+- [ ] Styles: `armedTargetItem` (dashed `success` border, static, all motion
+      settings), `nestedDropOutline` / `groupDropOutline`, picker
+      `overlay/container/card/row/rowText/title` adapted to the redesigned tokens.
+
+**~220 LOC.**
+
+---
+
+### Step 4 — `EditGoalView` forwards the reparent contract
+
+**Files**: `EditGoalView.tsx`.
+
+**Commit**: `feat(editgoal): thread onReparentStep + nest/un-nest copy through host`
+
+- [ ] Add `onReparentStep?` + nest/un-nest copy props to `EditGoalViewProps`.
+- [ ] Forward to `EditGoalStepList` alongside the existing reorder/evidence
+      props. No behavioural change in the host — it remains a thin composition;
+      the nest picker `Modal` lives in `EditGoalStepRow`.
+
+**~30 LOC.**
+
+---
+
+### Step 5 — `NewGoalWizard` forwards `onReparentStep`
+
+**Files**: `NewGoalWizard.tsx`, `NewGoalWizard.stories.tsx`.
+
+**Commit**: `feat(wizard): forward onReparentStep through NewGoalWizard`
+
+- [ ] Add `onReparentStep?: (stepId: string, newParentStepId: string | null) => void`
+      to `NewGoalWizardProps` (review #3) + the nest/un-nest copy props
+      (forwarded, English defaults).
+- [ ] Forward `onReparentStep` + copy to the internal `EditGoalStepList` on the
+      build step.
+- [ ] Add a `BuildStepReparent` story: stateful local steps using
+      `applyReparent`, exercising nest/un-nest via the wizard's build screen.
+
+**~40 LOC.**
+
+---
+
+### Step 6 — Stories
+
+**Files**: `EditGoalView.stories.tsx`.
+
+**Commit**: `test(storybook): reparent promote/demote/move-between-parents/invalid stories`
+
+- [ ] `InteractiveEditGoal` gains a `reparent(stepId, newParent)` handler using
+      `applyReparent` so the reviewer sees the real nesting change in local
+      state (review #5).
+- [ ] `ReparentInteraction` — long-press a leaf root, dwell on another root
+      ~220ms → dashed arm → release to nest.
+- [ ] `PromoteInteraction` — long-press a sub-step, drag above its parent group
+      → promotes to a root.
+- [ ] `MoveBetweenParents` — two parents each with sub-steps; drag a sub-step
+      into the other parent's child block.
+- [ ] `InvalidReparentTargets` — a parent-with-children (cannot be demoted) and
+      a sub-step (cannot be demoted further); snap-back + no control.
+- [ ] `AccessibleNestControls` — static anatomy with
+      `showAccessibleControls` forced on: "Nest under…" trigger + picker open,
+      "Un-nest" on a sub-step.
+
+**~60 LOC.**
+
+---
+
+### Step 7 — Component + integration tests
+
+**Files**: `__tests__/EditGoalView.test.tsx` (extend),
+`__tests__/NewGoalWizard.test.tsx` (extend).
+
+**Commit**: `test(editgoal): reparent contract, child-coordinator wiring, wizard forwarding`
+
+- [ ] `EditGoalView.test.tsx`:
+  - `onReparentStep` fires with `(id, null)` via the Un-nest button (deterministic
+    SR path in Node; drag-path dispatch is covered by the hook's unit tests).
+  - `onReparentStep` fires with `(id, targetId)` via the Nest-under picker.
+  - A parent-with-children renders no "Nest under…" control; the hook refuses
+    the drop (no callback).
+  - A sub-step renders no "Nest under…" control (one-level cap) but renders
+    "Un-nest".
+  - `canNestUnder` is false when there is only one root.
+  - Moving between parents dispatches `onReparentStep(id, newParentId)` and
+    does **not** dispatch `onReorderSubSteps` for the source parent.
+  - `↑/↓` on a child at its group boundary does not promote (no
+    `onReparentStep`).
+  - **Child-wired-to-coordinator integration test (review #6)**: render
+    `EditGoalView` with two parents + sub-steps, spy on `onReparentStep`, drive
+    a sub-step's drag handlers through the shared coordinator (via the row's
+    `onDragStart`/`onDragMove`/`onDragEnd` props, gestures mocked as in the
+    existing test file), and assert the reparent callback fires with the
+    correct `newParentStepId` — proving the sub-step row is wired to the
+    unified hierarchy coordinator, not a parent-local hook. Also assert a
+    sibling sub-step reorder dispatches `onReorderSubSteps` through the same
+    coordinator.
+  - **R13 single-child promotion regression (component)**: render a parent with
+    a single sub-step and `onReparentStep` enabled; assert the lone sub-step
+    row is draggable (`canDrag` true) and that driving its drag to promote
+    dispatches `onReparentStep(id, null)` — the component-level proof that the
+    old sibling-count gate no longer blocks the single-child promote path.
+  - `EditGoalView` forwards `onReparentStep` through to the list (prop-chain
+    regression guard).
+- [ ] `NewGoalWizard.test.tsx`:
+  - `onReparentStep` is forwarded: render the build step, open the nest picker
+    on a leaf root, select a target → `onReparentStep` fires (review #3).
+  - Omitted `onReparentStep`: the build step still reorders (no reparent
+    control rendered, reorder callbacks work).
+- [ ] Do **not** duplicate `classifyDrop`'s existing guard tests (review #6).
+
+**~80 LOC.**
+
+---
+
+## Testing Strategy
+
+- [ ] Unit tests for `flattenEditGoalSteps` (Step 1).
+- [ ] Unit tests for `applyReparent` append ordering (Step 1, review #5).
+- [ ] Unit tests for `useEditGoalHierarchyDrag` dispatch wiring + omitted-prop
+      collapse + R13 `canDrag` derivation / lone-child promote (Step 2). No
+      `classifyDrop` guard duplication (review #6).
+- [ ] Pure unit tests for geometry normalization (absolute→local outline
+      conversion + scroll-delta pointer normalization) (Step 2, R14).
+- [ ] Component tests for `EditGoalView` reparent contract + SR controls +
+      child-wired-to-coordinator integration (Step 7, review #6).
+- [ ] Component tests for `NewGoalWizard` forwarding (enabled + omitted)
+      (Step 7, review #3).
+- [ ] `reorderStepIds` (existing) and `classifyDrop` (existing, 13 cases) are
+      reused unchanged — no new tests there.
+- [ ] `bun run type-check` + `bun run lint` after each commit; component tests
+      via `bash apps/native-rd/scripts/jest-node.sh` (Bun segfaults on RN
+      component suites — tooling note from #330).
+- [ ] Storybook manual QA: each new story across the 7 themes (toolbar
+      switcher — `EditGoalView` re-renders post-mount, so no live per-cell
+      matrix, per the existing `AllThemesMatrix` note).
+
+## Not in Scope
+
+| Item                                                            | Reason                                                                | Follow-up          |
+| --------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------ |
+| `EditModeScreen` / `StepList` integration                       | This is the Storybook redesign track                                  | #446 ([Integrate]) |
+| Evolu persistence (`updateStep`/`reorderSubSteps` ordinal norm) | Persistence is the [Integrate] issue's job                            | #446               |
+| i18n resource keys (en/de/pseudo)                               | Redesigned editor is i18n-free; copy via props                        | #446               |
+| Position-implied insert on demote (land at drop slot)           | Append-to-end first, per #330/Q5                                      | Post-#446          |
+| Auto-scroll of the Storybook stage                              | Short story lists don't scroll; `dragScrollController` stays optional | #446               |
+| `classifyDrop` changes or re-tests of its guards                | Reused unchanged (R1, review #6)                                      | —                  |
+| `EditModeScreen` reparent regression coverage                   | `StepList`/`EditModeScreen` unchanged; covered by #330's tests        | —                  |
+
+## Open Questions
+
+None — all decisions settled per the issue brief and the review:
+
+- One unified flattened hierarchy coordinator with absolute row-id geometry
+  (R2/R3/R4, review #1).
+- Always-called hook; reorder-only collapse when `onReparentStep` omitted
+  (R2/R5, review #2).
+- `NewGoalWizardProps.onReparentStep` added + forwarded + tested both ways
+  (R11, review #3).
+- No `parentStepId` on `EditGoalStep`; the adapter owns the flat shape (R6,
+  review #4).
+- `applyReparent` pure helper evidences append ordering; production emits only
+  the callback (R9, review #5).
+- Component integration test proves a child row is wired to the shared
+  coordinator; `classifyDrop` unchanged, no guard-test duplication (Step 7,
+  review #6).
+- LOC estimate revised to ~750 to cover the coordinator, threading, wizard
+  prop, helper, and tests honestly (review #7).

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
@@ -22,7 +22,7 @@
  * are the shared EditGoalView.styles module (D4). Drag orchestration lives in
  * useEditGoalDrag; the row anatomy in EditGoalStepRow.
  */
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   View,
   Text as RNText,
@@ -38,7 +38,7 @@ import type { DragScrollController } from "../StepList/dragAutoScroll";
 import { ConfirmDeleteModal } from "../ConfirmDeleteModal";
 import { EditGoalStepRow } from "./EditGoalStepRow";
 import { EditGoalSubStepList } from "./EditGoalSubStepList";
-import { useEditGoalDrag } from "./useEditGoalDrag";
+import { useEditGoalHierarchyDrag } from "./useEditGoalHierarchyDrag";
 import { styles } from "./EditGoalView.styles";
 import type { EditGoalStep, EditGoalSubStep } from "./EditGoalView";
 
@@ -54,6 +54,12 @@ export interface EditGoalStepListProps {
     parentStepId: string,
     orderedSubStepIds: string[],
   ) => void;
+  /**
+   * Fired on a drag-reparent / nest-under / un-nest (#496). When omitted the
+   * coordinator collapses to local sibling reorder only (R5) and the
+   * nest/un-nest accessible controls do not render.
+   */
+  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
   onAddStep: (title: string) => void;
   onStepTitleChange: (stepId: string, title: string) => void;
   /**
@@ -113,6 +119,14 @@ export interface EditGoalStepListProps {
   deleteSubStepConfirmTitle?: string;
   /** Confirm-modal message when deleting a sub-step (receives the sub-step title). */
   deleteSubStepConfirmMessage?: (title: string) => string;
+  // --- Nest-under / un-nest copy (#496, R10) ---
+  nestUnderTriggerA11yLabel?: string;
+  nestUnderPickerTitle?: string;
+  nestUnderRowLabel?: (targetTitle: string) => string;
+  nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  unNestA11yLabel?: string;
+  announcePromote?: (stepTitle: string) => string;
+  announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
 }
 
 const defaultStepCountLabel = (count: number) =>
@@ -122,6 +136,7 @@ export function EditGoalStepList({
   steps,
   onReorderSteps,
   onReorderSubSteps,
+  onReparentStep,
   onAddStep,
   onStepTitleChange,
   onEvidenceChipPress,
@@ -147,6 +162,14 @@ export function EditGoalStepList({
   deleteSubStepConfirmTitle = "Delete sub-step?",
   deleteSubStepConfirmMessage = (title) =>
     `Delete "${title}"? Its evidence will be removed too.`,
+  nestUnderTriggerA11yLabel = "Nest this step under another step",
+  nestUnderPickerTitle = "Choose a step to nest under",
+  nestUnderRowLabel = (targetTitle) => `Nest under "${targetTitle}"`,
+  nestUnderRowA11yLabel = (targetTitle) =>
+    `Nest this step under ${targetTitle}`,
+  unNestA11yLabel = "Promote this step to top level",
+  announcePromote,
+  announceNestedUnder,
 }: EditGoalStepListProps) {
   const { theme } = useUnistyles();
   const { animationPref } = useAnimationPref();
@@ -165,12 +188,34 @@ export function EditGoalStepList({
     title: string;
   } | null>(null);
 
-  const drag = useEditGoalDrag({
+  const drag = useEditGoalHierarchyDrag({
     steps,
     onReorderSteps,
+    onReorderSubSteps,
+    onReparentStep,
     dragScrollController,
+    editingId,
     announceReorder,
+    announcePromote,
+    announceNestedUnder,
   });
+
+  // R14: register the list container's screen-absolute origin so drop outlines
+  // render in list-local coordinates. measureInWindow is called from onLayout
+  // of the list container below (listOriginRef is owned by the coordinator).
+  const listContainerRef = useRef<View>(null);
+  function measureListOrigin() {
+    const node = listContainerRef.current as unknown as {
+      measureInWindow?: (
+        cb: (x: number, y: number, w: number, h: number) => void,
+      ) => void;
+    } | null;
+    if (node?.measureInWindow) {
+      node.measureInWindow((_x, y) => {
+        drag.registerListOrigin(y);
+      });
+    }
+  }
 
   useEffect(() => {
     AccessibilityInfo.isScreenReaderEnabled()
@@ -187,7 +232,10 @@ export function EditGoalStepList({
   }, []);
 
   const showAccessibleControls = screenReaderActive || animationPref === "none";
-  const canDrag = steps.length > 1 && editingId === null;
+  // R13: canDrag per row is derived by the coordinator from the flattened
+  // hierarchy + edit state + available actions (a lone child can promote when
+  // reparent is enabled). The list-level `editingId === null` guard is retained
+  // via the coordinator's editingId param.
 
   function handleAddStep() {
     const trimmed = newStepTitle.trim();
@@ -280,8 +328,22 @@ export function EditGoalStepList({
           }
           showAccessibleControls={showAccessibleControls}
           animationPref={animationPref}
-          dragScrollController={dragScrollController}
-          announceReorder={announceReorder}
+          onDragStart={drag.handleDragStart}
+          onDragMove={drag.handleDragMove}
+          onDragEnd={drag.handleDragEnd}
+          registerRowLayout={drag.registerRowLayout}
+          registerRemeasure={drag.registerRemeasure}
+          dragScrollCompensation={drag.dragScrollCompensation}
+          canDragRow={drag.canDragRow}
+          draggedRowId={drag.draggedRowId}
+          moveStep={drag.moveStep}
+          canUnNest={!!onReparentStep}
+          onUnNest={
+            onReparentStep
+              ? (subStepId) => onReparentStep(subStepId, null)
+              : undefined
+          }
+          unNestA11yLabel={unNestA11yLabel}
         />
         <Pressable
           style={styles.addSubStepRow}
@@ -317,63 +379,111 @@ export function EditGoalStepList({
         <RNText style={styles.stepCount}>{stepCountLabel(steps.length)}</RNText>
       </View>
 
-      <GestureHandlerRootView style={styles.stepList}>
-        {steps.map((step, index) => (
-          <View
-            key={step.id}
-            onLayout={(e) =>
-              drag.registerRowLayout(index, {
-                y: e.nativeEvent.layout.y,
-                height: e.nativeEvent.layout.height,
-              })
-            }
-          >
-            <EditGoalStepRow
-              step={step}
-              index={index}
-              stepNumber={index + 1}
-              isBeingDragged={drag.draggedIndex === index}
-              isEditing={editingId === step.id}
-              editText={editText}
-              onEditTextChange={setEditText}
-              onStartEditing={() => beginEdit(step.id, step.title)}
-              onCommitEditing={commitEditing}
-              onEvidenceChipPress={() => onEvidenceChipPress(step.id)}
-              onDragStart={drag.handleDragStart}
-              onDragMove={drag.handleDragMove}
-              onDragEnd={drag.handleDragEnd}
-              dragScrollCompensation={
-                drag.draggedIndex === index
-                  ? drag.dragScrollCompensation
-                  : undefined
-              }
-              onMoveUp={() => drag.moveStep(index, -1)}
-              onMoveDown={() => drag.moveStep(index, 1)}
-              showAccessibleControls={showAccessibleControls}
-              animationPref={animationPref}
-              isFirst={index === 0}
-              isLast={index === steps.length - 1}
-              canDrag={canDrag}
-              onDelete={() =>
-                setPendingDelete({
-                  kind: "step",
-                  id: step.id,
-                  title: step.title,
-                })
-              }
-            >
-              {/* Sub-steps block (D12), rendered inside the parent card so
-                  it drags with the parent. See renderSubStepBlock. */}
-              {renderSubStepBlock(step)}
-            </EditGoalStepRow>
-          </View>
-        ))}
-        {drag.isDragging && drag.dropSlot && (
+      <GestureHandlerRootView
+        onLayout={measureListOrigin}
+        style={styles.stepList}
+      >
+        <View
+          ref={listContainerRef}
+          onLayout={measureListOrigin}
+          accessibilityElementsHidden
+          importantForAccessibility="no"
+          style={{ position: "absolute", top: 0, left: 0, height: 0, width: 0 }}
+        />
+        {steps.map((step, index) => {
+          const isLeafRoot = (step.subSteps?.length ?? 0) === 0;
+          const nestTargets = steps
+            .filter((s) => s.id !== step.id)
+            .map((s) => ({ id: s.id, title: s.title }));
+          const canNestUnder =
+            !!onReparentStep && isLeafRoot && nestTargets.length > 0;
+          return (
+            <View key={step.id}>
+              <EditGoalStepRow
+                step={step}
+                index={index}
+                stepNumber={index + 1}
+                isBeingDragged={drag.draggedRowId === step.id}
+                isEditing={editingId === step.id}
+                editText={editText}
+                onEditTextChange={setEditText}
+                onStartEditing={() => beginEdit(step.id, step.title)}
+                onCommitEditing={commitEditing}
+                onEvidenceChipPress={() => onEvidenceChipPress(step.id)}
+                onDragStart={drag.handleDragStart}
+                onDragMove={drag.handleDragMove}
+                onDragEnd={drag.handleDragEnd}
+                registerRowLayout={drag.registerRowLayout}
+                registerRemeasure={drag.registerRemeasure}
+                dragScrollCompensation={
+                  drag.draggedRowId === step.id
+                    ? drag.dragScrollCompensation
+                    : undefined
+                }
+                onMoveUp={() => drag.moveStep(step.id, -1)}
+                onMoveDown={() => drag.moveStep(step.id, 1)}
+                showAccessibleControls={showAccessibleControls}
+                animationPref={animationPref}
+                isFirst={index === 0}
+                isLast={index === steps.length - 1}
+                canDrag={drag.canDragRow(step.id)}
+                isArmedTarget={
+                  drag.isDragging && drag.armedTargetId === step.id
+                }
+                canNestUnder={canNestUnder}
+                nestTargets={nestTargets}
+                onNestUnder={
+                  onReparentStep
+                    ? (targetId) => onReparentStep(step.id, targetId)
+                    : undefined
+                }
+                onDelete={() =>
+                  setPendingDelete({
+                    kind: "step",
+                    id: step.id,
+                    title: step.title,
+                  })
+                }
+                nestUnderTriggerA11yLabel={nestUnderTriggerA11yLabel}
+                nestUnderPickerTitle={nestUnderPickerTitle}
+                nestUnderRowLabel={nestUnderRowLabel}
+                nestUnderRowA11yLabel={nestUnderRowA11yLabel}
+              >
+                {/* Sub-steps block (D12), rendered inside the parent card so
+                    it drags with the parent. See renderSubStepBlock. */}
+                {renderSubStepBlock(step)}
+              </EditGoalStepRow>
+            </View>
+          );
+        })}
+        {drag.isDragging && drag.dropOutline?.kind === "line" && (
           <View
             pointerEvents="none"
             accessibilityElementsHidden
             importantForAccessibility="no"
-            style={[styles.dropLine, { top: drag.dropSlot.top }]}
+            style={[styles.dropLine, { top: drag.dropOutline.top }]}
+          />
+        )}
+        {drag.isDragging && drag.dropOutline?.kind === "nested" && (
+          <View
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+            style={[
+              styles.nestedDropOutline,
+              { top: drag.dropOutline.top, height: drag.dropOutline.height },
+            ]}
+          />
+        )}
+        {drag.isDragging && drag.dropOutline?.kind === "group" && (
+          <View
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+            style={[
+              styles.groupDropOutline,
+              { top: drag.dropOutline.top, height: drag.dropOutline.height },
+            ]}
           />
         )}
       </GestureHandlerRootView>

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepList.tsx
@@ -124,6 +124,7 @@ export interface EditGoalStepListProps {
   nestUnderPickerTitle?: string;
   nestUnderRowLabel?: (targetTitle: string) => string;
   nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  nestUnderCancelLabel?: string;
   unNestA11yLabel?: string;
   announcePromote?: (stepTitle: string) => string;
   announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
@@ -167,6 +168,7 @@ export function EditGoalStepList({
   nestUnderRowLabel = (targetTitle) => `Nest under "${targetTitle}"`,
   nestUnderRowA11yLabel = (targetTitle) =>
     `Nest this step under ${targetTitle}`,
+  nestUnderCancelLabel = "Cancel",
   unNestA11yLabel = "Promote this step to top level",
   announcePromote,
   announceNestedUnder,
@@ -187,7 +189,6 @@ export function EditGoalStepList({
     id: string;
     title: string;
   } | null>(null);
-
   const drag = useEditGoalHierarchyDrag({
     steps,
     onReorderSteps,
@@ -216,6 +217,13 @@ export function EditGoalStepList({
       });
     }
   }
+
+  useEffect(() => {
+    drag.registerListOriginRemeasure(measureListOrigin);
+    return () => drag.registerListOriginRemeasure(null);
+    // Coordinator registry functions read stable refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     AccessibilityInfo.isScreenReaderEnabled()
@@ -312,7 +320,6 @@ export function EditGoalStepList({
       <View style={styles.subStepBlock}>
         <EditGoalSubStepList
           subSteps={subs}
-          onReorder={(ids) => onReorderSubSteps(step.id, ids)}
           editingId={editingId}
           editText={editText}
           onEditTextChange={setEditText}
@@ -401,7 +408,6 @@ export function EditGoalStepList({
             <View key={step.id}>
               <EditGoalStepRow
                 step={step}
-                index={index}
                 stepNumber={index + 1}
                 isBeingDragged={drag.draggedRowId === step.id}
                 isEditing={editingId === step.id}
@@ -448,6 +454,7 @@ export function EditGoalStepList({
                 nestUnderPickerTitle={nestUnderPickerTitle}
                 nestUnderRowLabel={nestUnderRowLabel}
                 nestUnderRowA11yLabel={nestUnderRowA11yLabel}
+                nestUnderCancelLabel={nestUnderCancelLabel}
               >
                 {/* Sub-steps block (D12), rendered inside the parent card so
                     it drags with the parent. See renderSubStepBlock. */}

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepRow.tsx
@@ -16,8 +16,15 @@
  * appears when a screen reader is active or motion is off, so keyboard/VoiceOver
  * users are never drag-only.
  */
-import React from "react";
-import { View, Text as RNText, TextInput, Pressable } from "react-native";
+import React, { useRef, useState } from "react";
+import {
+  View,
+  Text as RNText,
+  TextInput,
+  Pressable,
+  Modal,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import Animated, {
@@ -27,13 +34,20 @@ import Animated, {
   withTiming,
   runOnJS,
 } from "react-native-reanimated";
-import { ArrowUp, ArrowDown } from "phosphor-react-native";
+import {
+  ArrowUp,
+  ArrowDown,
+  ArrowBendDownRight,
+  ArrowBendUpLeft,
+} from "phosphor-react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
 import { getTimingConfig } from "../../utils/animation";
 import { IconButton } from "../IconButton";
+import { Button } from "../Button";
 import { EvidenceTypePicker } from "../EvidenceTypePicker";
 import { styles } from "./EditGoalView.styles";
 import type { EditGoalChipTone, EditGoalStep } from "./EditGoalView";
+import type { RowGeometry } from "./useEditGoalHierarchyDrag";
 
 // Date/dependency chip glyphs, transcribed from the App Shell prototype's
 // `edit` route (subOf/editSteps): after ↩ / waiting ⏳ / due ▦.
@@ -57,9 +71,14 @@ export interface EditGoalStepRowProps {
   onCommitEditing: () => void;
   /** Opens the evidence-type picker for this step (D8). */
   onEvidenceChipPress: () => void;
-  onDragStart: (index: number) => void;
+  /** Unified coordinator handlers, keyed by row id (#496, R2). */
+  onDragStart: (rowId: string) => void;
   onDragMove: (translationY: number, absoluteY: number) => void;
   onDragEnd: () => void;
+  /** Register the root header's screen-absolute geometry (R3/R4/R15). */
+  registerRowLayout: (rowId: string, geometry: RowGeometry) => void;
+  /** Register a remeasure callback so drag-start can refresh geometry (R15). */
+  registerRemeasure: (rowId: string, fn: (() => void) | null) => void;
   dragScrollCompensation?: SharedValue<number>;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
@@ -71,6 +90,15 @@ export interface EditGoalStepRowProps {
   canDrag: boolean;
   /** Signal intent to delete this step (D1) — opens the confirm modal in the view. */
   onDelete: () => void;
+  /** Dwell-arm highlight on this root header (R12). */
+  isArmedTarget?: boolean;
+  /** Accessible nest-under control eligibility (R8). */
+  canNestUnder?: boolean;
+  nestTargets?: { id: string; title: string }[];
+  onNestUnder?: (targetId: string) => void;
+  /** Accessible un-nest control (R8) — a root with this step's children can't, a sub-step can. Not used on a root row. */
+  canUnNest?: boolean;
+  onUnNest?: () => void;
   /** Rendered inside the card below the row — the sub-steps block (D12). */
   children?: React.ReactNode;
 
@@ -87,6 +115,16 @@ export interface EditGoalStepRowProps {
   moveDownLabel?: (stepTitle: string) => string;
   /** a11y label for the × delete affordance. */
   deleteStepLabel?: (stepTitle: string) => string;
+  /** a11y label for the “Nest under…” trigger (R8). */
+  nestUnderTriggerA11yLabel?: string;
+  /** Title of the nest-under picker modal. */
+  nestUnderPickerTitle?: string;
+  /** Row label inside the nest-under picker (receives the target title). */
+  nestUnderRowLabel?: (targetTitle: string) => string;
+  /** a11y label for a nest-under picker row. */
+  nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  /** a11y label for the un-nest button (unused on a root row, kept for parity). */
+  unNestA11yLabel?: string;
 }
 
 export function EditGoalStepRow({
@@ -103,6 +141,8 @@ export function EditGoalStepRow({
   onDragStart,
   onDragMove,
   onDragEnd,
+  registerRowLayout,
+  registerRemeasure,
   dragScrollCompensation,
   onMoveUp,
   onMoveDown,
@@ -112,6 +152,12 @@ export function EditGoalStepRow({
   isLast,
   canDrag,
   onDelete,
+  isArmedTarget = false,
+  canNestUnder = false,
+  nestTargets = [],
+  onNestUnder,
+  canUnNest = false,
+  onUnNest,
   children,
   editStepA11yLabel = (stepTitle) => `Edit step: ${stepTitle}`,
   tapToEditHint = "Tap to edit step title",
@@ -119,11 +165,44 @@ export function EditGoalStepRow({
   moveUpLabel = (stepTitle) => `Move "${stepTitle}" up`,
   moveDownLabel = (stepTitle) => `Move "${stepTitle}" down`,
   deleteStepLabel = (stepTitle) => `Delete step: ${stepTitle}`,
+  nestUnderTriggerA11yLabel = "Nest this step under another step",
+  nestUnderPickerTitle = "Choose a step to nest under",
+  nestUnderRowLabel = (targetTitle) => `Nest under "${targetTitle}"`,
+  nestUnderRowA11yLabel = (targetTitle) =>
+    `Nest this step under ${targetTitle}`,
+  unNestA11yLabel = "Promote this step to top level",
 }: EditGoalStepRowProps) {
   const { theme } = useUnistyles();
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
   const isDragging = useSharedValue(false);
+  const headerRef = useRef<View>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  // R3/R15: register the root header's screen-absolute geometry. onLayout
+  // provides relative y; measureInWindow provides the absolute y the
+  // coordinator's hover math needs. The remeasure callback is registered so
+  // drag-start can refresh this row's geometry (the registry never goes stale).
+  function measureAndRegister() {
+    const node = headerRef.current as unknown as {
+      measureInWindow?: (
+        cb: (x: number, y: number, w: number, h: number) => void,
+      ) => void;
+    } | null;
+    if (node?.measureInWindow) {
+      node.measureInWindow((_x, y, _w, h) => {
+        registerRowLayout(step.id, { absoluteY: y, height: h });
+      });
+    }
+  }
+  React.useEffect(() => {
+    registerRemeasure(step.id, measureAndRegister);
+    return () => registerRemeasure(step.id, null);
+    // registerRemeasure/registerRowLayout are stable-enough closures from the
+    // coordinator; step.id is stable. Exclude them to avoid re-subscribing every
+    // render (the coordinator recreates them each render but they read refs).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step.id]);
 
   const timingQuick = getTimingConfig(animationPref, "quick");
   const timingNormal = getTimingConfig(animationPref, "normal");
@@ -149,7 +228,7 @@ export function EditGoalStepRow({
     .onStart(() => {
       isDragging.value = true;
       scale.value = noAnimation ? 1.02 : withTiming(1.02, timingQuick);
-      runOnJS(onDragStart)(index);
+      runOnJS(onDragStart)(step.id);
     });
 
   const pan = Gesture.Pan()
@@ -178,7 +257,7 @@ export function EditGoalStepRow({
   }));
 
   const body = isEditing ? (
-    <View style={styles.rowMain}>
+    <View ref={headerRef} onLayout={measureAndRegister} style={styles.rowMain}>
       <RNText
         style={styles.dragHandle}
         accessibilityElementsHidden
@@ -202,7 +281,11 @@ export function EditGoalStepRow({
     </View>
   ) : (
     <>
-      <View style={styles.rowMain}>
+      <View
+        ref={headerRef}
+        onLayout={measureAndRegister}
+        style={styles.rowMain}
+      >
         <View style={styles.rowLead}>
           <RNText
             style={styles.dragHandle}
@@ -259,6 +342,26 @@ export function EditGoalStepRow({
                   testID={`edit-goal-step-down-${step.id}`}
                 />
               )}
+              {canNestUnder && onNestUnder && (
+                <IconButton
+                  icon={<ArrowBendDownRight size={18} weight="bold" />}
+                  onPress={() => setPickerOpen(true)}
+                  size="sm"
+                  tone="ghost"
+                  accessibilityLabel={nestUnderTriggerA11yLabel}
+                  testID={`edit-goal-step-nest-under-${step.id}`}
+                />
+              )}
+              {canUnNest && onUnNest && (
+                <IconButton
+                  icon={<ArrowBendUpLeft size={18} weight="bold" />}
+                  onPress={onUnNest}
+                  size="sm"
+                  tone="ghost"
+                  accessibilityLabel={unNestA11yLabel}
+                  testID={`edit-goal-step-un-nest-${step.id}`}
+                />
+              )}
             </View>
           )}
           <Pressable
@@ -302,11 +405,65 @@ export function EditGoalStepRow({
     </>
   );
 
+  // Nest-under picker (R8): an accessible modal listing eligible root
+  // targets. Reuses DraggableStepItem's picker pattern, adapted to the
+  // redesigned mint-rail tokens. Suppresses rendering when the list has no
+  // targets (canNestUnder already gates the trigger, but the modal is only
+  // mounted when opened).
+  const picker =
+    canNestUnder && onNestUnder ? (
+      <Modal
+        visible={pickerOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setPickerOpen(false)}
+        accessibilityViewIsModal
+      >
+        <View
+          style={[
+            styles.pickerOverlay,
+            { backgroundColor: `${theme.colors.shadow}80` },
+          ]}
+        >
+          <SafeAreaView edges={["bottom"]} style={styles.pickerContainer}>
+            <View style={styles.pickerCard}>
+              <RNText style={styles.pickerTitle} accessibilityRole="header">
+                {nestUnderPickerTitle}
+              </RNText>
+              {nestTargets.map((target) => (
+                <Pressable
+                  key={target.id}
+                  style={styles.pickerRow}
+                  onPress={() => {
+                    onNestUnder(target.id);
+                    setPickerOpen(false);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel={nestUnderRowA11yLabel(target.title)}
+                  testID={`edit-goal-step-nest-target-${step.id}-${target.id}`}
+                >
+                  <RNText style={styles.pickerRowText}>
+                    {nestUnderRowLabel(target.title)}
+                  </RNText>
+                </Pressable>
+              ))}
+              <Button
+                label="Cancel"
+                variant="secondary"
+                onPress={() => setPickerOpen(false)}
+              />
+            </View>
+          </SafeAreaView>
+        </View>
+      </Modal>
+    ) : null;
+
   if (!canDrag) {
     return (
-      <View style={styles.rowCard}>
+      <View style={[styles.rowCard, isArmedTarget && styles.armedTargetItem]}>
         {body}
         {children}
+        {picker}
       </View>
     );
   }
@@ -322,6 +479,7 @@ export function EditGoalStepRow({
       style={[
         styles.rowCard,
         isBeingDragged && styles.rowCardDragging,
+        isArmedTarget && styles.armedTargetItem,
         animatedStyle,
       ]}
     >
@@ -329,6 +487,7 @@ export function EditGoalStepRow({
         <View>{body}</View>
       </GestureDetector>
       {children}
+      {picker}
     </Animated.View>
   );
 }

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepRow.tsx
@@ -16,7 +16,7 @@
  * appears when a screen reader is active or motion is off, so keyboard/VoiceOver
  * users are never drag-only.
  */
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import {
   View,
   Text as RNText,
@@ -34,20 +34,15 @@ import Animated, {
   withTiming,
   runOnJS,
 } from "react-native-reanimated";
-import {
-  ArrowUp,
-  ArrowDown,
-  ArrowBendDownRight,
-  ArrowBendUpLeft,
-} from "phosphor-react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
 import { getTimingConfig } from "../../utils/animation";
-import { IconButton } from "../IconButton";
 import { Button } from "../Button";
 import { EvidenceTypePicker } from "../EvidenceTypePicker";
 import { styles } from "./EditGoalView.styles";
 import type { EditGoalChipTone, EditGoalStep } from "./EditGoalView";
-import type { RowGeometry } from "./useEditGoalHierarchyDrag";
+import { HierarchyActionRow } from "./HierarchyActionRow";
+import type { RowGeometry } from "./useEditGoalHierarchyDragTypes";
+import { useRowGeometryRegistration } from "./useRowGeometryRegistration";
 
 // Date/dependency chip glyphs, transcribed from the App Shell prototype's
 // `edit` route (subOf/editSteps): after ↩ / waiting ⏳ / due ▦.
@@ -59,7 +54,6 @@ const CHIP_GLYPH: Record<EditGoalChipTone, string> = {
 
 export interface EditGoalStepRowProps {
   step: EditGoalStep;
-  index: number;
   /** 1-based display number shown before the title. */
   stepNumber: number;
   isBeingDragged: boolean;
@@ -96,9 +90,6 @@ export interface EditGoalStepRowProps {
   canNestUnder?: boolean;
   nestTargets?: { id: string; title: string }[];
   onNestUnder?: (targetId: string) => void;
-  /** Accessible un-nest control (R8) — a root with this step's children can't, a sub-step can. Not used on a root row. */
-  canUnNest?: boolean;
-  onUnNest?: () => void;
   /** Rendered inside the card below the row — the sub-steps block (D12). */
   children?: React.ReactNode;
 
@@ -123,13 +114,12 @@ export interface EditGoalStepRowProps {
   nestUnderRowLabel?: (targetTitle: string) => string;
   /** a11y label for a nest-under picker row. */
   nestUnderRowA11yLabel?: (targetTitle: string) => string;
-  /** a11y label for the un-nest button (unused on a root row, kept for parity). */
-  unNestA11yLabel?: string;
+  /** Visible label on the picker cancel button (R10 / review finding 4). */
+  nestUnderCancelLabel?: string;
 }
 
 export function EditGoalStepRow({
   step,
-  index,
   stepNumber,
   isBeingDragged,
   isEditing,
@@ -156,8 +146,6 @@ export function EditGoalStepRow({
   canNestUnder = false,
   nestTargets = [],
   onNestUnder,
-  canUnNest = false,
-  onUnNest,
   children,
   editStepA11yLabel = (stepTitle) => `Edit step: ${stepTitle}`,
   tapToEditHint = "Tap to edit step title",
@@ -170,39 +158,18 @@ export function EditGoalStepRow({
   nestUnderRowLabel = (targetTitle) => `Nest under "${targetTitle}"`,
   nestUnderRowA11yLabel = (targetTitle) =>
     `Nest this step under ${targetTitle}`,
-  unNestA11yLabel = "Promote this step to top level",
+  nestUnderCancelLabel = "Cancel",
 }: EditGoalStepRowProps) {
   const { theme } = useUnistyles();
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
   const isDragging = useSharedValue(false);
-  const headerRef = useRef<View>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
-
-  // R3/R15: register the root header's screen-absolute geometry. onLayout
-  // provides relative y; measureInWindow provides the absolute y the
-  // coordinator's hover math needs. The remeasure callback is registered so
-  // drag-start can refresh this row's geometry (the registry never goes stale).
-  function measureAndRegister() {
-    const node = headerRef.current as unknown as {
-      measureInWindow?: (
-        cb: (x: number, y: number, w: number, h: number) => void,
-      ) => void;
-    } | null;
-    if (node?.measureInWindow) {
-      node.measureInWindow((_x, y, _w, h) => {
-        registerRowLayout(step.id, { absoluteY: y, height: h });
-      });
-    }
-  }
-  React.useEffect(() => {
-    registerRemeasure(step.id, measureAndRegister);
-    return () => registerRemeasure(step.id, null);
-    // registerRemeasure/registerRowLayout are stable-enough closures from the
-    // coordinator; step.id is stable. Exclude them to avoid re-subscribing every
-    // render (the coordinator recreates them each render but they read refs).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step.id]);
+  const { ref: headerRef, measureAndRegister } = useRowGeometryRegistration(
+    step.id,
+    registerRowLayout,
+    registerRemeasure,
+  );
 
   const timingQuick = getTimingConfig(animationPref, "quick");
   const timingNormal = getTimingConfig(animationPref, "normal");
@@ -320,50 +287,6 @@ export function EditGoalStepRow({
               compact
             />
           </Pressable>
-          {showAccessibleControls && (
-            <View style={styles.reorderButtons}>
-              {onMoveUp && !isFirst && (
-                <IconButton
-                  icon={<ArrowUp size={18} weight="bold" />}
-                  onPress={onMoveUp}
-                  size="sm"
-                  tone="ghost"
-                  accessibilityLabel={moveUpLabel(step.title)}
-                  testID={`edit-goal-step-up-${step.id}`}
-                />
-              )}
-              {onMoveDown && !isLast && (
-                <IconButton
-                  icon={<ArrowDown size={18} weight="bold" />}
-                  onPress={onMoveDown}
-                  size="sm"
-                  tone="ghost"
-                  accessibilityLabel={moveDownLabel(step.title)}
-                  testID={`edit-goal-step-down-${step.id}`}
-                />
-              )}
-              {canNestUnder && onNestUnder && (
-                <IconButton
-                  icon={<ArrowBendDownRight size={18} weight="bold" />}
-                  onPress={() => setPickerOpen(true)}
-                  size="sm"
-                  tone="ghost"
-                  accessibilityLabel={nestUnderTriggerA11yLabel}
-                  testID={`edit-goal-step-nest-under-${step.id}`}
-                />
-              )}
-              {canUnNest && onUnNest && (
-                <IconButton
-                  icon={<ArrowBendUpLeft size={18} weight="bold" />}
-                  onPress={onUnNest}
-                  size="sm"
-                  tone="ghost"
-                  accessibilityLabel={unNestA11yLabel}
-                  testID={`edit-goal-step-un-nest-${step.id}`}
-                />
-              )}
-            </View>
-          )}
           <Pressable
             style={styles.stepDelete}
             onPress={onDelete}
@@ -404,6 +327,28 @@ export function EditGoalStepRow({
       )}
     </>
   );
+
+  // A root can expose up, down, and nest-under simultaneously. Give those
+  // fallback controls a dedicated line so they never compete with evidence,
+  // title, or delete for horizontal space.
+  const accessibleActions =
+    !isEditing && showAccessibleControls ? (
+      <HierarchyActionRow
+        testID={`edit-goal-step-hierarchy-actions-${step.id}`}
+        onMoveUp={!isFirst ? onMoveUp : undefined}
+        onMoveDown={!isLast ? onMoveDown : undefined}
+        onReparent={
+          canNestUnder && onNestUnder ? () => setPickerOpen(true) : undefined
+        }
+        moveUpLabel={moveUpLabel(step.title)}
+        moveDownLabel={moveDownLabel(step.title)}
+        reparentLabel={nestUnderTriggerA11yLabel}
+        moveUpTestID={`edit-goal-step-up-${step.id}`}
+        moveDownTestID={`edit-goal-step-down-${step.id}`}
+        reparentTestID={`edit-goal-step-nest-under-${step.id}`}
+        reparentDirection="demote"
+      />
+    ) : null;
 
   // Nest-under picker (R8): an accessible modal listing eligible root
   // targets. Reuses DraggableStepItem's picker pattern, adapted to the
@@ -448,7 +393,7 @@ export function EditGoalStepRow({
                 </Pressable>
               ))}
               <Button
-                label="Cancel"
+                label={nestUnderCancelLabel}
                 variant="secondary"
                 onPress={() => setPickerOpen(false)}
               />
@@ -462,6 +407,7 @@ export function EditGoalStepRow({
     return (
       <View style={[styles.rowCard, isArmedTarget && styles.armedTargetItem]}>
         {body}
+        {accessibleActions}
         {children}
         {picker}
       </View>
@@ -486,6 +432,7 @@ export function EditGoalStepRow({
       <GestureDetector gesture={composed}>
         <View>{body}</View>
       </GestureDetector>
+      {accessibleActions}
       {children}
       {picker}
     </Animated.View>

--- a/apps/native-rd/src/components/EditGoalView/EditGoalSubStepList.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalSubStepList.tsx
@@ -1,23 +1,24 @@
 /**
- * EditGoalSubStepList — the draggable sub-step rows for a single parent step
- * (#459). Owns one `useEditGoalDrag` instance scoped to this parent's siblings,
- * so reorder never crosses parents: each instance has its own row-layout/drag
- * refs and fires `onReorder` with only this parent's ordered sub-step ids.
+ * EditGoalSubStepList — the sub-step rows for a single parent step (#459,
+ * revised for #496). Previously instantiated its own `useEditGoalDrag` scoped to
+ * one parent's siblings; now it is a **thin mapping** over `EditGoalSubStepRow`
+ * that forwards the unified hierarchy coordinator's shared handlers + geometry
+ * registration (R2). The coordinator owns one flat index space across roots and
+ * sub-steps alike, so a sub-step drag can promote / move between parents —
+ * impossible when each parent had its own independent hook (review #1).
  *
- * Reuses the top-level list's gesture + auto-scroll math verbatim (D2) — the
- * hook is generic over `{ id, title }[]`, so calling it per-parent needs no
- * change to useEditGoalDrag. Returns the rows plus the scoped drop-line as a
- * fragment; the caller wraps them in the (position: relative) `subStepBlock`
- * so the absolutely-positioned drop-line shares the rows' coordinate system.
+ * Reuses the top-level list's gesture + auto-scroll math verbatim via the
+ * coordinator; the `EditGoalSubStepRow` anatomy is unchanged apart from the
+ * shared handlers + the un-nest accessible control (R8).
  */
 import React from "react";
 import { View } from "react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
 import type { DragScrollController } from "../StepList/dragAutoScroll";
+import type { SharedValue } from "react-native-reanimated";
 import { EditGoalSubStepRow } from "./EditGoalSubStepRow";
-import { useEditGoalDrag } from "./useEditGoalDrag";
-import { styles } from "./EditGoalView.styles";
 import type { EditGoalSubStep } from "./EditGoalView";
+import type { RowGeometry } from "./useEditGoalHierarchyDrag";
 
 export interface EditGoalSubStepListProps {
   subSteps: EditGoalSubStep[];
@@ -35,11 +36,29 @@ export interface EditGoalSubStepListProps {
   animationPref: AnimationPref;
   dragScrollController?: DragScrollController;
   announceReorder?: (subStepTitle: string, position: number) => string;
+  // --- Unified coordinator wiring (#496, R2) ---
+  /** Shared drag handlers from the coordinator, keyed by row id. */
+  onDragStart: (rowId: string) => void;
+  onDragMove: (translationY: number, absoluteY: number) => void;
+  onDragEnd: () => void;
+  registerRowLayout: (rowId: string, geometry: RowGeometry) => void;
+  registerRemeasure: (rowId: string, fn: (() => void) | null) => void;
+  dragScrollCompensation?: SharedValue<number>;
+  /** Per-row drag eligibility from the coordinator (R13). */
+  canDragRow: (rowId: string) => boolean;
+  /** Which row id is currently being dragged (to flag isBeingDragged). */
+  draggedRowId: string | null;
+  /** Move a row by ±1 within its sibling group (coordinator, R8). */
+  moveStep: (rowId: string, direction: 1 | -1) => void;
+  /** Un-nest (promote) a sub-step to root (R8). */
+  onUnNest?: (subStepId: string) => void;
+  /** Whether the un-nest control should show (reparent enabled + onReparentStep). */
+  canUnNest?: boolean;
+  unNestA11yLabel?: string;
 }
 
 export function EditGoalSubStepList({
   subSteps,
-  onReorder,
   editingId,
   editText,
   onEditTextChange,
@@ -49,34 +68,27 @@ export function EditGoalSubStepList({
   onDelete,
   showAccessibleControls,
   animationPref,
-  dragScrollController,
-  announceReorder,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  registerRowLayout,
+  registerRemeasure,
+  dragScrollCompensation,
+  canDragRow,
+  draggedRowId,
+  moveStep,
+  onUnNest,
+  canUnNest = false,
+  unNestA11yLabel,
 }: EditGoalSubStepListProps) {
-  const drag = useEditGoalDrag({
-    steps: subSteps,
-    onReorderSteps: onReorder,
-    dragScrollController,
-    announceReorder,
-  });
-
-  const canDrag = subSteps.length > 1 && editingId === null;
-
   return (
     <>
       {subSteps.map((sub, index) => (
-        <View
-          key={sub.id}
-          onLayout={(e) =>
-            drag.registerRowLayout(index, {
-              y: e.nativeEvent.layout.y,
-              height: e.nativeEvent.layout.height,
-            })
-          }
-        >
+        <View key={sub.id}>
           <EditGoalSubStepRow
             subStep={sub}
             index={index}
-            isBeingDragged={drag.draggedIndex === index}
+            isBeingDragged={draggedRowId === sub.id}
             isEditing={editingId === sub.id}
             editText={editText}
             onEditTextChange={onEditTextChange}
@@ -84,32 +96,27 @@ export function EditGoalSubStepList({
             onCommitEditing={onCommitEditing}
             onEvidenceChipPress={() => onEvidenceChipPress(sub.id)}
             onDelete={() => onDelete(sub.id)}
-            onDragStart={drag.handleDragStart}
-            onDragMove={drag.handleDragMove}
-            onDragEnd={drag.handleDragEnd}
+            onDragStart={onDragStart}
+            onDragMove={onDragMove}
+            onDragEnd={onDragEnd}
+            registerRowLayout={registerRowLayout}
+            registerRemeasure={registerRemeasure}
             dragScrollCompensation={
-              drag.draggedIndex === index
-                ? drag.dragScrollCompensation
-                : undefined
+              draggedRowId === sub.id ? dragScrollCompensation : undefined
             }
-            onMoveUp={() => drag.moveStep(index, -1)}
-            onMoveDown={() => drag.moveStep(index, 1)}
+            onMoveUp={() => moveStep(sub.id, -1)}
+            onMoveDown={() => moveStep(sub.id, 1)}
             showAccessibleControls={showAccessibleControls}
             animationPref={animationPref}
             isFirst={index === 0}
             isLast={index === subSteps.length - 1}
-            canDrag={canDrag}
+            canDrag={canDragRow(sub.id)}
+            canUnNest={canUnNest}
+            onUnNest={onUnNest ? () => onUnNest(sub.id) : undefined}
+            unNestA11yLabel={unNestA11yLabel}
           />
         </View>
       ))}
-      {drag.isDragging && drag.dropSlot && (
-        <View
-          pointerEvents="none"
-          accessibilityElementsHidden
-          importantForAccessibility="no"
-          style={[styles.dropLine, { top: drag.dropSlot.top }]}
-        />
-      )}
     </>
   );
 }

--- a/apps/native-rd/src/components/EditGoalView/EditGoalSubStepList.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalSubStepList.tsx
@@ -14,7 +14,6 @@
 import React from "react";
 import { View } from "react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
-import type { DragScrollController } from "../StepList/dragAutoScroll";
 import type { SharedValue } from "react-native-reanimated";
 import { EditGoalSubStepRow } from "./EditGoalSubStepRow";
 import type { EditGoalSubStep } from "./EditGoalView";
@@ -22,8 +21,6 @@ import type { RowGeometry } from "./useEditGoalHierarchyDrag";
 
 export interface EditGoalSubStepListProps {
   subSteps: EditGoalSubStep[];
-  /** Fired on drop / ↑↓ with this parent's new sub-step order. */
-  onReorder: (orderedSubStepIds: string[]) => void;
   /** Which id (step or sub-step) is being renamed inline; drag off while editing. */
   editingId: string | null;
   editText: string;
@@ -34,8 +31,6 @@ export interface EditGoalSubStepListProps {
   onDelete: (id: string) => void;
   showAccessibleControls: boolean;
   animationPref: AnimationPref;
-  dragScrollController?: DragScrollController;
-  announceReorder?: (subStepTitle: string, position: number) => string;
   // --- Unified coordinator wiring (#496, R2) ---
   /** Shared drag handlers from the coordinator, keyed by row id. */
   onDragStart: (rowId: string) => void;
@@ -87,7 +82,6 @@ export function EditGoalSubStepList({
         <View key={sub.id}>
           <EditGoalSubStepRow
             subStep={sub}
-            index={index}
             isBeingDragged={draggedRowId === sub.id}
             isEditing={editingId === sub.id}
             editText={editText}

--- a/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
@@ -14,7 +14,7 @@
  * motion is off, so keyboard/VoiceOver users are never drag-only. A parent with
  * one sub-step renders the row static (`canDrag={false}`), no ↑/↓ buttons.
  */
-import React from "react";
+import React, { useRef } from "react";
 import { View, Text as RNText, TextInput, Pressable } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
@@ -25,13 +25,14 @@ import Animated, {
   withTiming,
   runOnJS,
 } from "react-native-reanimated";
-import { ArrowUp, ArrowDown } from "phosphor-react-native";
+import { ArrowUp, ArrowDown, ArrowBendUpLeft } from "phosphor-react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
 import { getTimingConfig } from "../../utils/animation";
 import { IconButton } from "../IconButton";
 import { EvidenceTypePicker } from "../EvidenceTypePicker";
 import { styles } from "./EditGoalView.styles";
 import type { EditGoalSubStep } from "./EditGoalView";
+import type { RowGeometry } from "./useEditGoalHierarchyDrag";
 
 export interface EditGoalSubStepRowProps {
   subStep: EditGoalSubStep;
@@ -46,9 +47,12 @@ export interface EditGoalSubStepRowProps {
   /** Opens the evidence-type picker for this sub-step (D8/D12). */
   onEvidenceChipPress: () => void;
   onDelete: () => void;
-  onDragStart: (index: number) => void;
+  onDragStart: (rowId: string) => void;
   onDragMove: (translationY: number, absoluteY: number) => void;
   onDragEnd: () => void;
+  /** Register this sub-step's screen-absolute geometry (R3/R15). */
+  registerRowLayout: (rowId: string, geometry: RowGeometry) => void;
+  registerRemeasure: (rowId: string, fn: (() => void) | null) => void;
   dragScrollCompensation?: SharedValue<number>;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
@@ -58,6 +62,9 @@ export interface EditGoalSubStepRowProps {
   isLast: boolean;
   /** When false, the row renders static (single sibling, or a title is being edited). */
   canDrag: boolean;
+  /** Accessible un-nest control (R8) — a sub-step can promote to root. */
+  canUnNest?: boolean;
+  onUnNest?: () => void;
 
   // --- Copy (i18n-free per D9; English defaults; [Integrate] passes t()). ---
   /** a11y label for the inline title-edit field. */
@@ -72,6 +79,8 @@ export interface EditGoalSubStepRowProps {
   moveSubStepUpLabel?: (subStepTitle: string) => string;
   /** a11y label for the ↓ reorder-down fallback button. */
   moveSubStepDownLabel?: (subStepTitle: string) => string;
+  /** a11y label for the un-nest button (R8). */
+  unNestA11yLabel?: string;
 }
 
 export function EditGoalSubStepRow({
@@ -88,6 +97,8 @@ export function EditGoalSubStepRow({
   onDragStart,
   onDragMove,
   onDragEnd,
+  registerRowLayout,
+  registerRemeasure,
   dragScrollCompensation,
   onMoveUp,
   onMoveDown,
@@ -96,17 +107,41 @@ export function EditGoalSubStepRow({
   isFirst,
   isLast,
   canDrag,
+  canUnNest = false,
+  onUnNest,
   editSubStepA11yLabel = (subStepTitle) => `Edit sub-step: ${subStepTitle}`,
   tapToEditHint = "Tap to edit sub-step title",
   editEvidenceLabel = "Edit planned evidence",
   deleteSubStepLabel = (subStepTitle) => `Delete sub-step: ${subStepTitle}`,
   moveSubStepUpLabel = (subStepTitle) => `Move "${subStepTitle}" up`,
   moveSubStepDownLabel = (subStepTitle) => `Move "${subStepTitle}" down`,
+  unNestA11yLabel = "Promote this step to top level",
 }: EditGoalSubStepRowProps) {
   const { theme } = useUnistyles();
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
   const isDragging = useSharedValue(false);
+  const rowRef = useRef<View>(null);
+
+  // R3/R15: register this sub-step's screen-absolute geometry so the unified
+  // coordinator can hit-test it in the same flat coordinate space as roots.
+  function measureAndRegister() {
+    const node = rowRef.current as unknown as {
+      measureInWindow?: (
+        cb: (x: number, y: number, w: number, h: number) => void,
+      ) => void;
+    } | null;
+    if (node?.measureInWindow) {
+      node.measureInWindow((_x, y, _w, h) => {
+        registerRowLayout(subStep.id, { absoluteY: y, height: h });
+      });
+    }
+  }
+  React.useEffect(() => {
+    registerRemeasure(subStep.id, measureAndRegister);
+    return () => registerRemeasure(subStep.id, null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subStep.id]);
 
   const timingQuick = getTimingConfig(animationPref, "quick");
   const timingNormal = getTimingConfig(animationPref, "normal");
@@ -136,7 +171,7 @@ export function EditGoalSubStepRow({
     .onStart(() => {
       isDragging.value = true;
       scale.value = noAnimation ? 1.02 : withTiming(1.02, timingQuick);
-      runOnJS(onDragStart)(index);
+      runOnJS(onDragStart)(subStep.id);
     });
 
   const pan = Gesture.Pan()
@@ -166,7 +201,11 @@ export function EditGoalSubStepRow({
 
   if (isEditing) {
     return (
-      <View style={styles.subStepRow}>
+      <View
+        ref={rowRef}
+        onLayout={measureAndRegister}
+        style={styles.subStepRow}
+      >
         {marker}
         <TextInput
           style={styles.subStepEditInput}
@@ -187,7 +226,7 @@ export function EditGoalSubStepRow({
 
   const body = (
     <>
-      <View style={styles.rowLead}>
+      <View ref={rowRef} onLayout={measureAndRegister} style={styles.rowLead}>
         {marker}
         <Pressable
           style={styles.subStepTitlePress}
@@ -234,6 +273,16 @@ export function EditGoalSubStepRow({
                 tone="ghost"
                 accessibilityLabel={moveSubStepDownLabel(subStep.title)}
                 testID={`edit-goal-substep-down-${subStep.id}`}
+              />
+            )}
+            {canUnNest && onUnNest && (
+              <IconButton
+                icon={<ArrowBendUpLeft size={18} weight="bold" />}
+                onPress={onUnNest}
+                size="sm"
+                tone="ghost"
+                accessibilityLabel={unNestA11yLabel}
+                testID={`edit-goal-substep-un-nest-${subStep.id}`}
               />
             )}
           </View>

--- a/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
@@ -1,20 +1,9 @@
 /**
- * EditGoalSubStepRow — one sub-step nested under a parent step inside
- * EditGoalView (D12). Rendered inside the parent card's mint-rail block.
- *
- * A leaf row: a functional `≡` drag handle + tap-to-edit title (D10) + a
- * planned-evidence chip (reused EvidenceTypePicker `compact`, one pill per
- * planned type — D4; opens the type picker on tap — D8) + a × delete button.
- *
- * Reorder-within-parent (#459) reuses the exact LongPress + Pan gesture shape
- * as EditGoalStepRow, stripped of all nesting/dwell state — the parent
- * (EditGoalSubStepList) owns reorder math and auto-scroll via useEditGoalDrag,
- * scoped to a single parent's siblings. The `≡` handle is hidden from screen
- * readers; a visible ↑/↓ fallback appears when a screen reader is active or
- * motion is off, so keyboard/VoiceOver users are never drag-only. A parent with
- * one sub-step renders the row static (`canDrag={false}`), no ↑/↓ buttons.
+ * Nested leaf row for EditGoalView. It shares the hierarchy drag coordinator
+ * with root rows, while explicit ↑/↓ and Un-nest controls preserve equivalent
+ * screen-reader and reduced-motion access.
  */
-import React, { useRef } from "react";
+import React from "react";
 import { View, Text as RNText, TextInput, Pressable } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
@@ -25,18 +14,17 @@ import Animated, {
   withTiming,
   runOnJS,
 } from "react-native-reanimated";
-import { ArrowUp, ArrowDown, ArrowBendUpLeft } from "phosphor-react-native";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
 import { getTimingConfig } from "../../utils/animation";
-import { IconButton } from "../IconButton";
 import { EvidenceTypePicker } from "../EvidenceTypePicker";
 import { styles } from "./EditGoalView.styles";
 import type { EditGoalSubStep } from "./EditGoalView";
-import type { RowGeometry } from "./useEditGoalHierarchyDrag";
+import { HierarchyActionRow } from "./HierarchyActionRow";
+import type { RowGeometry } from "./useEditGoalHierarchyDragTypes";
+import { useRowGeometryRegistration } from "./useRowGeometryRegistration";
 
 export interface EditGoalSubStepRowProps {
   subStep: EditGoalSubStep;
-  index: number;
   isBeingDragged: boolean;
   /** Whether this sub-row's title is in inline-edit mode (state lives in the view). */
   isEditing: boolean;
@@ -85,7 +73,6 @@ export interface EditGoalSubStepRowProps {
 
 export function EditGoalSubStepRow({
   subStep,
-  index,
   isBeingDragged,
   isEditing,
   editText,
@@ -121,27 +108,11 @@ export function EditGoalSubStepRow({
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
   const isDragging = useSharedValue(false);
-  const rowRef = useRef<View>(null);
-
-  // R3/R15: register this sub-step's screen-absolute geometry so the unified
-  // coordinator can hit-test it in the same flat coordinate space as roots.
-  function measureAndRegister() {
-    const node = rowRef.current as unknown as {
-      measureInWindow?: (
-        cb: (x: number, y: number, w: number, h: number) => void,
-      ) => void;
-    } | null;
-    if (node?.measureInWindow) {
-      node.measureInWindow((_x, y, _w, h) => {
-        registerRowLayout(subStep.id, { absoluteY: y, height: h });
-      });
-    }
-  }
-  React.useEffect(() => {
-    registerRemeasure(subStep.id, measureAndRegister);
-    return () => registerRemeasure(subStep.id, null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subStep.id]);
+  const { ref: rowRef, measureAndRegister } = useRowGeometryRegistration(
+    subStep.id,
+    registerRowLayout,
+    registerRemeasure,
+  );
 
   const timingQuick = getTimingConfig(animationPref, "quick");
   const timingNormal = getTimingConfig(animationPref, "normal");
@@ -253,40 +224,6 @@ export function EditGoalSubStepRow({
             compact
           />
         </Pressable>
-        {showAccessibleControls && (
-          <View style={styles.reorderButtons}>
-            {onMoveUp && !isFirst && (
-              <IconButton
-                icon={<ArrowUp size={18} weight="bold" />}
-                onPress={onMoveUp}
-                size="sm"
-                tone="ghost"
-                accessibilityLabel={moveSubStepUpLabel(subStep.title)}
-                testID={`edit-goal-substep-up-${subStep.id}`}
-              />
-            )}
-            {onMoveDown && !isLast && (
-              <IconButton
-                icon={<ArrowDown size={18} weight="bold" />}
-                onPress={onMoveDown}
-                size="sm"
-                tone="ghost"
-                accessibilityLabel={moveSubStepDownLabel(subStep.title)}
-                testID={`edit-goal-substep-down-${subStep.id}`}
-              />
-            )}
-            {canUnNest && onUnNest && (
-              <IconButton
-                icon={<ArrowBendUpLeft size={18} weight="bold" />}
-                onPress={onUnNest}
-                size="sm"
-                tone="ghost"
-                accessibilityLabel={unNestA11yLabel}
-                testID={`edit-goal-substep-un-nest-${subStep.id}`}
-              />
-            )}
-          </View>
-        )}
         <Pressable
           style={styles.subStepDelete}
           onPress={onDelete}
@@ -301,8 +238,32 @@ export function EditGoalSubStepRow({
     </>
   );
 
+  // Keep non-gesture hierarchy actions on their own line. A sub-step can show
+  // up, down, and promote at once; placing that cluster beside evidence made
+  // the fixed-width controls overlap the evidence chip on narrow screens.
+  const accessibleActions = showAccessibleControls ? (
+    <HierarchyActionRow
+      testID={`edit-goal-substep-hierarchy-actions-${subStep.id}`}
+      onMoveUp={!isFirst ? onMoveUp : undefined}
+      onMoveDown={!isLast ? onMoveDown : undefined}
+      onReparent={canUnNest ? onUnNest : undefined}
+      moveUpLabel={moveSubStepUpLabel(subStep.title)}
+      moveDownLabel={moveSubStepDownLabel(subStep.title)}
+      reparentLabel={unNestA11yLabel}
+      moveUpTestID={`edit-goal-substep-up-${subStep.id}`}
+      moveDownTestID={`edit-goal-substep-down-${subStep.id}`}
+      reparentTestID={`edit-goal-substep-un-nest-${subStep.id}`}
+      reparentDirection="promote"
+    />
+  ) : null;
+
   if (!canDrag) {
-    return <View style={styles.subStepRow}>{body}</View>;
+    return (
+      <View>
+        <View style={styles.subStepRow}>{body}</View>
+        {accessibleActions}
+      </View>
+    );
   }
 
   // The flex-row layout (`subStepRow`) lives on a plain inner View, never on
@@ -313,13 +274,9 @@ export function EditGoalSubStepRow({
   return (
     <GestureDetector gesture={composed}>
       <Animated.View style={animatedStyle}>
-        <View
-          style={[
-            styles.subStepRow,
-            isBeingDragged && styles.subStepRowDragging,
-          ]}
-        >
-          {body}
+        <View style={[isBeingDragged && styles.subStepRowDragging]}>
+          <View style={styles.subStepRow}>{body}</View>
+          {accessibleActions}
         </View>
       </Animated.View>
     </GestureDetector>

--- a/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
@@ -197,7 +197,7 @@ export function EditGoalSubStepRow({
 
   const body = (
     <>
-      <View ref={rowRef} onLayout={measureAndRegister} style={styles.rowLead}>
+      <View style={styles.rowLead}>
         {marker}
         <Pressable
           style={styles.subStepTitlePress}
@@ -257,27 +257,38 @@ export function EditGoalSubStepRow({
     />
   ) : null;
 
+  // Measure and highlight the complete primary row band, including both the
+  // title and controls. The separate accessible hierarchy actions move with
+  // the item but remain outside this row's drag border and hover geometry.
+  const primaryRow = (
+    <View
+      ref={rowRef}
+      onLayout={measureAndRegister}
+      style={[styles.subStepRow, isBeingDragged && styles.subStepRowDragging]}
+    >
+      {body}
+    </View>
+  );
+
   if (!canDrag) {
     return (
       <View>
-        <View style={styles.subStepRow}>{body}</View>
+        {primaryRow}
         {accessibleActions}
       </View>
     );
   }
 
-  // The flex-row layout (`subStepRow`) lives on a plain inner View, never on
-  // the Animated.View: unistyles styles handed straight to a reanimated
+  // The flex-row layout (`subStepRow`) lives on the plain primaryRow View,
+  // never on the Animated.View: unistyles styles handed straight to a reanimated
   // Animated.View aren't applied on web (no class injected), so `flexDirection:
   // "row"` would silently drop and the controls would stack under the title.
   // Mirrors StepList's DraggableStepItem and this file's own !canDrag branch.
   return (
     <GestureDetector gesture={composed}>
       <Animated.View style={animatedStyle}>
-        <View style={[isBeingDragged && styles.subStepRowDragging]}>
-          <View style={styles.subStepRow}>{body}</View>
-          {accessibleActions}
-        </View>
+        {primaryRow}
+        {accessibleActions}
       </Animated.View>
     </GestureDetector>
   );

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx
@@ -353,7 +353,6 @@ function AnatomyRow({ step }: { step: EditGoalStep }) {
   return (
     <EditGoalStepRow
       step={step}
-      index={0}
       stepNumber={1}
       isBeingDragged={false}
       isEditing={false}

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx
@@ -290,6 +290,8 @@ function AnatomyRow({ step }: { step: EditGoalStep }) {
       onDragStart={() => {}}
       onDragMove={() => {}}
       onDragEnd={() => {}}
+      registerRowLayout={() => {}}
+      registerRemeasure={() => {}}
       showAccessibleControls={false}
       animationPref="full"
       isFirst

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.stories.tsx
@@ -9,6 +9,7 @@ import {
   type EditGoalStep,
   type EditGoalSubStep,
 } from "./EditGoalView";
+import { applyReparent } from "./applyReparent";
 import { EditGoalStepRow } from "./EditGoalStepRow";
 import { EditGoalOverflowMenu } from "./EditGoalOverflowMenu";
 import { Text } from "../Text";
@@ -114,10 +115,16 @@ const initialSteps: EditGoalStep[] = [
  * chip, dragging a row, adding a step, or renaming one all update local state so
  * the reviewer sees the real interaction (persistence is the [Integrate] job).
  */
-function InteractiveEditGoal({ note }: { note?: string }) {
+function InteractiveEditGoal({
+  note,
+  initialSteps: seed = initialSteps,
+}: {
+  note?: string;
+  initialSteps?: EditGoalStep[];
+}) {
   const [goalTitle, setGoalTitle] = useState("Learn watercolor basics");
-  const [steps, setSteps] = useState<EditGoalStep[]>(initialSteps);
-  const nextId = useRef(initialSteps.length + 1);
+  const [steps, setSteps] = useState<EditGoalStep[]>(seed);
+  const nextId = useRef(seed.length + 1);
 
   function reorder(orderedIds: string[]) {
     setSteps((prev) =>
@@ -219,6 +226,10 @@ function InteractiveEditGoal({ note }: { note?: string }) {
     setSteps((prev) => prev.filter((s) => s.id !== stepId));
   }
 
+  function reparent(stepId: string, newParentId: string | null) {
+    setSteps((prev) => applyReparent(prev, stepId, newParentId));
+  }
+
   return (
     <View>
       {note ? (
@@ -233,6 +244,7 @@ function InteractiveEditGoal({ note }: { note?: string }) {
           steps={steps}
           onReorderSteps={reorder}
           onReorderSubSteps={reorderSubSteps}
+          onReparentStep={reparent}
           onAddStep={addStep}
           onStepTitleChange={renameStep}
           onStepEvidenceChange={changeEvidence}
@@ -269,6 +281,69 @@ export const EvidencePickerInteraction: Story = {
 export const SubSteps: Story = {
   render: () => (
     <InteractiveEditGoal note='Step 1 is broken into three sub-steps (the indented mint-rail block): tap a sub-step to rename it, tap its chip to set evidence, × to remove it, or "add a sub-step" for another. Steps with none show "break into sub-steps" — tap it to seed the first one. Each sub-step requires its own evidence. Reorder within a parent: long-press a sub-step’s ≡ handle and drag it among its siblings (it never leaves its parent, and the parent card itself does not drag). With a screen reader on or reduced motion set, ↑/↓ buttons appear on each sub-step as the accessible fallback.' />
+  ),
+};
+
+export const ReparentInteraction: Story = {
+  render: () => (
+    <InteractiveEditGoal note="Reparent is enabled: long-press a leaf root (e.g. “Gather references”) and dwell on another root ~220ms — the target shows a dashed success outline — then release to nest it under that root. The nested step moves into the target’s mint-rail block." />
+  ),
+};
+
+export const PromoteInteraction: Story = {
+  render: () => (
+    <InteractiveEditGoal note="Long-press a sub-step (inside Step 1’s mint-rail block) and drag it above its parent’s header — on release it promotes to a top-level root step at the end of the list." />
+  ),
+};
+
+export const MoveBetweenParents: Story = {
+  render: () => (
+    <InteractiveEditGoal
+      initialSteps={[
+        {
+          id: "s1",
+          title: "Draft the outline",
+          plannedEvidenceTypes: [EvidenceType.text],
+          subSteps: [
+            {
+              id: "s1a",
+              title: "List sections",
+              plannedEvidenceTypes: [EvidenceType.text],
+            },
+            {
+              id: "s1b",
+              title: "Order them",
+              plannedEvidenceTypes: [EvidenceType.photo],
+            },
+          ],
+        },
+        {
+          id: "s2",
+          title: "Gather references",
+          plannedEvidenceTypes: [EvidenceType.link],
+          subSteps: [
+            {
+              id: "s2a",
+              title: "Library books",
+              plannedEvidenceTypes: [EvidenceType.link],
+            },
+          ],
+        },
+      ]}
+      note="With two parents each carrying sub-steps: long-press a sub-step and drag it into the other parent’s child block. It leaves its source parent and is appended to the destination parent’s sub-steps."
+    />
+  ),
+};
+
+export const InvalidReparentTargets: Story = {
+  render: () => (
+    <InteractiveEditGoal note="Invalid reparent targets: a parent that already has children (Step 1) cannot be demoted — it snaps back with no write and shows no “Nest under…” control. A sub-step cannot be demoted further (one-level cap) — only “Un-nest” is available." />
+  ),
+};
+
+export const AccessibleNestControls: Story = {
+  render: () => (
+    <InteractiveEditGoal note="With a screen reader on or reduced motion set, each leaf root shows a “Nest under…” trigger (↳) that opens an accessible picker of eligible roots, and each sub-step shows an “Un-nest” button (↰) that promotes it to a root. ↑/↓ stay sibling-reorder only." />
   ),
 };
 

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts
@@ -224,6 +224,83 @@ export const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.accentPrimary,
     zIndex: 50,
   },
+  // Armed dwell-target feedback (R12): a sustained dashed success outline
+  // that stays for the whole time the root header is armed. Dashed + the
+  // success token read as a distinct "drop here to nest" target, separate
+  // from the dragged row's solid accent border. Static for all motion settings
+  // (no separate reduced-motion path needed).
+  armedTargetItem: {
+    borderStyle: "dashed" as const,
+    borderWidth: theme.borderWidth.thick + 1,
+    borderColor: theme.colors.success,
+  },
+  // Nested drop destination: outline the full target sub-step band rather
+  // than a small insertion line, so the destination remains legible under the
+  // translated dragged card.
+  nestedDropOutline: {
+    position: "absolute" as const,
+    left: theme.space[3],
+    right: 0,
+    borderStyle: "dashed" as const,
+    borderWidth: theme.borderWidth.thick + 1,
+    borderColor: theme.colors.success,
+    borderRadius: theme.radius.md,
+    zIndex: 150,
+  },
+  // Group drop destination: outline a whole parent+children group during a
+  // root-with-children block reorder.
+  groupDropOutline: {
+    position: "absolute" as const,
+    left: 0,
+    right: 0,
+    borderStyle: "dashed" as const,
+    borderWidth: theme.borderWidth.thick + 1,
+    borderColor: theme.colors.success,
+    borderRadius: theme.radius.md,
+    zIndex: 150,
+  },
+  // --- Nest-under picker (accessible control, R8) ---
+  pickerOverlay: {
+    flex: 1,
+    justifyContent: "center" as const,
+    alignItems: "center" as const,
+    padding: theme.space[4],
+  },
+  pickerContainer: {
+    width: "100%" as const,
+    maxWidth: 400,
+  },
+  pickerCard: {
+    backgroundColor: theme.colors.background,
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.md,
+    padding: theme.space[4],
+    gap: theme.space[2],
+    ...shadowStyle(theme, "cardElevation"),
+  },
+  pickerTitle: {
+    fontFamily: theme.fontFamily.headline,
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.size.md,
+    color: theme.colors.text,
+    marginBottom: theme.space[2],
+  },
+  pickerRow: {
+    minHeight: 44,
+    justifyContent: "center" as const,
+    paddingHorizontal: theme.space[3],
+    paddingVertical: theme.space[2],
+    borderWidth: theme.borderWidth.medium,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  pickerRowText: {
+    fontSize: theme.size.md,
+    fontFamily: theme.fontFamily.body,
+    color: theme.colors.text,
+  },
 
   // --- Sub-steps block (D12) ---
   // Indented, mint-railed block under a parent step that has some. accentMint is

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts
@@ -178,6 +178,17 @@ export const styles = StyleSheet.create((theme) => ({
     gap: theme.space[1],
     width: 36 * 2 + theme.space[1],
   },
+  // Screen-reader/reduced-motion hierarchy fallbacks can expose three actions
+  // at once. Their own line prevents arrows from covering evidence on compact
+  // screens and keeps the primary content row visually stable.
+  hierarchyActionRow: {
+    flexDirection: "row" as const,
+    justifyContent: "flex-end" as const,
+    alignItems: "center" as const,
+    gap: theme.space[1],
+    minHeight: 44,
+    marginTop: theme.space[1],
+  },
   // Per-step delete × on the main row (#460) — mirrors subStepDelete/Glyph (D3).
   stepDelete: {
     minWidth: 44,
@@ -316,8 +327,8 @@ export const styles = StyleSheet.create((theme) => ({
     gap: theme.space[2],
   },
   // Same plain single-row treatment as rowMain (A-D4): [handle][title] in
-  // rowLead (title wraps in place), [evidence][↑↓][×] in rowControls at natural
-  // width — no flexWrap, so the controls never paint over the next sub-row.
+  // rowLead (title wraps in place), with [evidence][×] in rowControls. Optional
+  // hierarchy actions render below in hierarchyActionRow.
   subStepRow: {
     flexDirection: "row" as const,
     alignItems: "center" as const,

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
@@ -212,6 +212,7 @@ export interface EditGoalViewProps {
   nestUnderPickerTitle?: string;
   nestUnderRowLabel?: (targetTitle: string) => string;
   nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  nestUnderCancelLabel?: string;
   unNestA11yLabel?: string;
   announcePromote?: (stepTitle: string) => string;
   announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
@@ -272,6 +273,7 @@ export function EditGoalView({
   nestUnderPickerTitle,
   nestUnderRowLabel,
   nestUnderRowA11yLabel,
+  nestUnderCancelLabel,
   unNestA11yLabel,
   announcePromote,
   announceNestedUnder,
@@ -439,6 +441,7 @@ export function EditGoalView({
           nestUnderPickerTitle={nestUnderPickerTitle}
           nestUnderRowLabel={nestUnderRowLabel}
           nestUnderRowA11yLabel={nestUnderRowA11yLabel}
+          nestUnderCancelLabel={nestUnderCancelLabel}
           unNestA11yLabel={unNestA11yLabel}
           announcePromote={announcePromote}
           announceNestedUnder={announceNestedUnder}

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
@@ -115,6 +115,12 @@ export interface EditGoalViewProps {
     parentStepId: string,
     orderedSubStepIds: string[],
   ) => void;
+  /**
+   * Fired on a drag-reparent / nest-under / un-nest (#496). When omitted the
+   * editor collapses to sibling reorder only and the nest/un-nest accessible
+   * controls do not render (R5).
+   */
+  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
   onAddStep: (title: string) => void;
   onStepTitleChange: (stepId: string, title: string) => void;
   /**
@@ -201,6 +207,14 @@ export interface EditGoalViewProps {
   deleteSubStepConfirmTitle?: string;
   /** Confirm-modal message when deleting a sub-step (receives the sub-step title). */
   deleteSubStepConfirmMessage?: (title: string) => string;
+  // --- Nest-under / un-nest copy (#496, R10) ---
+  nestUnderTriggerA11yLabel?: string;
+  nestUnderPickerTitle?: string;
+  nestUnderRowLabel?: (targetTitle: string) => string;
+  nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  unNestA11yLabel?: string;
+  announcePromote?: (stepTitle: string) => string;
+  announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
 }
 
 export function EditGoalView({
@@ -211,6 +225,7 @@ export function EditGoalView({
   steps,
   onReorderSteps,
   onReorderSubSteps,
+  onReparentStep,
   onAddStep,
   onStepTitleChange,
   onStepEvidenceChange,
@@ -253,6 +268,13 @@ export function EditGoalView({
   deleteStepConfirmMessage,
   deleteSubStepConfirmTitle,
   deleteSubStepConfirmMessage,
+  nestUnderTriggerA11yLabel,
+  nestUnderPickerTitle,
+  nestUnderRowLabel,
+  nestUnderRowA11yLabel,
+  unNestA11yLabel,
+  announcePromote,
+  announceNestedUnder,
 }: EditGoalViewProps) {
   const { theme } = useUnistyles();
 
@@ -390,6 +412,7 @@ export function EditGoalView({
           steps={steps}
           onReorderSteps={onReorderSteps}
           onReorderSubSteps={onReorderSubSteps}
+          onReparentStep={onReparentStep}
           onAddStep={onAddStep}
           onStepTitleChange={onStepTitleChange}
           onEvidenceChipPress={setEditingEvidenceId}
@@ -412,6 +435,13 @@ export function EditGoalView({
           deleteStepConfirmMessage={deleteStepConfirmMessage}
           deleteSubStepConfirmTitle={deleteSubStepConfirmTitle}
           deleteSubStepConfirmMessage={deleteSubStepConfirmMessage}
+          nestUnderTriggerA11yLabel={nestUnderTriggerA11yLabel}
+          nestUnderPickerTitle={nestUnderPickerTitle}
+          nestUnderRowLabel={nestUnderRowLabel}
+          nestUnderRowA11yLabel={nestUnderRowA11yLabel}
+          unNestA11yLabel={unNestA11yLabel}
+          announcePromote={announcePromote}
+          announceNestedUnder={announceNestedUnder}
         />
 
         <View style={styles.infoBanner}>

--- a/apps/native-rd/src/components/EditGoalView/HierarchyActionRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/HierarchyActionRow.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { View } from "react-native";
+import {
+  ArrowBendDownRight,
+  ArrowBendUpLeft,
+  ArrowDown,
+  ArrowUp,
+} from "phosphor-react-native";
+import { IconButton } from "../IconButton";
+import { styles } from "./EditGoalView.styles";
+
+interface HierarchyActionRowProps {
+  testID: string;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onReparent?: () => void;
+  moveUpLabel: string;
+  moveDownLabel: string;
+  reparentLabel: string;
+  moveUpTestID: string;
+  moveDownTestID: string;
+  reparentTestID: string;
+  reparentDirection: "promote" | "demote";
+}
+
+/** Explicit hierarchy controls shown when gesture-only interaction is unsafe. */
+export function HierarchyActionRow({
+  testID,
+  onMoveUp,
+  onMoveDown,
+  onReparent,
+  moveUpLabel,
+  moveDownLabel,
+  reparentLabel,
+  moveUpTestID,
+  moveDownTestID,
+  reparentTestID,
+  reparentDirection,
+}: HierarchyActionRowProps) {
+  if (!onMoveUp && !onMoveDown && !onReparent) return null;
+
+  const reparentIcon =
+    reparentDirection === "promote" ? (
+      <ArrowBendUpLeft size={18} weight="bold" />
+    ) : (
+      <ArrowBendDownRight size={18} weight="bold" />
+    );
+
+  return (
+    <View style={styles.hierarchyActionRow} testID={testID}>
+      {onMoveUp && (
+        <IconButton
+          icon={<ArrowUp size={18} weight="bold" />}
+          onPress={onMoveUp}
+          size="sm"
+          tone="ghost"
+          accessibilityLabel={moveUpLabel}
+          testID={moveUpTestID}
+        />
+      )}
+      {onMoveDown && (
+        <IconButton
+          icon={<ArrowDown size={18} weight="bold" />}
+          onPress={onMoveDown}
+          size="sm"
+          tone="ghost"
+          accessibilityLabel={moveDownLabel}
+          testID={moveDownTestID}
+        />
+      )}
+      {onReparent && (
+        <IconButton
+          icon={reparentIcon}
+          onPress={onReparent}
+          size="sm"
+          tone="ghost"
+          accessibilityLabel={reparentLabel}
+          testID={reparentTestID}
+        />
+      )}
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
@@ -259,17 +259,18 @@ describe("EditGoalView", () => {
       expect(screen.getByText("Photo")).toBeOnTheScreen();
     });
 
-    it("keeps the title and every control on a two-type step with the ↑/↓ fallback (D5 clustering)", () => {
-      // The narrow-screen fix splits the row into a rowLead (title) + rowControls
-      // (evidence + ↑/↓) so controls wrap instead of crushing the title. This is
-      // the worst case for width (two pills + both arrows); the restructure must
-      // not drop the title or any control. Layout wrapping itself is verified in
-      // Storybook — the Node renderer has no width.
+    it("keeps hierarchy fallbacks separate from a two-type evidence row (D5 clustering)", () => {
+      // The narrow-screen layout reserves the primary row for title, evidence,
+      // and delete, then renders hierarchy fallbacks in a dedicated action row.
+      // Geometry is verified in Storybook because the Node renderer has no width.
       mockAnimationPref = "none";
       renderWithProviders(<EditGoalView {...makeProps()} />);
       expect(screen.getByText("Second step")).toBeOnTheScreen();
       expect(screen.getByText("Link")).toBeOnTheScreen();
       expect(screen.getByText("Photo")).toBeOnTheScreen();
+      expect(
+        screen.getByTestId("edit-goal-step-hierarchy-actions-s2"),
+      ).toBeOnTheScreen();
       expect(screen.getByLabelText('Move "Second step" up')).toBeOnTheScreen();
     });
   });
@@ -569,6 +570,9 @@ describe("EditGoalView", () => {
       expect(screen.getByLabelText('Move "Alpha one" down')).toBeOnTheScreen();
       expect(screen.getByLabelText('Move "Alpha two" up')).toBeOnTheScreen();
       expect(screen.getByLabelText('Move "Alpha two" down')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId("edit-goal-substep-hierarchy-actions-a2"),
+      ).toBeOnTheScreen();
       expect(screen.getByLabelText('Move "Alpha three" up')).toBeOnTheScreen();
       // First has no ↑, last has no ↓.
       expect(screen.queryByLabelText('Move "Alpha one" up')).toBeNull();
@@ -758,6 +762,17 @@ describe("EditGoalView", () => {
       // Picker lists eligible roots excluding s2 → s1.
       fireEvent.press(screen.getByTestId("edit-goal-step-nest-target-s2-s1"));
       expect(onReparentStep).toHaveBeenCalledWith("s2", "s1");
+    });
+
+    it("uses the English default for the nest-under picker cancel action", () => {
+      mockAnimationPref = "none";
+      renderWithProviders(
+        <EditGoalView
+          {...makeProps({ steps: withSub, onReparentStep: jest.fn() })}
+        />,
+      );
+      fireEvent.press(screen.getByTestId("edit-goal-step-nest-under-s2"));
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeOnTheScreen();
     });
 
     it("renders no Nest-under control on a parent-with-children", () => {

--- a/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
@@ -69,6 +69,7 @@ function makeProps(overrides?: Partial<EditGoalViewProps>): EditGoalViewProps {
     steps: baseSteps,
     onReorderSteps: jest.fn(),
     onReorderSubSteps: jest.fn(),
+    onReparentStep: jest.fn(),
     onAddStep: jest.fn(),
     onStepTitleChange: jest.fn(),
     onStepEvidenceChange: jest.fn(),
@@ -732,6 +733,166 @@ describe("EditGoalView", () => {
       expect(announceReorder).toHaveBeenCalledWith("First step", 2);
       expect(announce).toHaveBeenCalledWith("First step → #2");
       announce.mockRestore();
+    });
+  });
+
+  describe("reparent (#496)", () => {
+    it("fires onReparentStep(id, null) from a sub-step’s Un-nest button", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps: withSub, onReparentStep })} />,
+      );
+      fireEvent.press(screen.getByTestId("edit-goal-substep-un-nest-sub1"));
+      expect(onReparentStep).toHaveBeenCalledWith("sub1", null);
+    });
+
+    it("fires onReparentStep(id, targetId) from a leaf root’s Nest-under picker", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      // withSub: s1 (parent with sub1), s2 (bare leaf root). s2 can nest under s1.
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps: withSub, onReparentStep })} />,
+      );
+      fireEvent.press(screen.getByTestId("edit-goal-step-nest-under-s2"));
+      // Picker lists eligible roots excluding s2 → s1.
+      fireEvent.press(screen.getByTestId("edit-goal-step-nest-target-s2-s1"));
+      expect(onReparentStep).toHaveBeenCalledWith("s2", "s1");
+    });
+
+    it("renders no Nest-under control on a parent-with-children", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps: withSub, onReparentStep })} />,
+      );
+      // s1 has children → no nest-under trigger.
+      expect(screen.queryByTestId("edit-goal-step-nest-under-s1")).toBeNull();
+    });
+
+    it("renders no Nest-under control on a sub-step (one-level cap)", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps: withSub, onReparentStep })} />,
+      );
+      expect(
+        screen.queryByTestId("edit-goal-substep-nest-under-sub1"),
+      ).toBeNull();
+    });
+
+    it("renders no nest/un-nest controls when onReparentStep is omitted", () => {
+      mockAnimationPref = "none";
+      renderWithProviders(
+        <EditGoalView
+          {...makeProps({ steps: withSub, onReparentStep: undefined })}
+        />,
+      );
+      expect(screen.queryByTestId("edit-goal-step-nest-under-s2")).toBeNull();
+      expect(screen.queryByTestId("edit-goal-substep-un-nest-sub1")).toBeNull();
+    });
+
+    it("does not render a Nest-under trigger when there is only one root", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      const steps: EditGoalStep[] = [
+        {
+          id: "s1",
+          title: "Only step",
+          plannedEvidenceTypes: [EvidenceType.text],
+        },
+      ];
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps, onReparentStep })} />,
+      );
+      expect(screen.queryByTestId("edit-goal-step-nest-under-s1")).toBeNull();
+    });
+
+    it("↑/↓ on a child at its group boundary does not promote (no onReparentStep)", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      renderWithProviders(
+        <EditGoalView
+          {...makeProps({
+            steps: withMultiSub,
+            onReparentStep,
+            onReorderSubSteps,
+          })}
+        />,
+      );
+      // Alpha one is first in its group → moving up is a no-op (no promote).
+      expect(screen.queryByLabelText('Move "Alpha one" up')).toBeNull();
+      // Moving down is a sibling reorder, not a reparent.
+      fireEvent.press(screen.getByLabelText('Move "Alpha one" down'));
+      expect(onReorderSubSteps).toHaveBeenCalledWith("s1", ["a2", "a1", "a3"]);
+      expect(onReparentStep).not.toHaveBeenCalled();
+    });
+
+    it("a sub-step reorder dispatches onReorderSubSteps through the shared coordinator (child-wired-to-coordinator)", () => {
+      mockAnimationPref = "none";
+      const onReorderSubSteps = jest.fn();
+      const onReparentStep = jest.fn();
+      renderWithProviders(
+        <EditGoalView
+          {...makeProps({
+            steps: withMultiSub,
+            onReorderSubSteps,
+            onReparentStep,
+          })}
+        />,
+      );
+      // Driving a sub-step’s ↑/↓ routes through the unified coordinator’s
+      // moveStep (scoped to the sub-step’s parent), proving the sub-step row
+      // is wired to the shared hierarchy coordinator, not a parent-local hook.
+      fireEvent.press(screen.getByLabelText('Move "Beta one" down'));
+      expect(onReorderSubSteps).toHaveBeenCalledWith("s2", ["b2", "b1"]);
+    });
+
+    it("R13: a lone sub-step is draggable (Un-nest present) when reparent is enabled", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      // A parent with a single sub-step.
+      const steps: EditGoalStep[] = [
+        {
+          id: "s1",
+          title: "Parent",
+          plannedEvidenceTypes: [EvidenceType.text],
+          subSteps: [
+            {
+              id: "only",
+              title: "Only child",
+              plannedEvidenceTypes: [EvidenceType.text],
+            },
+          ],
+        },
+        {
+          id: "s2",
+          title: "Other root",
+          plannedEvidenceTypes: [EvidenceType.text],
+        },
+      ];
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps, onReparentStep })} />,
+      );
+      // The lone sub-step has an Un-nest control (reparent enabled) and can
+      // promote via it — the component-level proof that the old sibling-count
+      // gate no longer blocks the single-child promote path.
+      fireEvent.press(screen.getByTestId("edit-goal-substep-un-nest-only"));
+      expect(onReparentStep).toHaveBeenCalledWith("only", null);
+    });
+
+    it("forwards onReparentStep through to the list (prop-chain guard)", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      renderWithProviders(
+        <EditGoalView {...makeProps({ steps: withSub, onReparentStep })} />,
+      );
+      // The nest-under trigger is only rendered when the list received
+      // onReparentStep, so its presence proves the host forwarded it.
+      expect(
+        screen.getByTestId("edit-goal-step-nest-under-s2"),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/apps/native-rd/src/components/EditGoalView/__tests__/applyReparent.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/applyReparent.test.ts
@@ -61,18 +61,27 @@ describe("applyReparent", () => {
     expect(
       result.find((s) => s.id === "a")?.subSteps?.map((ss) => ss.id),
     ).toEqual(["a1"]);
+    expect(result).toBe(steps);
   });
 
   it("refuses to nest a step under itself and returns the input unchanged", () => {
     const steps = [step("a", "A"), step("b", "B")];
     const result = applyReparent(steps, "a", "a");
     expect(result.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(result).toBe(steps);
   });
 
   it("refuses to nest under a non-existent parent and returns the input unchanged", () => {
     const steps = [step("a", "A")];
     const result = applyReparent(steps, "a", "nope");
     expect(result.map((s) => s.id)).toEqual(["a"]);
+    expect(result).toBe(steps);
+  });
+
+  it("returns the input unchanged when the moved step does not exist", () => {
+    const steps = [step("a", "A")];
+    const result = applyReparent(steps, "nope", null);
+    expect(result).toBe(steps);
   });
 
   it("does not mutate the input array", () => {

--- a/apps/native-rd/src/components/EditGoalView/__tests__/applyReparent.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/applyReparent.test.ts
@@ -1,0 +1,84 @@
+import { applyReparent } from "../applyReparent";
+import type { EditGoalStep } from "../EditGoalView";
+import { EvidenceType } from "../../../db";
+
+function step(
+  id: string,
+  title: string,
+  subSteps?: EditGoalStep["subSteps"],
+): EditGoalStep {
+  return {
+    id,
+    title,
+    plannedEvidenceTypes: [EvidenceType.text],
+    subSteps,
+  };
+}
+
+function sub(id: string, title: string) {
+  return { id, title, plannedEvidenceTypes: [EvidenceType.text] };
+}
+
+describe("applyReparent", () => {
+  it("promotes a child to the end of the root array and removes it from the source parent", () => {
+    const steps = [
+      step("a", "A", [sub("a1", "A1"), sub("a2", "A2")]),
+      step("b", "B"),
+    ];
+    const result = applyReparent(steps, "a1", null);
+    expect(result.map((s) => s.id)).toEqual(["a", "b", "a1"]);
+    const a = result.find((s) => s.id === "a");
+    expect(a?.subSteps?.map((ss) => ss.id)).toEqual(["a2"]);
+    const promoted = result.find((s) => s.id === "a1");
+    expect(promoted?.subSteps).toEqual([]);
+  });
+
+  it("demotes a leaf root to the end of the target parent's sub-steps", () => {
+    const steps = [step("a", "A", [sub("a1", "A1")]), step("b", "B")];
+    const result = applyReparent(steps, "b", "a");
+    expect(result.map((s) => s.id)).toEqual(["a"]);
+    const a = result.find((s) => s.id === "a");
+    expect(a?.subSteps?.map((ss) => ss.id)).toEqual(["a1", "b"]);
+    expect(result.find((s) => s.id === "b")).toBeUndefined();
+  });
+
+  it("moves a child between parents, appending to the destination's sub-steps", () => {
+    const steps = [
+      step("a", "A", [sub("a1", "A1"), sub("a2", "A2")]),
+      step("b", "B", [sub("b1", "B1")]),
+    ];
+    const result = applyReparent(steps, "a2", "b");
+    const a = result.find((s) => s.id === "a");
+    const b = result.find((s) => s.id === "b");
+    expect(a?.subSteps?.map((ss) => ss.id)).toEqual(["a1"]);
+    expect(b?.subSteps?.map((ss) => ss.id)).toEqual(["b1", "a2"]);
+  });
+
+  it("refuses to demote a parent-with-children (one-level cap) and returns the input unchanged", () => {
+    const steps = [step("a", "A", [sub("a1", "A1")]), step("b", "B")];
+    const result = applyReparent(steps, "a", "b");
+    expect(result.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(
+      result.find((s) => s.id === "a")?.subSteps?.map((ss) => ss.id),
+    ).toEqual(["a1"]);
+  });
+
+  it("refuses to nest a step under itself and returns the input unchanged", () => {
+    const steps = [step("a", "A"), step("b", "B")];
+    const result = applyReparent(steps, "a", "a");
+    expect(result.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+
+  it("refuses to nest under a non-existent parent and returns the input unchanged", () => {
+    const steps = [step("a", "A")];
+    const result = applyReparent(steps, "a", "nope");
+    expect(result.map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const steps = [step("a", "A", [sub("a1", "A1")]), step("b", "B")];
+    const snapshot = JSON.parse(JSON.stringify(steps));
+    applyReparent(steps, "a1", null);
+    expect(steps).toEqual(snapshot);
+  });
+});

--- a/apps/native-rd/src/components/EditGoalView/__tests__/flattenEditGoalSteps.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/flattenEditGoalSteps.test.ts
@@ -1,0 +1,68 @@
+import { flattenEditGoalSteps } from "../flattenEditGoalSteps";
+import type { EditGoalStep } from "../EditGoalView";
+import { EvidenceType } from "../../../db";
+
+function step(
+  id: string,
+  title: string,
+  subSteps?: EditGoalStep["subSteps"],
+): EditGoalStep {
+  return {
+    id,
+    title,
+    plannedEvidenceTypes: [EvidenceType.text],
+    subSteps,
+  };
+}
+
+function sub(id: string, title: string) {
+  return { id, title, plannedEvidenceTypes: [EvidenceType.text] };
+}
+
+describe("flattenEditGoalSteps", () => {
+  it("flattens a flat root-only list", () => {
+    const steps = [step("a", "A"), step("b", "B"), step("c", "C")];
+    expect(flattenEditGoalSteps(steps)).toEqual([
+      { id: "a", parentStepId: null },
+      { id: "b", parentStepId: null },
+      { id: "c", parentStepId: null },
+    ]);
+  });
+
+  it("flattens a parent with three sub-steps in render order", () => {
+    const steps = [
+      step("a", "A", [sub("a1", "A1"), sub("a2", "A2"), sub("a3", "A3")]),
+    ];
+    expect(flattenEditGoalSteps(steps)).toEqual([
+      { id: "a", parentStepId: null },
+      { id: "a1", parentStepId: "a" },
+      { id: "a2", parentStepId: "a" },
+      { id: "a3", parentStepId: "a" },
+    ]);
+  });
+
+  it("flattens two parents each with children", () => {
+    const steps = [
+      step("a", "A", [sub("a1", "A1")]),
+      step("b", "B", [sub("b1", "B1"), sub("b2", "B2")]),
+    ];
+    expect(flattenEditGoalSteps(steps)).toEqual([
+      { id: "a", parentStepId: null },
+      { id: "a1", parentStepId: "a" },
+      { id: "b", parentStepId: null },
+      { id: "b1", parentStepId: "b" },
+      { id: "b2", parentStepId: "b" },
+    ]);
+  });
+
+  it("flattens an empty list to an empty array", () => {
+    expect(flattenEditGoalSteps([])).toEqual([]);
+  });
+
+  it("flattens a parent with no sub-steps as just itself", () => {
+    const steps = [step("a", "A", [])];
+    expect(flattenEditGoalSteps(steps)).toEqual([
+      { id: "a", parentStepId: null },
+    ]);
+  });
+});

--- a/apps/native-rd/src/components/EditGoalView/__tests__/geometryNormalize.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/geometryNormalize.test.ts
@@ -1,4 +1,4 @@
-import { toLocalTop, normalizePointerY } from "../geometryNormalize";
+import { toLocalTop } from "../geometryNormalize";
 
 describe("geometryNormalize", () => {
   describe("toLocalTop (absolute → list-local outline conversion)", () => {
@@ -19,35 +19,6 @@ describe("geometryNormalize", () => {
 
     it("handles a list scrolled below the top of the screen (negative origin)", () => {
       expect(toLocalTop(150, -30)).toBe(180);
-    });
-  });
-
-  describe("normalizePointerY (scroll-delta pointer normalization)", () => {
-    it("is a passthrough when there is no scroll delta", () => {
-      expect(normalizePointerY(100, 0)).toBe(100);
-    });
-
-    it("adds a positive scroll delta (scrolled down moves rows up)", () => {
-      // Rows measured at drag start are now scrollDelta higher in the
-      // measurement frame than the stationary finger, so the pointer is
-      // adjusted up by adding the delta to find the right row.
-      expect(normalizePointerY(100, 50)).toBe(150);
-    });
-
-    it("adds a negative scroll delta (scrolled up)", () => {
-      expect(normalizePointerY(100, -20)).toBe(80);
-    });
-
-    it("composes with toLocalTop to locate a drop slot in list-local space", () => {
-      const pointerScreenY = 250;
-      const scrollDelta = 60;
-      const listOriginY = 40;
-      const localPointer = toLocalTop(
-        normalizePointerY(pointerScreenY, scrollDelta),
-        listOriginY,
-      );
-      // (250 + 60) - 40 = 270
-      expect(localPointer).toBe(270);
     });
   });
 });

--- a/apps/native-rd/src/components/EditGoalView/__tests__/geometryNormalize.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/geometryNormalize.test.ts
@@ -1,0 +1,53 @@
+import { toLocalTop, normalizePointerY } from "../geometryNormalize";
+
+describe("geometryNormalize", () => {
+  describe("toLocalTop (absolute → list-local outline conversion)", () => {
+    it("subtracts the measured list origin from an absolute y", () => {
+      expect(toLocalTop(120, 40)).toBe(80);
+    });
+
+    it("is a passthrough when the list origin is 0", () => {
+      expect(toLocalTop(200, 0)).toBe(200);
+    });
+
+    it("never returns the raw absolute y when the origin is non-zero", () => {
+      // A row at screen-absolute y=300 inside a list whose origin is y=80 must
+      // render its drop outline at local top 220, not 300.
+      expect(toLocalTop(300, 80)).toBe(220);
+      expect(toLocalTop(300, 80)).not.toBe(300);
+    });
+
+    it("handles a list scrolled below the top of the screen (negative origin)", () => {
+      expect(toLocalTop(150, -30)).toBe(180);
+    });
+  });
+
+  describe("normalizePointerY (scroll-delta pointer normalization)", () => {
+    it("is a passthrough when there is no scroll delta", () => {
+      expect(normalizePointerY(100, 0)).toBe(100);
+    });
+
+    it("adds a positive scroll delta (scrolled down moves rows up)", () => {
+      // Rows measured at drag start are now scrollDelta higher in the
+      // measurement frame than the stationary finger, so the pointer is
+      // adjusted up by adding the delta to find the right row.
+      expect(normalizePointerY(100, 50)).toBe(150);
+    });
+
+    it("adds a negative scroll delta (scrolled up)", () => {
+      expect(normalizePointerY(100, -20)).toBe(80);
+    });
+
+    it("composes with toLocalTop to locate a drop slot in list-local space", () => {
+      const pointerScreenY = 250;
+      const scrollDelta = 60;
+      const listOriginY = 40;
+      const localPointer = toLocalTop(
+        normalizePointerY(pointerScreenY, scrollDelta),
+        listOriginY,
+      );
+      // (250 + 60) - 40 = 270
+      expect(localPointer).toBe(270);
+    });
+  });
+});

--- a/apps/native-rd/src/components/EditGoalView/__tests__/hierarchyDragHelpers.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/hierarchyDragHelpers.test.ts
@@ -1,0 +1,29 @@
+import { retainEqualDropOutline } from "../hierarchyDragHelpers";
+import type { DropOutline } from "../useEditGoalHierarchyDragTypes";
+
+jest.mock("../../../utils/haptics", () => ({
+  triggerDragDrop: jest.fn(),
+}));
+
+describe("retainEqualDropOutline", () => {
+  const previous: DropOutline = { kind: "nested", top: 24, height: 44 };
+
+  it("retains the previous reference when the visual outline is unchanged", () => {
+    const equalCopy: DropOutline = { ...previous };
+    expect(retainEqualDropOutline(previous, equalCopy)).toBe(previous);
+  });
+
+  it.each([
+    { kind: "line" as const, top: 24, height: 44 },
+    { kind: "nested" as const, top: 25, height: 44 },
+    { kind: "nested" as const, top: 24, height: 45 },
+  ])("returns the next outline when geometry changes: %o", (next) => {
+    expect(retainEqualDropOutline(previous, next)).toBe(next);
+  });
+
+  it("propagates transitions to and from no outline", () => {
+    expect(retainEqualDropOutline(previous, null)).toBeNull();
+    expect(retainEqualDropOutline(null, previous)).toBe(previous);
+    expect(retainEqualDropOutline(null, null)).toBeNull();
+  });
+});

--- a/apps/native-rd/src/components/EditGoalView/__tests__/useEditGoalHierarchyDrag.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/useEditGoalHierarchyDrag.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Unit tests for useEditGoalHierarchyDrag dispatch wiring + canDrag + geometry
+ * normalization (issue #496, Step 2). These cover the coordinator's dispatch
+ * paths and the R13 canDrag derivation / lone-child promote regression. They do
+ * NOT re-test classifyDrop's own guards (review #6) — only the wiring from
+ * flat-list + armed target → callback dispatch.
+ *
+ * The hook is driven directly via its returned handlers with injected row
+ * geometry (registerRowLayout), so no native gesture runtime is needed.
+ */
+import { renderHook, act } from "../../../__tests__/test-utils";
+import { AccessibilityInfo } from "react-native";
+import { useEditGoalHierarchyDrag } from "../useEditGoalHierarchyDrag";
+import type { EditGoalStep } from "../EditGoalView";
+import { EvidenceType } from "../../../db";
+
+jest.mock("../../../utils/haptics", () => ({
+  triggerDragStart: jest.fn(),
+  triggerDragDrop: jest.fn(),
+}));
+
+function step(
+  id: string,
+  title: string,
+  subSteps?: EditGoalStep["subSteps"],
+): EditGoalStep {
+  return { id, title, plannedEvidenceTypes: [EvidenceType.text], subSteps };
+}
+function sub(id: string, title: string) {
+  return { id, title, plannedEvidenceTypes: [EvidenceType.text] };
+}
+
+// Register a uniform-height grid of rows starting at originY=0 (list-local =
+// absolute since listOrigin defaults to 0). Each row is 50px tall.
+function registerGrid(
+  result: ReturnType<typeof useEditGoalHierarchyDrag>,
+  flatIds: string[],
+  height = 50,
+) {
+  for (let i = 0; i < flatIds.length; i++) {
+    result.registerRowLayout(flatIds[i], {
+      absoluteY: i * height,
+      height,
+    });
+  }
+}
+
+describe("useEditGoalHierarchyDrag", () => {
+  const announce = jest
+    .spyOn(AccessibilityInfo, "announceForAccessibility")
+    .mockImplementation(() => {});
+  afterEach(() => announce.mockClear());
+
+  describe("sibling reorder dispatch", () => {
+    it("dispatches onReorderSteps for a root reorder", () => {
+      const onReorderSteps = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      const steps = [step("a", "A"), step("b", "B"), step("c", "C")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps,
+          onReorderSubSteps,
+        }),
+      );
+      registerGrid(result.current, ["a", "b", "c"]);
+      act(() => {
+        result.current.handleDragStart("a");
+        // Drag a down so its center lands in row c's band (index 2).
+        result.current.handleDragMove(120, 120);
+        result.current.handleDragEnd();
+      });
+      expect(onReorderSteps).toHaveBeenCalledWith(["b", "c", "a"]);
+      expect(onReorderSubSteps).not.toHaveBeenCalled();
+    });
+
+    it("dispatches onReorderSubSteps for a child reorder, scoped to one parent", () => {
+      const onReorderSteps = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      const steps = [
+        step("a", "A", [sub("a1", "A1"), sub("a2", "A2"), sub("a3", "A3")]),
+        step("b", "B", [sub("b1", "B1")]),
+      ];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({ steps, onReorderSteps, onReorderSubSteps }),
+      );
+      // Flat order: a, a1, a2, a3, b, b1
+      registerGrid(result.current, ["a", "a1", "a2", "a3", "b", "b1"]);
+      act(() => {
+        result.current.handleDragStart("a1");
+        // Move a1 down two rows so its center is in a3's band (flat index 3).
+        result.current.handleDragMove(120, 120);
+        result.current.handleDragEnd();
+      });
+      expect(onReorderSubSteps).toHaveBeenCalledWith("a", ["a2", "a3", "a1"]);
+      expect(onReorderSteps).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reparent dispatch (onReparentStep supplied)", () => {
+    it("promotes a child to root via a positional drop above its parent", () => {
+      const onReparentStep = jest.fn();
+      const onReorderSteps = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      // a {b}  c — flat: a, b, c. Drag b above a (flat index 0).
+      const steps = [step("a", "A", [sub("b", "B")]), step("c", "C")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps,
+          onReorderSubSteps,
+          onReparentStep,
+        }),
+      );
+      registerGrid(result.current, ["a", "b", "c"]);
+      act(() => {
+        result.current.handleDragStart("b");
+        // Move b up so its center is above a's band (flat index 0).
+        result.current.handleDragMove(-40, -40);
+        result.current.handleDragEnd();
+      });
+      expect(onReparentStep).toHaveBeenCalledWith("b", null);
+      expect(onReorderSteps).not.toHaveBeenCalled();
+      expect(onReorderSubSteps).not.toHaveBeenCalled();
+    });
+
+    it("demotes a leaf root onto an armed dwell target", () => {
+      jest.useFakeTimers();
+      const onReparentStep = jest.fn();
+      const steps = [step("a", "A"), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep,
+        }),
+      );
+      registerGrid(result.current, ["a", "b"]);
+      act(() => {
+        result.current.handleDragStart("b");
+        // Hover b over a's band (flat index 0) — same row as start? start is
+        // b at index 1, hover a at index 0.
+        result.current.handleDragMove(-30, -30);
+      });
+      // Dwell requires a timer; flush it.
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+      act(() => {
+        result.current.handleDragEnd();
+      });
+      expect(onReparentStep).toHaveBeenCalledWith("b", "a");
+      jest.useRealTimers();
+    });
+
+    it("moves a child between parents via a positional demote", () => {
+      const onReparentStep = jest.fn();
+      // a {a1}  b {b1} — flat: a, a1, b, b1. Drag a1 into b's group.
+      const steps = [
+        step("a", "A", [sub("a1", "A1")]),
+        step("b", "B", [sub("b1", "B1")]),
+      ];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep,
+        }),
+      );
+      registerGrid(result.current, ["a", "a1", "b", "b1"]);
+      act(() => {
+        result.current.handleDragStart("a1");
+        // Move a1 down to rest in b1's band (flat index 3). a1 starts at
+        // index 1 (y=50); moving +100 lands center at 50+100+25=175 → band of
+        // b1 (index 3, y=150..200).
+        result.current.handleDragMove(100, 100);
+        result.current.handleDragEnd();
+      });
+      expect(onReparentStep).toHaveBeenCalledWith("a1", "b");
+    });
+
+    it("refuses to demote a parent-with-children (no callback)", () => {
+      jest.useFakeTimers();
+      const onReparentStep = jest.fn();
+      const onReorderSteps = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      // a {a1}  b — drag a (parent) and dwell on b → refused.
+      const steps = [step("a", "A", [sub("a1", "A1")]), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps,
+          onReorderSubSteps,
+          onReparentStep,
+        }),
+      );
+      registerGrid(result.current, ["a", "a1", "b"]);
+      act(() => {
+        result.current.handleDragStart("a");
+        result.current.handleDragMove(100, 100); // hover into b's band
+      });
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+      act(() => {
+        result.current.handleDragEnd();
+      });
+      // A parent-with-children cannot be demoted; the armed target should not
+      // arm, and the drop should be a none/snap-back (no reparent).
+      expect(onReparentStep).not.toHaveBeenCalledWith("a", "b");
+      jest.useRealTimers();
+    });
+
+    it("refuses an armed target equal to the dragged step", () => {
+      jest.useFakeTimers();
+      const onReparentStep = jest.fn();
+      const steps = [step("a", "A"), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep,
+        }),
+      );
+      registerGrid(result.current, ["a", "b"]);
+      act(() => {
+        result.current.handleDragStart("a");
+        result.current.handleDragMove(0, 0); // stay on a's own band
+      });
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+      act(() => {
+        result.current.handleDragEnd();
+      });
+      // Armed target equal to dragged is refused; no self-reparent.
+      expect(onReparentStep).not.toHaveBeenCalledWith("a", "a");
+      jest.useRealTimers();
+    });
+  });
+
+  describe("omitted onReparentStep collapses to reorder-only", () => {
+    it("does not reparent when onReparentStep is omitted, but reorder still works", () => {
+      const onReorderSteps = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      const steps = [step("a", "A", [sub("b", "B")]), step("c", "C")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({ steps, onReorderSteps, onReorderSubSteps }),
+      );
+      registerGrid(result.current, ["a", "b", "c"]);
+      act(() => {
+        result.current.handleDragStart("b");
+        result.current.handleDragMove(-40, -40); // promote position
+        result.current.handleDragEnd();
+      });
+      // Without onReparentStep, classifyDrop may return reparent but the
+      // dispatch no-ops (onReparentStep undefined). Neither reorder fires for
+      // a reparent result.
+      expect(onReorderSteps).not.toHaveBeenCalled();
+      expect(onReorderSubSteps).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("R13 canDragRow", () => {
+    it("a lone child is draggable when reparent is enabled (single-child promote path)", () => {
+      const steps = [step("a", "A", [sub("a1", "A1")]), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep: jest.fn(),
+        }),
+      );
+      expect(result.current.canDragRow("a1")).toBe(true);
+    });
+
+    it("a lone child is NOT draggable when reparent is omitted (old behavior)", () => {
+      const steps = [step("a", "A", [sub("a1", "A1")]), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+        }),
+      );
+      expect(result.current.canDragRow("a1")).toBe(false);
+    });
+
+    it("a lone leaf root is not draggable (no other root target)", () => {
+      const steps = [step("a", "A")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep: jest.fn(),
+        }),
+      );
+      expect(result.current.canDragRow("a")).toBe(false);
+    });
+
+    it("a root with ≥2 roots is draggable in both modes", () => {
+      const steps = [step("a", "A"), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep: jest.fn(),
+        }),
+      );
+      expect(result.current.canDragRow("a")).toBe(true);
+    });
+
+    it("drag is disabled while a row is being edited", () => {
+      const steps = [step("a", "A"), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep: jest.fn(),
+          editingId: "a",
+        }),
+      );
+      expect(result.current.canDragRow("a")).toBe(false);
+      expect(result.current.canDragRow("b")).toBe(false);
+    });
+  });
+
+  describe("moveStep (sibling-scoped, R8)", () => {
+    it("reorders within a root group and never reparents", () => {
+      const onReorderSteps = jest.fn();
+      const onReparentStep = jest.fn();
+      const steps = [step("a", "A"), step("b", "B"), step("c", "C")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps,
+          onReorderSubSteps: jest.fn(),
+          onReparentStep,
+        }),
+      );
+      act(() => {
+        result.current.moveStep("a", 1);
+      });
+      expect(onReorderSteps).toHaveBeenCalledWith(["b", "a", "c"]);
+      expect(onReparentStep).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op at a group boundary (does not promote)", () => {
+      const onReparentStep = jest.fn();
+      const onReorderSteps = jest.fn();
+      const onReorderSubSteps = jest.fn();
+      const steps = [
+        step("a", "A", [sub("a1", "A1"), sub("a2", "A2")]),
+        step("b", "B"),
+      ];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps,
+          onReorderSubSteps,
+          onReparentStep,
+        }),
+      );
+      act(() => {
+        // a1 is first in its group — moving up is a no-op (no promote).
+        result.current.moveStep("a1", -1);
+      });
+      expect(onReparentStep).not.toHaveBeenCalled();
+      expect(onReorderSteps).not.toHaveBeenCalled();
+      expect(onReorderSubSteps).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/native-rd/src/components/EditGoalView/__tests__/useEditGoalHierarchyDrag.test.ts
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/useEditGoalHierarchyDrag.test.ts
@@ -95,6 +95,51 @@ describe("useEditGoalHierarchyDrag", () => {
       expect(onReorderSubSteps).toHaveBeenCalledWith("a", ["a2", "a3", "a1"]);
       expect(onReorderSteps).not.toHaveBeenCalled();
     });
+
+    it("refreshes the list origin and every row before using absolute geometry", () => {
+      const onReorderSteps = jest.fn();
+      const steps = [step("a", "A"), step("b", "B"), step("c", "C")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps,
+          onReorderSubSteps: jest.fn(),
+        }),
+      );
+
+      // Stale pre-scroll coordinates. Drag start must replace all of them.
+      registerGrid(result.current, ["a", "b", "c"], 50);
+      result.current.registerRowLayout("a", { absoluteY: 1000, height: 50 });
+      result.current.registerRowLayout("b", { absoluteY: 1050, height: 50 });
+      result.current.registerRowLayout("c", { absoluteY: 1100, height: 50 });
+      const originRemeasure = jest.fn(() =>
+        result.current.registerListOrigin(0),
+      );
+      const rowRemeasures = ["a", "b", "c"].map((id, index) =>
+        jest.fn(() =>
+          result.current.registerRowLayout(id, {
+            absoluteY: index * 50,
+            height: 50,
+          }),
+        ),
+      );
+      result.current.registerListOriginRemeasure(originRemeasure);
+      ["a", "b", "c"].forEach((id, index) =>
+        result.current.registerRemeasure(id, rowRemeasures[index]),
+      );
+
+      act(() => {
+        result.current.handleDragStart("a");
+        result.current.handleDragMove(120, 120);
+        result.current.handleDragEnd();
+      });
+
+      expect(originRemeasure).toHaveBeenCalledTimes(1);
+      rowRemeasures.forEach((remeasure) =>
+        expect(remeasure).toHaveBeenCalledTimes(1),
+      );
+      expect(onReorderSteps).toHaveBeenCalledWith(["b", "c", "a"]);
+    });
   });
 
   describe("reparent dispatch (onReparentStep supplied)", () => {
@@ -151,6 +196,61 @@ describe("useEditGoalHierarchyDrag", () => {
         result.current.handleDragEnd();
       });
       expect(onReparentStep).toHaveBeenCalledWith("b", "a");
+      jest.useRealTimers();
+    });
+
+    it("does not arm when the insertion target is outside its measured band", () => {
+      jest.useFakeTimers();
+      const onReparentStep = jest.fn();
+      const steps = [step("a", "A"), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep,
+        }),
+      );
+      result.current.registerRowLayout("a", { absoluteY: 0, height: 20 });
+      result.current.registerRowLayout("b", { absoluteY: 100, height: 20 });
+
+      act(() => {
+        result.current.handleDragStart("b");
+        // Center moves above a. It still maps to a as the insertion target,
+        // but is outside a's 0..20 dwell band.
+        result.current.handleDragMove(-130, -20);
+        jest.advanceTimersByTime(250);
+        result.current.handleDragEnd();
+      });
+
+      expect(onReparentStep).not.toHaveBeenCalledWith("b", "a");
+      jest.useRealTimers();
+    });
+
+    it("disarms when leaving a target band without changing the hover id", () => {
+      jest.useFakeTimers();
+      const onReparentStep = jest.fn();
+      const steps = [step("a", "A"), step("b", "B")];
+      const { result } = renderHook(() =>
+        useEditGoalHierarchyDrag({
+          steps,
+          onReorderSteps: jest.fn(),
+          onReorderSubSteps: jest.fn(),
+          onReparentStep,
+        }),
+      );
+      result.current.registerRowLayout("a", { absoluteY: 0, height: 20 });
+      result.current.registerRowLayout("b", { absoluteY: 100, height: 20 });
+
+      act(() => {
+        result.current.handleDragStart("b");
+        result.current.handleDragMove(-100, 10); // center 10: inside a
+        result.current.handleDragMove(-130, -20); // still hover a, now outside
+        jest.advanceTimersByTime(250);
+        result.current.handleDragEnd();
+      });
+
+      expect(onReparentStep).not.toHaveBeenCalledWith("b", "a");
       jest.useRealTimers();
     });
 

--- a/apps/native-rd/src/components/EditGoalView/applyReparent.ts
+++ b/apps/native-rd/src/components/EditGoalView/applyReparent.ts
@@ -1,0 +1,84 @@
+/**
+ * applyReparent — pure nested-reparent helper for stateful stories/tests
+ * (issue #496, R9). Removes a step (root or sub-step) from its source sibling
+ * group and appends it to the destination group: `newParentId === null`
+ * promotes to the end of the root array; otherwise the step is appended to the
+ * target parent's `subSteps[]`. Returns a new `EditGoalStep[]` (immutable).
+ *
+ * Refuses (returns the input array unchanged) when the move would violate the
+ * one-level hierarchy cap — a parent that itself has children cannot be
+ * demoted (mirrors `classifyDrop`'s guard, for story safety so a stateful
+ * story never produces grandchildren). Production code emits only the
+ * `onReparentStep` callback; persistence/ordinal normalization is the
+ * [Integrate] issue's (#446) job.
+ */
+import type { EditGoalStep } from "./EditGoalView";
+
+export function applyReparent(
+  steps: readonly EditGoalStep[],
+  stepId: string,
+  newParentId: string | null,
+): EditGoalStep[] {
+  // A parent-with-children can never be demoted (one-level cap).
+  if (newParentId !== null) {
+    const dragged = steps.find((s) => s.id === stepId);
+    if (dragged && (dragged.subSteps?.length ?? 0) > 0) {
+      return [...steps];
+    }
+    // Can't nest under a non-existent parent, or under self.
+    const target = steps.find((s) => s.id === newParentId);
+    if (!target || newParentId === stepId) return [...steps];
+  }
+
+  // Pull the moved step out of its source location and strip its sub-steps on
+  // promote (a promoted step carries no children — it was a leaf child).
+  let movedStep: EditGoalStep | undefined;
+  const withoutSource: EditGoalStep[] = [];
+  for (const step of steps) {
+    if (step.id === stepId) {
+      // The dragged step is a root — only valid for a demote, which keeps its
+      // (empty) sub-steps. A leaf root has none.
+      movedStep = step;
+      continue;
+    }
+    const subIdx = step.subSteps?.findIndex((ss) => ss.id === stepId) ?? -1;
+    if (subIdx >= 0 && step.subSteps) {
+      movedStep = {
+        id: step.subSteps[subIdx].id,
+        title: step.subSteps[subIdx].title,
+        plannedEvidenceTypes: step.subSteps[subIdx].plannedEvidenceTypes,
+        // A promoted sub-step becomes a root with no children of its own.
+        subSteps: newParentId === null ? [] : undefined,
+      };
+      const remainingSubs = step.subSteps.filter((_, i) => i !== subIdx);
+      withoutSource.push({
+        ...step,
+        subSteps: remainingSubs,
+      });
+    } else {
+      withoutSource.push(step);
+    }
+  }
+  if (!movedStep) return [...steps];
+
+  if (newParentId === null) {
+    // Promote: append to the root array.
+    return [...withoutSource, movedStep];
+  }
+  // Demote / move-between-parents: append to the target parent's sub-steps.
+  return withoutSource.map((step) =>
+    step.id === newParentId
+      ? {
+          ...step,
+          subSteps: [
+            ...(step.subSteps ?? []),
+            {
+              id: movedStep!.id,
+              title: movedStep!.title,
+              plannedEvidenceTypes: movedStep!.plannedEvidenceTypes,
+            },
+          ],
+        }
+      : step,
+  );
+}

--- a/apps/native-rd/src/components/EditGoalView/applyReparent.ts
+++ b/apps/native-rd/src/components/EditGoalView/applyReparent.ts
@@ -15,7 +15,7 @@
 import type { EditGoalStep } from "./EditGoalView";
 
 export function applyReparent(
-  steps: readonly EditGoalStep[],
+  steps: EditGoalStep[],
   stepId: string,
   newParentId: string | null,
 ): EditGoalStep[] {
@@ -23,11 +23,11 @@ export function applyReparent(
   if (newParentId !== null) {
     const dragged = steps.find((s) => s.id === stepId);
     if (dragged && (dragged.subSteps?.length ?? 0) > 0) {
-      return [...steps];
+      return steps;
     }
     // Can't nest under a non-existent parent, or under self.
     const target = steps.find((s) => s.id === newParentId);
-    if (!target || newParentId === stepId) return [...steps];
+    if (!target || newParentId === stepId) return steps;
   }
 
   // Pull the moved step out of its source location and strip its sub-steps on
@@ -59,7 +59,7 @@ export function applyReparent(
       withoutSource.push(step);
     }
   }
-  if (!movedStep) return [...steps];
+  if (!movedStep) return steps;
 
   if (newParentId === null) {
     // Promote: append to the root array.

--- a/apps/native-rd/src/components/EditGoalView/flattenEditGoalSteps.ts
+++ b/apps/native-rd/src/components/EditGoalView/flattenEditGoalSteps.ts
@@ -1,0 +1,28 @@
+/**
+ * flattenEditGoalSteps — pure adapter (issue #496, R7) that converts the
+ * redesigned editor's nested `EditGoalStep[]` model into the flat
+ * `ClassifyStep[]` render-order shape `classifyDrop` consumes (R1 — reused
+ * unchanged from StepList). The redesigned model nests `subSteps[]` under a
+ * parent; `classifyDrop` expects one flat column where each root is
+ * immediately followed by its children. No `parentStepId` is added to
+ * `EditGoalStep` (R6) — this adapter owns the flat shape.
+ *
+ * Render order: parent then its `subSteps[]`, then the next parent, etc. A
+ * parent with no sub-steps contributes just itself. Ids are assumed unique
+ * across steps and sub-steps (an existing invariant of the redesigned editor).
+ */
+import type { ClassifyStep } from "../StepList/classifyDrop";
+import type { EditGoalStep } from "./EditGoalView";
+
+export function flattenEditGoalSteps(
+  steps: readonly EditGoalStep[],
+): ClassifyStep[] {
+  const flat: ClassifyStep[] = [];
+  for (const step of steps) {
+    flat.push({ id: step.id, parentStepId: null });
+    for (const sub of step.subSteps ?? []) {
+      flat.push({ id: sub.id, parentStepId: step.id });
+    }
+  }
+  return flat;
+}

--- a/apps/native-rd/src/components/EditGoalView/geometryNormalize.ts
+++ b/apps/native-rd/src/components/EditGoalView/geometryNormalize.ts
@@ -1,0 +1,37 @@
+/**
+ * Geometry normalization helpers (issue #496, R14). The unified hierarchy
+ * coordinator registers row geometry as **screen-absolute** `absoluteY` (via
+ * `measureInWindow`), because nested `onLayout` `y` values are parent-relative
+ * and cannot be compared across groups (R3). Two conversions are needed:
+ *
+ * - `toLocalTop` — drop-outline `top` values rendered *inside* the list must be
+ *   list-local (the list's absolutely-positioned children use the list
+ *   container's coordinate origin). An absolute `y` is never rendered directly
+ *   as a local `top`; it is converted by subtracting the measured list origin.
+ * - `normalizePointerY` — during edge auto-scroll the screen-absolute registry
+ *   (measured at drag start) goes stale: rows physically move as content
+ *   scrolls. The pointer's screen `absoluteY` is normalized back into the
+ *   measurement frame by adding the accumulated scroll delta
+ *   (`currentScroll - scrollAtDragStart`), so hover math stays aligned. When no
+ *   scrolling occurs the delta is 0 and this is a passthrough.
+ *
+ * Pure + unit-tested in `__tests__/geometryNormalize.test.ts` so the math is
+ * locked independently of the gesture hook.
+ */
+
+/** Convert a screen-absolute `y` to a list-local `top` for in-list rendering. */
+export function toLocalTop(absoluteY: number, listOriginY: number): number {
+  return absoluteY - listOriginY;
+}
+
+/**
+ * Normalize a screen-absolute pointer `y` into the registry's measurement
+ * frame by adding the accumulated scroll delta. `scrollDelta` is
+ * `currentScrollOffset - scrollOffsetAtDragStart` (≥ 0 when scrolled down).
+ */
+export function normalizePointerY(
+  pointerAbsoluteY: number,
+  scrollDelta: number,
+): number {
+  return pointerAbsoluteY + scrollDelta;
+}

--- a/apps/native-rd/src/components/EditGoalView/geometryNormalize.ts
+++ b/apps/native-rd/src/components/EditGoalView/geometryNormalize.ts
@@ -1,37 +1,22 @@
 /**
- * Geometry normalization helpers (issue #496, R14). The unified hierarchy
+ * Geometry normalization helper (issue #496, R14). The unified hierarchy
  * coordinator registers row geometry as **screen-absolute** `absoluteY` (via
  * `measureInWindow`), because nested `onLayout` `y` values are parent-relative
- * and cannot be compared across groups (R3). Two conversions are needed:
+ * and cannot be compared across groups (R3).
  *
- * - `toLocalTop` — drop-outline `top` values rendered *inside* the list must be
- *   list-local (the list's absolutely-positioned children use the list
- *   container's coordinate origin). An absolute `y` is never rendered directly
- *   as a local `top`; it is converted by subtracting the measured list origin.
- * - `normalizePointerY` — during edge auto-scroll the screen-absolute registry
- *   (measured at drag start) goes stale: rows physically move as content
- *   scrolls. The pointer's screen `absoluteY` is normalized back into the
- *   measurement frame by adding the accumulated scroll delta
- *   (`currentScroll - scrollAtDragStart`), so hover math stays aligned. When no
- *   scrolling occurs the delta is 0 and this is a passthrough.
+ * `toLocalTop` — drop-outline `top` values rendered *inside* the list must be
+ * list-local (the list's absolutely-positioned children use the list
+ * container's coordinate origin). An absolute `y` is never rendered directly
+ * as a local `top`; it is converted by subtracting the measured list origin.
  *
- * Pure + unit-tested in `__tests__/geometryNormalize.test.ts` so the math is
- * locked independently of the gesture hook.
+ * During active auto-scroll the pointer is normalized by the scroll delta via
+ * the already-tested `getEffectiveTranslationY` from `dragAutoScroll` — no
+ * separate helper is needed here.
+ *
+ * Pure + unit-tested in `__tests__/geometryNormalize.test.ts`.
  */
 
 /** Convert a screen-absolute `y` to a list-local `top` for in-list rendering. */
 export function toLocalTop(absoluteY: number, listOriginY: number): number {
   return absoluteY - listOriginY;
-}
-
-/**
- * Normalize a screen-absolute pointer `y` into the registry's measurement
- * frame by adding the accumulated scroll delta. `scrollDelta` is
- * `currentScrollOffset - scrollOffsetAtDragStart` (≥ 0 when scrolled down).
- */
-export function normalizePointerY(
-  pointerAbsoluteY: number,
-  scrollDelta: number,
-): number {
-  return pointerAbsoluteY + scrollDelta;
 }

--- a/apps/native-rd/src/components/EditGoalView/hierarchyDragHelpers.ts
+++ b/apps/native-rd/src/components/EditGoalView/hierarchyDragHelpers.ts
@@ -1,0 +1,280 @@
+/**
+ * Pure helpers for useEditGoalHierarchyDrag (issue #496, finding 5 split).
+ * Extracted so the coordinator hook stays under the 300-line lint limit and
+ * each piece is independently unit-testable. None of these touch React state
+ * or refs — they take the flat list + geometry registry + callbacks and return
+ * values or perform dispatch.
+ */
+import { AccessibilityInfo } from "react-native";
+import { triggerDragDrop } from "../../utils/haptics";
+import {
+  classifyDrop,
+  type ClassifyStep,
+  type DropResult,
+} from "../StepList/classifyDrop";
+import { toLocalTop } from "./geometryNormalize";
+import type { EditGoalStep } from "./EditGoalView";
+import type { RowGeometry, DropOutline } from "./useEditGoalHierarchyDragTypes";
+
+/** Dwell duration before a hovered root target arms for demote (R12). */
+export const DWELL_ARM_MS = 220;
+
+/**
+ * R13: per-row canDrag from the flattened hierarchy + edit state + available
+ * actions. A root needs ≥1 other root; a sub-step is draggable when reparent
+ * is enabled (a lone child can promote / move) or when it has siblings.
+ */
+export function canDragForRowId(
+  flat: readonly ClassifyStep[],
+  steps: readonly EditGoalStep[],
+  rowId: string,
+  editingId: string | null,
+  reparentEnabled: boolean,
+): boolean {
+  if (editingId !== null) return false;
+  const idx = flat.findIndex((s) => s.id === rowId);
+  if (idx < 0) return false;
+  const step = flat[idx];
+  if (step.parentStepId === null) {
+    return steps.length > 1;
+  }
+  const parent = steps.find((s) => s.id === step.parentStepId);
+  const siblingCount = parent?.subSteps?.length ?? 0;
+  if (reparentEnabled) return true;
+  return siblingCount > 1;
+}
+
+/**
+ * Flat index of the row whose measured band contains `centerAbsoluteY`.
+ * Gaps between rows map to the neighbouring row (the insertion target), so
+ * callers that need dwell-zoned hit-testing must separately check whether the
+ * center is actually inside the returned row's band (see `isInsideBand`).
+ */
+export function flatIndexAtY(
+  flat: readonly ClassifyStep[],
+  geometry: Map<string, RowGeometry>,
+  centerAbsoluteY: number,
+  draggedFlat: number,
+): number {
+  for (let i = 0; i < flat.length; i++) {
+    const g = geometry.get(flat[i].id);
+    if (!g) continue;
+    if (centerAbsoluteY < g.absoluteY + g.height) return i;
+  }
+  if (flat.some((s) => geometry.has(s.id))) {
+    return flat.length - 1;
+  }
+  return draggedFlat;
+}
+
+/** Whether `centerAbsoluteY` falls inside `rowId`'s measured band (R12 dwell). */
+export function isInsideBand(
+  geometry: Map<string, RowGeometry>,
+  rowId: string,
+  centerAbsoluteY: number,
+): boolean {
+  const g = geometry.get(rowId);
+  if (!g) return false;
+  return (
+    centerAbsoluteY >= g.absoluteY && centerAbsoluteY <= g.absoluteY + g.height
+  );
+}
+
+/** Whether the dragged step is a root that has children (can't be demoted). */
+export function draggedHasChildren(
+  flat: readonly ClassifyStep[],
+  steps: readonly EditGoalStep[],
+  draggedId: string,
+): boolean {
+  const draggedStep = flat.find((s) => s.id === draggedId);
+  if (!draggedStep || draggedStep.parentStepId !== null) return false;
+  return (steps.find((s) => s.id === draggedId)?.subSteps?.length ?? 0) > 0;
+}
+
+/**
+ * Whether a root header is a valid dwell-arm target for the dragged leaf:
+ * the target is a root, distinct from the dragged step, and the dragged step
+ * is itself a leaf (mirrors classifyDrop's dwell rule so the highlight never
+ * lies). `inBand` must be true — arming only happens inside the measured band.
+ */
+export function isArmableDwellTarget(
+  flat: readonly ClassifyStep[],
+  steps: readonly EditGoalStep[],
+  draggedId: string,
+  hoveredId: string | null,
+  inBand: boolean,
+  reparentEnabled: boolean,
+): boolean {
+  if (!reparentEnabled || !hoveredId || !inBand) return false;
+  const hovered = flat.find((s) => s.id === hoveredId);
+  if (!hovered || hovered.parentStepId !== null) return false;
+  if (hoveredId === draggedId) return false;
+  return !draggedHasChildren(flat, steps, draggedId);
+}
+
+/**
+ * Pure drop-outline computation from the flat list + geometry + list origin.
+ * Returns `null` when armed (suppressed), same-row, or a refused drop. Outline
+ * `top` values are list-local (`absoluteY - listOriginY`), never raw absolute.
+ */
+export function computeDropOutline(
+  flat: readonly ClassifyStep[],
+  steps: readonly EditGoalStep[],
+  geometry: Map<string, RowGeometry>,
+  listOriginY: number,
+  draggedId: string,
+  draggedFlat: number,
+  hoverFlat: number,
+  armed: boolean,
+): DropOutline | null {
+  if (armed) return null;
+  if (hoverFlat === draggedFlat) return null;
+  const preview = classifyDrop(flat, draggedFlat, hoverFlat, null);
+  if (preview.kind === "none") return null;
+  const slotId = flat[hoverFlat]?.id ?? "";
+  const slotG = geometry.get(slotId);
+  if (!slotG) return null;
+
+  const isNested =
+    preview.kind === "reparent"
+      ? preview.newParentStepId !== null
+      : preview.parentStepId !== null;
+
+  const isGroupReorder =
+    draggedHasChildren(flat, steps, draggedId) &&
+    preview.kind === "reorder" &&
+    preview.parentStepId === null;
+
+  if (isGroupReorder) {
+    const targetRootId = flat[hoverFlat].parentStepId ?? flat[hoverFlat].id;
+    const groupStart = flat.findIndex((s) => s.id === targetRootId);
+    let groupEnd = groupStart;
+    while (
+      groupEnd + 1 < flat.length &&
+      flat[groupEnd + 1].parentStepId === targetRootId
+    ) {
+      groupEnd++;
+    }
+    const startG = geometry.get(flat[groupStart].id);
+    const endG = geometry.get(flat[groupEnd].id);
+    if (!startG || !endG) return null;
+    return {
+      top: toLocalTop(startG.absoluteY, listOriginY),
+      height: endG.absoluteY + endG.height - startG.absoluteY,
+      kind: "group",
+    };
+  }
+  if (isNested) {
+    return {
+      top: toLocalTop(slotG.absoluteY, listOriginY),
+      height: slotG.height,
+      kind: "nested",
+    };
+  }
+  const top =
+    hoverFlat > draggedFlat ? slotG.absoluteY + slotG.height : slotG.absoluteY;
+  return { top: toLocalTop(top, listOriginY), height: 3, kind: "line" };
+}
+
+/** Look up a row's display title across roots and sub-steps (ids are unique). */
+export function titleForRowId(
+  steps: readonly EditGoalStep[],
+  rowId: string,
+): string {
+  for (const s of steps) {
+    if (s.id === rowId) return s.title;
+    const sub = s.subSteps?.find((ss) => ss.id === rowId);
+    if (sub) return sub.title;
+  }
+  return rowId;
+}
+
+export interface DropDispatchCallbacks {
+  onReorderSteps: (orderedStepIds: string[]) => void;
+  onReorderSubSteps: (
+    parentStepId: string,
+    orderedSubStepIds: string[],
+  ) => void;
+  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
+  announceReorder: (stepTitle: string, position: number) => string;
+  announcePromote: (stepTitle: string) => string;
+  announceNestedUnder: (stepTitle: string, parentTitle: string) => string;
+}
+
+/**
+ * Dispatch a classifyDrop result to the right callback + fire haptics + an
+ * accessibility announcement. Returns true if a callback actually dispatched.
+ */
+export function dispatchDropResult(
+  result: DropResult,
+  flat: readonly ClassifyStep[],
+  steps: readonly EditGoalStep[],
+  draggedId: string,
+  callbacks: DropDispatchCallbacks,
+): boolean {
+  let dispatched = false;
+  if (result.kind === "reorder") {
+    if (result.parentStepId === null) {
+      callbacks.onReorderSteps(result.orderedIds);
+      dispatched = true;
+    } else {
+      callbacks.onReorderSubSteps(result.parentStepId, result.orderedIds);
+      dispatched = true;
+    }
+  } else if (result.kind === "reparent") {
+    callbacks.onReparentStep?.(result.stepId, result.newParentStepId);
+    dispatched = callbacks.onReparentStep !== undefined;
+  }
+  if (!dispatched) return false;
+  triggerDragDrop();
+  if (result.kind === "reparent") {
+    const stepTitle = titleForRowId(steps, result.stepId);
+    if (result.newParentStepId === null) {
+      AccessibilityInfo.announceForAccessibility(
+        callbacks.announcePromote(stepTitle),
+      );
+    } else {
+      const parentTitle =
+        steps.find((s) => s.id === result.newParentStepId)?.title ?? "";
+      AccessibilityInfo.announceForAccessibility(
+        callbacks.announceNestedUnder(stepTitle, parentTitle),
+      );
+    }
+  } else if (result.kind === "reorder") {
+    const draggedTitle = titleForRowId(steps, draggedId);
+    AccessibilityInfo.announceForAccessibility(
+      callbacks.announceReorder(
+        draggedTitle,
+        result.orderedIds.indexOf(draggedId) + 1,
+      ),
+    );
+  }
+  return true;
+}
+
+/**
+ * R8: sibling-scoped ↑/↓ reorder. Resolves the sibling group from the flat
+ * step's parentStepId, swaps within it, and returns the new ordered ids + the
+ * target's 1-based position (or null at a group boundary — never reparents).
+ */
+export function siblingReorder(
+  flat: readonly ClassifyStep[],
+  rowId: string,
+  direction: 1 | -1,
+): { parent: string | null; orderedIds: string[]; newPosition: number } | null {
+  const idx = flat.findIndex((s) => s.id === rowId);
+  if (idx < 0) return null;
+  const step = flat[idx];
+  const parent = step.parentStepId ?? null;
+  const group = flat.filter((s) => (s.parentStepId ?? null) === parent);
+  const pos = group.findIndex((s) => s.id === rowId);
+  const swapWith = pos + direction;
+  if (swapWith < 0 || swapWith >= group.length) return null;
+  const reordered = [...group];
+  [reordered[pos], reordered[swapWith]] = [reordered[swapWith], reordered[pos]];
+  return {
+    parent,
+    orderedIds: reordered.map((s) => s.id),
+    newPosition: swapWith + 1,
+  };
+}

--- a/apps/native-rd/src/components/EditGoalView/hierarchyDragHelpers.ts
+++ b/apps/native-rd/src/components/EditGoalView/hierarchyDragHelpers.ts
@@ -176,6 +176,20 @@ export function computeDropOutline(
   return { top: toLocalTop(top, listOriginY), height: 3, kind: "line" };
 }
 
+/** Preserve outline identity when a drag frame produces no visual change. */
+export function retainEqualDropOutline(
+  previous: DropOutline | null,
+  next: DropOutline | null,
+): DropOutline | null {
+  if (previous === next) return previous;
+  if (previous === null || next === null) return next;
+  return previous.kind === next.kind &&
+    previous.top === next.top &&
+    previous.height === next.height
+    ? previous
+    : next;
+}
+
 /** Look up a row's display title across roots and sub-steps (ids are unique). */
 export function titleForRowId(
   steps: readonly EditGoalStep[],

--- a/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
+++ b/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
@@ -1,86 +1,41 @@
 /**
- * useEditGoalHierarchyDrag — the unified flattened-hierarchy drag coordinator
- * for the redesigned Edit Goal editor (issue #496, R2). Replaces the old
- * architecture of one root `useEditGoalDrag` plus one independent
- * `useEditGoalDrag` per parent, which could not receive child drag gestures at
- * the root level and therefore could not support drag promote or
- * move-between-parents (review #1).
- *
- * One hook, one flat index space, one shared row-geometry registry. Root and
- * sub-step rows alike register their screen-absolute geometry (R3) and receive
- * drag handlers keyed by row id. `classifyDrop` (reused unchanged, R1) decides
- * reorder vs. reparent from the flat list; this hook dispatches
- * `onReorderSteps` / `onReorderSubSteps` / `onReparentStep`.
- *
- * Always called (review #2). When `onReparentStep` is omitted the reparent
- * dispatch path no-ops and the hook collapses to local sibling reorder only
- * (R5); `canDragRow` also falls back to the old sibling-count behavior (R13).
- *
- * Drag-reparent decisions: `classifyDrop` takes a flat render-order list
- * (`flattenEditGoalSteps`), the dragged flat index, the hover flat index, and
- * an optional armed dwell target id. Dwell-arm (R12) arms a root header as a
- * demote target after `DWELL_ARM_MS` ms of hovering within its measured band.
- *
- * Geometry (R14/R15): rows register `{ absoluteY, height }` measured via
- * `measureInWindow` (called from `onLayout` and on drag-start refresh via
- * `refreshGeometry`). Drop outlines are returned as list-local `top` values
- * (`absoluteY - listOriginY`); an absolute `y` is never rendered directly as a
- * local `top`. During edge auto-scroll the pointer is normalized by the scroll
- * delta so the registry does not go stale. `dragScrollController` is optional
- * (omitted in Storybook — short lists don't scroll).
+ * Unified root/sub-step drag coordinator for the redesigned editor (#496).
+ * `classifyDrop` remains the hierarchy source of truth; focused helpers own
+ * geometry, auto-scroll, outlines, and dispatch. Dwell arms only inside a
+ * measured root band, and every absolute measurement refreshes at drag start.
  */
 import { useEffect, useRef, useState } from "react";
 import { AccessibilityInfo } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { triggerDragStart, triggerDragDrop } from "../../utils/haptics";
 import { classifyDrop } from "../StepList/classifyDrop";
-import {
-  clampScrollOffset,
-  getAutoScrollVelocity,
-  getEffectiveTranslationY,
-  type DragScrollController,
-} from "../StepList/dragAutoScroll";
 import { flattenEditGoalSteps } from "./flattenEditGoalSteps";
-import { toLocalTop } from "./geometryNormalize";
-import { reorderStepIds } from "./useEditGoalDrag";
-import type { EditGoalStep } from "./EditGoalView";
+import {
+  canDragForRowId,
+  computeDropOutline,
+  dispatchDropResult,
+  flatIndexAtY,
+  isArmableDwellTarget,
+  isInsideBand,
+  siblingReorder,
+  titleForRowId,
+  DWELL_ARM_MS,
+  type DropDispatchCallbacks,
+} from "./hierarchyDragHelpers";
+import type {
+  DropOutline,
+  UseEditGoalHierarchyDrag,
+  UseEditGoalHierarchyDragParams,
+} from "./useEditGoalHierarchyDragTypes";
+import { useHierarchyAutoScroll } from "./useHierarchyAutoScroll";
+import { useHierarchyGeometryRegistry } from "./useHierarchyGeometryRegistry";
 
-/** Dwell duration before a hovered root target arms for demote (R12). */
-const DWELL_ARM_MS = 220;
-
-export interface RowGeometry {
-  absoluteY: number;
-  height: number;
-}
-
-export type DropOutlineKind = "line" | "nested" | "group";
-
-export interface DropOutline {
-  top: number;
-  height: number;
-  kind: DropOutlineKind;
-}
-
-export interface UseEditGoalHierarchyDragParams {
-  steps: readonly EditGoalStep[];
-  onReorderSteps: (orderedStepIds: string[]) => void;
-  onReorderSubSteps: (
-    parentStepId: string,
-    orderedSubStepIds: string[],
-  ) => void;
-  /** Optional. When omitted the reparent path no-ops (R5). */
-  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
-  /** Optional auto-scroll controller; omitted in Storybook. */
-  dragScrollController?: DragScrollController;
-  /** Suspend drag while a row is being inline-edited (existing invariant). */
-  editingId?: string | null;
-  /** Builds the reorder announcement (1-based position). */
-  announceReorder?: (stepTitle: string, position: number) => string;
-  /** Announcement for a promote (child → root). */
-  announcePromote?: (stepTitle: string) => string;
-  /** Announcement for a demote / move-between-parents. */
-  announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
-}
+export type {
+  DropOutline,
+  RowGeometry,
+  UseEditGoalHierarchyDrag,
+  UseEditGoalHierarchyDragParams,
+} from "./useEditGoalHierarchyDragTypes";
 
 const defaultAnnounceReorder = (stepTitle: string, position: number) =>
   `Moved "${stepTitle}" to position ${position}`;
@@ -88,31 +43,6 @@ const defaultAnnouncePromote = (stepTitle: string) =>
   `Promoted "${stepTitle}" to top level`;
 const defaultAnnounceNestedUnder = (stepTitle: string, parentTitle: string) =>
   `Nested "${stepTitle}" under "${parentTitle}"`;
-
-export interface UseEditGoalHierarchyDrag {
-  draggedRowId: string | null;
-  isDragging: boolean;
-  armedTargetId: string | null;
-  dropOutline: DropOutline | null;
-  dragScrollCompensation: ReturnType<typeof useSharedValue<number>>;
-  /** Register a row's screen-absolute geometry (R3/R15). */
-  registerRowLayout: (rowId: string, geometry: RowGeometry) => void;
-  /** Register a remeasure callback so drag-start can refresh geometry (R15). */
-  registerRemeasure: (rowId: string, fn: (() => void) | null) => void;
-  /** Register the list container's screen-absolute origin (R14). */
-  registerListOrigin: (originY: number) => void;
-  /** Remeasure a row on demand (drag-start refresh). */
-  refreshGeometry: (rowId: string) => void;
-  /** Per-row drag eligibility from the flattened hierarchy (R13). */
-  canDragRow: (rowId: string) => boolean;
-  handleDragStart: (rowId: string) => void;
-  handleDragMove: (translationY: number, absoluteY: number) => void;
-  handleDragEnd: () => void;
-  /** Sibling-scoped ↑/↓ fallback (never reparents, R8). */
-  moveStep: (rowId: string, direction: 1 | -1) => void;
-  /** Flat index for a row id (for rows that need it). */
-  flatIndexForRowId: (rowId: string) => number;
-}
 
 export function useEditGoalHierarchyDrag({
   steps,
@@ -126,30 +56,15 @@ export function useEditGoalHierarchyDrag({
   announceNestedUnder = defaultAnnounceNestedUnder,
 }: UseEditGoalHierarchyDragParams): UseEditGoalHierarchyDrag {
   const reparentEnabled = onReparentStep !== undefined;
-
   const flatSteps = flattenEditGoalSteps(steps);
 
-  // Keep the latest flat list + steps in refs so gesture callbacks (which can
-  // outlive the render that created them) never read a stale list.
-  const flatStepsRef = useRef(flatSteps);
-  flatStepsRef.current = flatSteps;
-  const stepsRef = useRef(steps);
-  stepsRef.current = steps;
-  const editingIdRef = useRef(editingId);
-  editingIdRef.current = editingId;
-  const reparentEnabledRef = useRef(reparentEnabled);
-  reparentEnabledRef.current = reparentEnabled;
-
-  // Look up a row's display title across both roots and sub-steps (ids are
-  // unique across both). Used for accessibility announcements.
-  function titleForRowId(rowId: string): string {
-    for (const s of stepsRef.current) {
-      if (s.id === rowId) return s.title;
-      const sub = s.subSteps?.find((ss) => ss.id === rowId);
-      if (sub) return sub.title;
-    }
-    return rowId;
-  }
+  // Gesture callbacks may outlive the render that created them. Updating this
+  // ref during render is intentional: a layout effect leaves one stale event
+  // window and breaks same-tick inline-edit commits under React Native.
+  /* eslint-disable react-hooks/refs */
+  const latestRef = useRef({ flatSteps, steps, editingId, reparentEnabled });
+  latestRef.current = { flatSteps, steps, editingId, reparentEnabled };
+  /* eslint-enable react-hooks/refs */
 
   const [draggedRowId, setDraggedRowId] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -158,271 +73,131 @@ export function useEditGoalHierarchyDrag({
 
   const draggedRowIdRef = useRef<string | null>(null);
   const hoverRowIdRef = useRef<string | null>(null);
+  const hoverInBandRef = useRef(false); // finding 1: in-band flag
   const armedTargetIdRef = useRef<string | null>(null);
-  const geometryRef = useRef<Map<string, RowGeometry>>(new Map());
-  const remeasureRef = useRef<Map<string, () => void>>(new Map());
-  const listOriginRef = useRef(0);
-  const lastDragTranslationYRef = useRef(0);
-  const lastDragAbsoluteYRef = useRef<number | null>(null);
-  const dragStartScrollOffsetRef = useRef(0);
-  const autoScrollFrameRef = useRef<number | null>(null);
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hoverRowIdForDwellRef = useRef<string | null>(null);
   const dragScrollCompensation = useSharedValue(0);
+  const {
+    geometryRef,
+    listOriginRef,
+    registerRowLayout,
+    registerRemeasure,
+    registerListOrigin,
+    registerListOriginRemeasure,
+    refreshAllGeometry,
+  } = useHierarchyGeometryRegistry();
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
-      if (autoScrollFrameRef.current !== null) {
-        cancelAnimationFrame(autoScrollFrameRef.current);
-      }
-    };
-  }, []);
+    },
+    [],
+  );
 
-  const registerRowLayout = (rowId: string, geometry: RowGeometry) => {
-    geometryRef.current.set(rowId, geometry);
-  };
-
-  const registerRemeasure = (rowId: string, fn: (() => void) | null) => {
-    if (fn) remeasureRef.current.set(rowId, fn);
-    else remeasureRef.current.delete(rowId);
-  };
-
-  const registerListOrigin = (originY: number) => {
-    listOriginRef.current = originY;
-  };
-
-  const refreshGeometry = (rowId: string) => {
-    remeasureRef.current.get(rowId)?.();
-  };
-
-  // --- R13: per-row canDrag from the flattened hierarchy + edit state --------
-  const canDragRow = (rowId: string): boolean => {
-    if (editingIdRef.current !== null) return false;
-    const flat = flatStepsRef.current;
-    const idx = flat.findIndex((s) => s.id === rowId);
-    if (idx < 0) return false;
-    const step = flat[idx];
-    const isRoot = step.parentStepId === null;
-    const stepsNow = stepsRef.current;
-    if (isRoot) {
-      // A root needs ≥1 other root to reorder among or to nest under; a lone
-      // root (rootCount === 1) has no valid target in either mode (R13).
-      const rootCount = stepsNow.length;
-      return rootCount > 1;
-    }
-    // Sub-step: when reparent is enabled a lone child is draggable (it can
-    // promote / move between parents); otherwise the old sibling-count gate
-    // applies (R13).
-    const parent = stepsNow.find((s) => s.id === step.parentStepId);
-    const siblingCount = parent?.subSteps?.length ?? 0;
-    if (reparentEnabledRef.current) return true;
-    return siblingCount > 1;
-  };
-
-  // --- Helpers --------------------------------------------------------------
-
-  // Flat index of the row whose measured band contains `centerAbsoluteY`.
-  function flatIndexAtY(centerAbsoluteY: number, draggedFlat: number): number {
-    const flat = flatStepsRef.current;
-    for (let i = 0; i < flat.length; i++) {
-      const g = geometryRef.current.get(flat[i].id);
-      if (!g) continue;
-      if (centerAbsoluteY < g.absoluteY + g.height) return i;
-    }
-    if (flat.some((s) => geometryRef.current.has(s.id))) {
-      return flat.length - 1;
-    }
-    return draggedFlat;
+  function canDragRow(rowId: string): boolean {
+    return canDragForRowId(
+      latestRef.current.flatSteps,
+      latestRef.current.steps,
+      rowId,
+      latestRef.current.editingId,
+      latestRef.current.reparentEnabled,
+    );
   }
 
-  function stopAutoScroll() {
-    if (autoScrollFrameRef.current !== null) {
-      cancelAnimationFrame(autoScrollFrameRef.current);
-      autoScrollFrameRef.current = null;
-    }
-  }
+  // --- Hover + dwell (finding 1: in-band tracking) --------------------------
 
   function updateDragHover(translationY: number) {
     const draggedId = draggedRowIdRef.current;
     if (!draggedId) return;
-    const flat = flatStepsRef.current;
+    const flat = latestRef.current.flatSteps;
     const draggedFlat = flat.findIndex((s) => s.id === draggedId);
     if (draggedFlat < 0) return;
 
     const draggedG = geometryRef.current.get(draggedId);
-    let centerAbsoluteY: number;
-    if (draggedG) {
-      centerAbsoluteY = draggedG.absoluteY + translationY + draggedG.height / 2;
-    } else {
-      centerAbsoluteY = translationY;
-    }
-    const hoverFlat = flatIndexAtY(centerAbsoluteY, draggedFlat);
+    const centerAbsoluteY = draggedG
+      ? draggedG.absoluteY + translationY + draggedG.height / 2
+      : translationY;
+    const hoverFlat = flatIndexAtY(
+      flat,
+      geometryRef.current,
+      centerAbsoluteY,
+      draggedFlat,
+    );
     const hoverId = flat[hoverFlat]?.id ?? null;
+    const inBand = hoverId
+      ? isInsideBand(geometryRef.current, hoverId, centerAbsoluteY)
+      : false;
 
-    if (hoverId !== hoverRowIdRef.current) {
+    // Finding 1: restart/disarm on either hovered-row-id OR in-band change.
+    if (
+      hoverId !== hoverRowIdRef.current ||
+      inBand !== hoverInBandRef.current
+    ) {
       hoverRowIdRef.current = hoverId;
-      // Dwell disarm on row change.
+      hoverInBandRef.current = inBand;
       if (dwellTimerRef.current) {
         clearTimeout(dwellTimerRef.current);
         dwellTimerRef.current = null;
       }
       armedTargetIdRef.current = null;
       setArmedTargetId(null);
-      hoverRowIdForDwellRef.current = hoverId;
 
-      // Arm only on a valid dwell target: a root, not the dragged step, while
-      // dragging a leaf (mirrors classifyDrop's dwell rule).
-      const draggedStep = flat[draggedFlat];
-      const draggedHasChildren =
-        draggedStep.parentStepId === null &&
-        (stepsRef.current.find((s) => s.id === draggedId)?.subSteps?.length ??
-          0) > 0;
-      const hoveredStep = flat[hoverFlat];
-      const armable =
-        reparentEnabledRef.current &&
-        !!hoveredStep &&
-        hoveredStep.parentStepId === null &&
-        hoveredStep.id !== draggedId &&
-        !draggedHasChildren;
-      if (armable) {
+      if (
+        isArmableDwellTarget(
+          flat,
+          latestRef.current.steps,
+          draggedId,
+          hoverId,
+          inBand,
+          latestRef.current.reparentEnabled,
+        )
+      ) {
+        const targetId = hoverId!;
         dwellTimerRef.current = setTimeout(() => {
           dwellTimerRef.current = null;
           if (draggedRowIdRef.current === null) return;
-          armedTargetIdRef.current = hoveredStep!.id;
-          setArmedTargetId(hoveredStep!.id);
+          armedTargetIdRef.current = targetId;
+          setArmedTargetId(targetId);
         }, DWELL_ARM_MS);
       }
     }
 
-    // Drop outline preview via classifyDrop (suppressed while armed).
-    if (armedTargetIdRef.current !== null) {
-      setDropOutline(null);
-      return;
-    }
-    if (hoverFlat === draggedFlat) {
-      setDropOutline(null);
-      return;
-    }
-    const preview = classifyDrop(flat, draggedFlat, hoverFlat, null);
-    if (preview.kind === "none") {
-      setDropOutline(null);
-      return;
-    }
-    const slotG = geometryRef.current.get(flat[hoverFlat]?.id ?? "");
-    if (!slotG) {
-      setDropOutline(null);
-      return;
-    }
-    const localTop = toLocalTop(slotG.absoluteY, listOriginRef.current);
-    const isNested =
-      preview.kind === "reparent"
-        ? preview.newParentStepId !== null
-        : preview.parentStepId !== null;
-    // Group reorder of a root-with-children: outline the whole destination group.
-    const draggedStep = flat[draggedFlat];
-    const draggedHasChildren =
-      draggedStep.parentStepId === null &&
-      (stepsRef.current.find((s) => s.id === draggedId)?.subSteps?.length ??
-        0) > 0;
-    const isGroupReorder =
-      draggedHasChildren &&
-      preview.kind === "reorder" &&
-      preview.parentStepId === null;
-    if (isGroupReorder) {
-      // Outline from the target root header through its last child.
-      const targetRootId = flat[hoverFlat].parentStepId ?? flat[hoverFlat].id;
-      const groupStart = flat.findIndex((s) => s.id === targetRootId);
-      let groupEnd = groupStart;
-      while (
-        groupEnd + 1 < flat.length &&
-        flat[groupEnd + 1].parentStepId === targetRootId
-      ) {
-        groupEnd++;
-      }
-      const startG = geometryRef.current.get(flat[groupStart].id);
-      const endG = geometryRef.current.get(flat[groupEnd].id);
-      if (startG && endG) {
-        setDropOutline({
-          top: toLocalTop(startG.absoluteY, listOriginRef.current),
-          height: endG.absoluteY + endG.height - startG.absoluteY,
-          kind: "group",
-        });
-      } else {
-        setDropOutline(null);
-      }
-    } else if (isNested) {
-      setDropOutline({ top: localTop, height: slotG.height, kind: "nested" });
-    } else {
-      const top =
-        hoverFlat > draggedFlat
-          ? slotG.absoluteY + slotG.height
-          : slotG.absoluteY;
-      setDropOutline({
-        top: toLocalTop(top, listOriginRef.current),
-        height: 3,
-        kind: "line",
-      });
-    }
-  }
-
-  function runAutoScrollFrame() {
-    autoScrollFrameRef.current = null;
-    const pointerY = lastDragAbsoluteYRef.current;
-    if (!dragScrollController || pointerY === null) return;
-    const metrics = dragScrollController.getMetrics();
-    const velocity = getAutoScrollVelocity(pointerY, metrics);
-    if (velocity === 0) return;
-    const nextOffset = clampScrollOffset(metrics.offsetY + velocity, metrics);
-    if (nextOffset === metrics.offsetY) return;
-    dragScrollController.scrollTo(nextOffset);
-    const scrollDelta = nextOffset - dragStartScrollOffsetRef.current;
-    dragScrollCompensation.value = scrollDelta;
-    updateDragHover(
-      getEffectiveTranslationY(
-        lastDragTranslationYRef.current,
-        nextOffset,
-        dragStartScrollOffsetRef.current,
+    // Drop outline preview (suppressed while armed).
+    setDropOutline(
+      computeDropOutline(
+        flat,
+        latestRef.current.steps,
+        geometryRef.current,
+        listOriginRef.current,
+        draggedId,
+        draggedFlat,
+        hoverFlat,
+        armedTargetIdRef.current !== null,
       ),
     );
-    autoScrollFrameRef.current = requestAnimationFrame(runAutoScrollFrame);
   }
 
-  function syncAutoScroll() {
-    const pointerY = lastDragAbsoluteYRef.current;
-    if (!dragScrollController || pointerY === null) {
-      stopAutoScroll();
-      return;
-    }
-    const velocity = getAutoScrollVelocity(
-      pointerY,
-      dragScrollController.getMetrics(),
-    );
-    if (velocity === 0) {
-      stopAutoScroll();
-    } else if (autoScrollFrameRef.current === null) {
-      autoScrollFrameRef.current = requestAnimationFrame(runAutoScrollFrame);
-    }
-  }
+  const autoScroll = useHierarchyAutoScroll(
+    dragScrollController,
+    dragScrollCompensation,
+    updateDragHover,
+  );
 
   // --- Gesture handlers -----------------------------------------------------
 
   function handleDragStart(rowId: string) {
-    // R15: remeasure the dragged row on drag start so the registry is fresh.
-    refreshGeometry(rowId);
+    // Finding 2: refresh the list origin + every registered row so the
+    // registry is in one coordinate frame before any hover decision.
+    refreshAllGeometry();
     draggedRowIdRef.current = rowId;
     hoverRowIdRef.current = rowId;
-    hoverRowIdForDwellRef.current = rowId;
+    hoverInBandRef.current = false;
     setDraggedRowId(rowId);
     setIsDragging(true);
     setArmedTargetId(null);
     setDropOutline(null);
     armedTargetIdRef.current = null;
-    lastDragTranslationYRef.current = 0;
-    lastDragAbsoluteYRef.current = null;
-    dragStartScrollOffsetRef.current =
-      dragScrollController?.getMetrics().offsetY ?? 0;
-    dragScrollCompensation.value = 0;
+    autoScroll.start();
     if (dwellTimerRef.current) {
       clearTimeout(dwellTimerRef.current);
       dwellTimerRef.current = null;
@@ -431,29 +206,11 @@ export function useEditGoalHierarchyDrag({
   }
 
   function handleDragMove(translationY: number, absoluteY: number) {
-    lastDragTranslationYRef.current = translationY;
-    lastDragAbsoluteYRef.current = absoluteY;
-    const currentScrollY =
-      dragScrollController?.getMetrics().offsetY ??
-      dragStartScrollOffsetRef.current;
-    dragScrollCompensation.value =
-      currentScrollY - dragStartScrollOffsetRef.current;
-    // R14: normalize the pointer by the scroll delta when a controller is
-    // present so the screen-absolute registry does not go stale. Without a
-    // controller (Storybook) the delta is 0 and this is a passthrough.
-    const effective = dragScrollController
-      ? getEffectiveTranslationY(
-          translationY,
-          currentScrollY,
-          dragStartScrollOffsetRef.current,
-        )
-      : translationY;
-    updateDragHover(effective);
-    syncAutoScroll();
+    autoScroll.move(translationY, absoluteY);
   }
 
   function handleDragEnd() {
-    stopAutoScroll();
+    autoScroll.stop();
     if (dwellTimerRef.current) {
       clearTimeout(dwellTimerRef.current);
       dwellTimerRef.current = null;
@@ -461,7 +218,7 @@ export function useEditGoalHierarchyDrag({
     const draggedId = draggedRowIdRef.current;
     const hoverId = hoverRowIdRef.current;
     if (draggedId && hoverId) {
-      const flat = flatStepsRef.current;
+      const flat = latestRef.current.flatSteps;
       const draggedFlat = flat.findIndex((s) => s.id === draggedId);
       const hoverFlat = flat.findIndex((s) => s.id === hoverId);
       if (draggedFlat >= 0 && hoverFlat >= 0) {
@@ -471,91 +228,53 @@ export function useEditGoalHierarchyDrag({
           hoverFlat,
           armedTargetIdRef.current,
         );
-        let dispatched = false;
-        if (result.kind === "reorder") {
-          if (result.parentStepId === null) {
-            onReorderSteps(result.orderedIds);
-            dispatched = true;
-          } else {
-            onReorderSubSteps(result.parentStepId, result.orderedIds);
-            dispatched = true;
-          }
-        } else if (result.kind === "reparent") {
-          onReparentStep?.(result.stepId, result.newParentStepId);
-          dispatched = onReparentStep !== undefined;
-        }
-        if (dispatched) {
-          triggerDragDrop();
-          if (result.kind === "reparent") {
-            const stepTitle = titleForRowId(result.stepId);
-            if (result.newParentStepId === null) {
-              AccessibilityInfo.announceForAccessibility(
-                announcePromote(stepTitle),
-              );
-            } else {
-              const parentTitle =
-                stepsRef.current.find((s) => s.id === result.newParentStepId)
-                  ?.title ?? "";
-              AccessibilityInfo.announceForAccessibility(
-                announceNestedUnder(stepTitle, parentTitle),
-              );
-            }
-          } else if (result.kind === "reorder") {
-            const draggedTitle = titleForRowId(draggedId);
-            AccessibilityInfo.announceForAccessibility(
-              announceReorder(
-                draggedTitle,
-                result.orderedIds.indexOf(draggedId) + 1,
-              ),
-            );
-          }
-        }
+        const callbacks: DropDispatchCallbacks = {
+          onReorderSteps,
+          onReorderSubSteps,
+          onReparentStep,
+          announceReorder,
+          announcePromote,
+          announceNestedUnder,
+        };
+        dispatchDropResult(
+          result,
+          flat,
+          latestRef.current.steps,
+          draggedId,
+          callbacks,
+        );
       }
     }
     draggedRowIdRef.current = null;
     hoverRowIdRef.current = null;
-    hoverRowIdForDwellRef.current = null;
+    hoverInBandRef.current = false;
     setDraggedRowId(null);
     setIsDragging(false);
     armedTargetIdRef.current = null;
     setArmedTargetId(null);
     setDropOutline(null);
-    lastDragAbsoluteYRef.current = null;
-    dragScrollCompensation.value = 0;
+    autoScroll.reset();
   }
 
   // --- Sibling-scoped ↑/↓ (R8: never reparents) ----------------------------
-  function moveStep(rowId: string, direction: 1 | -1) {
-    if (editingIdRef.current !== null) return;
-    const flat = flatStepsRef.current;
-    const idx = flat.findIndex((s) => s.id === rowId);
-    if (idx < 0) return;
-    const step = flat[idx];
-    const parent = step.parentStepId ?? null;
-    const group = flat.filter((s) => (s.parentStepId ?? null) === parent);
-    const pos = group.findIndex((s) => s.id === rowId);
-    const swapWith = pos + direction;
-    if (swapWith < 0 || swapWith >= group.length) return;
-    const reordered = [...group];
-    [reordered[pos], reordered[swapWith]] = [
-      reordered[swapWith],
-      reordered[pos],
-    ];
-    const ids = reordered.map((s) => s.id);
-    if (parent === null) {
-      onReorderSteps(ids);
-    } else {
-      onReorderSubSteps(parent, ids);
-    }
-    triggerDragDrop();
-    const title = titleForRowId(rowId);
-    AccessibilityInfo.announceForAccessibility(
-      announceReorder(title, swapWith + 1),
-    );
-  }
 
-  function flatIndexForRowId(rowId: string): number {
-    return flatSteps.findIndex((s) => s.id === rowId);
+  function moveStep(rowId: string, direction: 1 | -1) {
+    if (latestRef.current.editingId !== null) return;
+    const result = siblingReorder(
+      latestRef.current.flatSteps,
+      rowId,
+      direction,
+    );
+    if (!result) return;
+    if (result.parent === null) onReorderSteps(result.orderedIds);
+    else onReorderSubSteps(result.parent, result.orderedIds);
+    triggerDragDrop(); // haptic for the move
+    AccessibilityInfo.announceForAccessibility(
+      announceReorder(
+        titleForRowId(latestRef.current.steps, rowId),
+        result.newPosition,
+      ),
+    );
   }
 
   return {
@@ -567,15 +286,11 @@ export function useEditGoalHierarchyDrag({
     registerRowLayout,
     registerRemeasure,
     registerListOrigin,
-    refreshGeometry,
+    registerListOriginRemeasure,
     canDragRow,
     handleDragStart,
     handleDragMove,
     handleDragEnd,
     moveStep,
-    flatIndexForRowId,
   };
 }
-
-// Re-export for consumers that previously imported from useEditGoalDrag.
-export { reorderStepIds };

--- a/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
+++ b/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
@@ -140,6 +140,17 @@ export function useEditGoalHierarchyDrag({
   const reparentEnabledRef = useRef(reparentEnabled);
   reparentEnabledRef.current = reparentEnabled;
 
+  // Look up a row's display title across both roots and sub-steps (ids are
+  // unique across both). Used for accessibility announcements.
+  function titleForRowId(rowId: string): string {
+    for (const s of stepsRef.current) {
+      if (s.id === rowId) return s.title;
+      const sub = s.subSteps?.find((ss) => ss.id === rowId);
+      if (sub) return sub.title;
+    }
+    return rowId;
+  }
+
   const [draggedRowId, setDraggedRowId] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [armedTargetId, setArmedTargetId] = useState<string | null>(null);
@@ -476,9 +487,7 @@ export function useEditGoalHierarchyDrag({
         if (dispatched) {
           triggerDragDrop();
           if (result.kind === "reparent") {
-            const stepTitle =
-              stepsRef.current.find((s) => s.id === result.stepId)?.title ??
-              result.stepId;
+            const stepTitle = titleForRowId(result.stepId);
             if (result.newParentStepId === null) {
               AccessibilityInfo.announceForAccessibility(
                 announcePromote(stepTitle),
@@ -492,9 +501,7 @@ export function useEditGoalHierarchyDrag({
               );
             }
           } else if (result.kind === "reorder") {
-            const draggedTitle =
-              stepsRef.current.find((s) => s.id === draggedId)?.title ??
-              draggedId;
+            const draggedTitle = titleForRowId(draggedId);
             AccessibilityInfo.announceForAccessibility(
               announceReorder(
                 draggedTitle,
@@ -541,7 +548,7 @@ export function useEditGoalHierarchyDrag({
       onReorderSubSteps(parent, ids);
     }
     triggerDragDrop();
-    const title = stepsRef.current.find((s) => s.id === rowId)?.title ?? rowId;
+    const title = titleForRowId(rowId);
     AccessibilityInfo.announceForAccessibility(
       announceReorder(title, swapWith + 1),
     );

--- a/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
+++ b/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
@@ -17,6 +17,7 @@ import {
   flatIndexAtY,
   isArmableDwellTarget,
   isInsideBand,
+  retainEqualDropOutline,
   siblingReorder,
   titleForRowId,
   DWELL_ARM_MS,
@@ -163,17 +164,18 @@ export function useEditGoalHierarchyDrag({
     }
 
     // Drop outline preview (suppressed while armed).
-    setDropOutline(
-      computeDropOutline(
-        flat,
-        latestRef.current.steps,
-        geometryRef.current,
-        listOriginRef.current,
-        draggedId,
-        draggedFlat,
-        hoverFlat,
-        armedTargetIdRef.current !== null,
-      ),
+    const nextDropOutline = computeDropOutline(
+      flat,
+      latestRef.current.steps,
+      geometryRef.current,
+      listOriginRef.current,
+      draggedId,
+      draggedFlat,
+      hoverFlat,
+      armedTargetIdRef.current !== null,
+    );
+    setDropOutline((previous) =>
+      retainEqualDropOutline(previous, nextDropOutline),
     );
   }
 

--- a/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
+++ b/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDrag.ts
@@ -1,0 +1,574 @@
+/**
+ * useEditGoalHierarchyDrag — the unified flattened-hierarchy drag coordinator
+ * for the redesigned Edit Goal editor (issue #496, R2). Replaces the old
+ * architecture of one root `useEditGoalDrag` plus one independent
+ * `useEditGoalDrag` per parent, which could not receive child drag gestures at
+ * the root level and therefore could not support drag promote or
+ * move-between-parents (review #1).
+ *
+ * One hook, one flat index space, one shared row-geometry registry. Root and
+ * sub-step rows alike register their screen-absolute geometry (R3) and receive
+ * drag handlers keyed by row id. `classifyDrop` (reused unchanged, R1) decides
+ * reorder vs. reparent from the flat list; this hook dispatches
+ * `onReorderSteps` / `onReorderSubSteps` / `onReparentStep`.
+ *
+ * Always called (review #2). When `onReparentStep` is omitted the reparent
+ * dispatch path no-ops and the hook collapses to local sibling reorder only
+ * (R5); `canDragRow` also falls back to the old sibling-count behavior (R13).
+ *
+ * Drag-reparent decisions: `classifyDrop` takes a flat render-order list
+ * (`flattenEditGoalSteps`), the dragged flat index, the hover flat index, and
+ * an optional armed dwell target id. Dwell-arm (R12) arms a root header as a
+ * demote target after `DWELL_ARM_MS` ms of hovering within its measured band.
+ *
+ * Geometry (R14/R15): rows register `{ absoluteY, height }` measured via
+ * `measureInWindow` (called from `onLayout` and on drag-start refresh via
+ * `refreshGeometry`). Drop outlines are returned as list-local `top` values
+ * (`absoluteY - listOriginY`); an absolute `y` is never rendered directly as a
+ * local `top`. During edge auto-scroll the pointer is normalized by the scroll
+ * delta so the registry does not go stale. `dragScrollController` is optional
+ * (omitted in Storybook — short lists don't scroll).
+ */
+import { useEffect, useRef, useState } from "react";
+import { AccessibilityInfo } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { triggerDragStart, triggerDragDrop } from "../../utils/haptics";
+import { classifyDrop } from "../StepList/classifyDrop";
+import {
+  clampScrollOffset,
+  getAutoScrollVelocity,
+  getEffectiveTranslationY,
+  type DragScrollController,
+} from "../StepList/dragAutoScroll";
+import { flattenEditGoalSteps } from "./flattenEditGoalSteps";
+import { toLocalTop } from "./geometryNormalize";
+import { reorderStepIds } from "./useEditGoalDrag";
+import type { EditGoalStep } from "./EditGoalView";
+
+/** Dwell duration before a hovered root target arms for demote (R12). */
+const DWELL_ARM_MS = 220;
+
+export interface RowGeometry {
+  absoluteY: number;
+  height: number;
+}
+
+export type DropOutlineKind = "line" | "nested" | "group";
+
+export interface DropOutline {
+  top: number;
+  height: number;
+  kind: DropOutlineKind;
+}
+
+export interface UseEditGoalHierarchyDragParams {
+  steps: readonly EditGoalStep[];
+  onReorderSteps: (orderedStepIds: string[]) => void;
+  onReorderSubSteps: (
+    parentStepId: string,
+    orderedSubStepIds: string[],
+  ) => void;
+  /** Optional. When omitted the reparent path no-ops (R5). */
+  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
+  /** Optional auto-scroll controller; omitted in Storybook. */
+  dragScrollController?: DragScrollController;
+  /** Suspend drag while a row is being inline-edited (existing invariant). */
+  editingId?: string | null;
+  /** Builds the reorder announcement (1-based position). */
+  announceReorder?: (stepTitle: string, position: number) => string;
+  /** Announcement for a promote (child → root). */
+  announcePromote?: (stepTitle: string) => string;
+  /** Announcement for a demote / move-between-parents. */
+  announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
+}
+
+const defaultAnnounceReorder = (stepTitle: string, position: number) =>
+  `Moved "${stepTitle}" to position ${position}`;
+const defaultAnnouncePromote = (stepTitle: string) =>
+  `Promoted "${stepTitle}" to top level`;
+const defaultAnnounceNestedUnder = (stepTitle: string, parentTitle: string) =>
+  `Nested "${stepTitle}" under "${parentTitle}"`;
+
+export interface UseEditGoalHierarchyDrag {
+  draggedRowId: string | null;
+  isDragging: boolean;
+  armedTargetId: string | null;
+  dropOutline: DropOutline | null;
+  dragScrollCompensation: ReturnType<typeof useSharedValue<number>>;
+  /** Register a row's screen-absolute geometry (R3/R15). */
+  registerRowLayout: (rowId: string, geometry: RowGeometry) => void;
+  /** Register a remeasure callback so drag-start can refresh geometry (R15). */
+  registerRemeasure: (rowId: string, fn: (() => void) | null) => void;
+  /** Register the list container's screen-absolute origin (R14). */
+  registerListOrigin: (originY: number) => void;
+  /** Remeasure a row on demand (drag-start refresh). */
+  refreshGeometry: (rowId: string) => void;
+  /** Per-row drag eligibility from the flattened hierarchy (R13). */
+  canDragRow: (rowId: string) => boolean;
+  handleDragStart: (rowId: string) => void;
+  handleDragMove: (translationY: number, absoluteY: number) => void;
+  handleDragEnd: () => void;
+  /** Sibling-scoped ↑/↓ fallback (never reparents, R8). */
+  moveStep: (rowId: string, direction: 1 | -1) => void;
+  /** Flat index for a row id (for rows that need it). */
+  flatIndexForRowId: (rowId: string) => number;
+}
+
+export function useEditGoalHierarchyDrag({
+  steps,
+  onReorderSteps,
+  onReorderSubSteps,
+  onReparentStep,
+  dragScrollController,
+  editingId = null,
+  announceReorder = defaultAnnounceReorder,
+  announcePromote = defaultAnnouncePromote,
+  announceNestedUnder = defaultAnnounceNestedUnder,
+}: UseEditGoalHierarchyDragParams): UseEditGoalHierarchyDrag {
+  const reparentEnabled = onReparentStep !== undefined;
+
+  const flatSteps = flattenEditGoalSteps(steps);
+
+  // Keep the latest flat list + steps in refs so gesture callbacks (which can
+  // outlive the render that created them) never read a stale list.
+  const flatStepsRef = useRef(flatSteps);
+  flatStepsRef.current = flatSteps;
+  const stepsRef = useRef(steps);
+  stepsRef.current = steps;
+  const editingIdRef = useRef(editingId);
+  editingIdRef.current = editingId;
+  const reparentEnabledRef = useRef(reparentEnabled);
+  reparentEnabledRef.current = reparentEnabled;
+
+  const [draggedRowId, setDraggedRowId] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [armedTargetId, setArmedTargetId] = useState<string | null>(null);
+  const [dropOutline, setDropOutline] = useState<DropOutline | null>(null);
+
+  const draggedRowIdRef = useRef<string | null>(null);
+  const hoverRowIdRef = useRef<string | null>(null);
+  const armedTargetIdRef = useRef<string | null>(null);
+  const geometryRef = useRef<Map<string, RowGeometry>>(new Map());
+  const remeasureRef = useRef<Map<string, () => void>>(new Map());
+  const listOriginRef = useRef(0);
+  const lastDragTranslationYRef = useRef(0);
+  const lastDragAbsoluteYRef = useRef<number | null>(null);
+  const dragStartScrollOffsetRef = useRef(0);
+  const autoScrollFrameRef = useRef<number | null>(null);
+  const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoverRowIdForDwellRef = useRef<string | null>(null);
+  const dragScrollCompensation = useSharedValue(0);
+
+  useEffect(() => {
+    return () => {
+      if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
+      if (autoScrollFrameRef.current !== null) {
+        cancelAnimationFrame(autoScrollFrameRef.current);
+      }
+    };
+  }, []);
+
+  const registerRowLayout = (rowId: string, geometry: RowGeometry) => {
+    geometryRef.current.set(rowId, geometry);
+  };
+
+  const registerRemeasure = (rowId: string, fn: (() => void) | null) => {
+    if (fn) remeasureRef.current.set(rowId, fn);
+    else remeasureRef.current.delete(rowId);
+  };
+
+  const registerListOrigin = (originY: number) => {
+    listOriginRef.current = originY;
+  };
+
+  const refreshGeometry = (rowId: string) => {
+    remeasureRef.current.get(rowId)?.();
+  };
+
+  // --- R13: per-row canDrag from the flattened hierarchy + edit state --------
+  const canDragRow = (rowId: string): boolean => {
+    if (editingIdRef.current !== null) return false;
+    const flat = flatStepsRef.current;
+    const idx = flat.findIndex((s) => s.id === rowId);
+    if (idx < 0) return false;
+    const step = flat[idx];
+    const isRoot = step.parentStepId === null;
+    const stepsNow = stepsRef.current;
+    if (isRoot) {
+      // A root needs ≥1 other root to reorder among or to nest under; a lone
+      // root (rootCount === 1) has no valid target in either mode (R13).
+      const rootCount = stepsNow.length;
+      return rootCount > 1;
+    }
+    // Sub-step: when reparent is enabled a lone child is draggable (it can
+    // promote / move between parents); otherwise the old sibling-count gate
+    // applies (R13).
+    const parent = stepsNow.find((s) => s.id === step.parentStepId);
+    const siblingCount = parent?.subSteps?.length ?? 0;
+    if (reparentEnabledRef.current) return true;
+    return siblingCount > 1;
+  };
+
+  // --- Helpers --------------------------------------------------------------
+
+  // Flat index of the row whose measured band contains `centerAbsoluteY`.
+  function flatIndexAtY(centerAbsoluteY: number, draggedFlat: number): number {
+    const flat = flatStepsRef.current;
+    for (let i = 0; i < flat.length; i++) {
+      const g = geometryRef.current.get(flat[i].id);
+      if (!g) continue;
+      if (centerAbsoluteY < g.absoluteY + g.height) return i;
+    }
+    if (flat.some((s) => geometryRef.current.has(s.id))) {
+      return flat.length - 1;
+    }
+    return draggedFlat;
+  }
+
+  function stopAutoScroll() {
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
+    }
+  }
+
+  function updateDragHover(translationY: number) {
+    const draggedId = draggedRowIdRef.current;
+    if (!draggedId) return;
+    const flat = flatStepsRef.current;
+    const draggedFlat = flat.findIndex((s) => s.id === draggedId);
+    if (draggedFlat < 0) return;
+
+    const draggedG = geometryRef.current.get(draggedId);
+    let centerAbsoluteY: number;
+    if (draggedG) {
+      centerAbsoluteY = draggedG.absoluteY + translationY + draggedG.height / 2;
+    } else {
+      centerAbsoluteY = translationY;
+    }
+    const hoverFlat = flatIndexAtY(centerAbsoluteY, draggedFlat);
+    const hoverId = flat[hoverFlat]?.id ?? null;
+
+    if (hoverId !== hoverRowIdRef.current) {
+      hoverRowIdRef.current = hoverId;
+      // Dwell disarm on row change.
+      if (dwellTimerRef.current) {
+        clearTimeout(dwellTimerRef.current);
+        dwellTimerRef.current = null;
+      }
+      armedTargetIdRef.current = null;
+      setArmedTargetId(null);
+      hoverRowIdForDwellRef.current = hoverId;
+
+      // Arm only on a valid dwell target: a root, not the dragged step, while
+      // dragging a leaf (mirrors classifyDrop's dwell rule).
+      const draggedStep = flat[draggedFlat];
+      const draggedHasChildren =
+        draggedStep.parentStepId === null &&
+        (stepsRef.current.find((s) => s.id === draggedId)?.subSteps?.length ??
+          0) > 0;
+      const hoveredStep = flat[hoverFlat];
+      const armable =
+        reparentEnabledRef.current &&
+        !!hoveredStep &&
+        hoveredStep.parentStepId === null &&
+        hoveredStep.id !== draggedId &&
+        !draggedHasChildren;
+      if (armable) {
+        dwellTimerRef.current = setTimeout(() => {
+          dwellTimerRef.current = null;
+          if (draggedRowIdRef.current === null) return;
+          armedTargetIdRef.current = hoveredStep!.id;
+          setArmedTargetId(hoveredStep!.id);
+        }, DWELL_ARM_MS);
+      }
+    }
+
+    // Drop outline preview via classifyDrop (suppressed while armed).
+    if (armedTargetIdRef.current !== null) {
+      setDropOutline(null);
+      return;
+    }
+    if (hoverFlat === draggedFlat) {
+      setDropOutline(null);
+      return;
+    }
+    const preview = classifyDrop(flat, draggedFlat, hoverFlat, null);
+    if (preview.kind === "none") {
+      setDropOutline(null);
+      return;
+    }
+    const slotG = geometryRef.current.get(flat[hoverFlat]?.id ?? "");
+    if (!slotG) {
+      setDropOutline(null);
+      return;
+    }
+    const localTop = toLocalTop(slotG.absoluteY, listOriginRef.current);
+    const isNested =
+      preview.kind === "reparent"
+        ? preview.newParentStepId !== null
+        : preview.parentStepId !== null;
+    // Group reorder of a root-with-children: outline the whole destination group.
+    const draggedStep = flat[draggedFlat];
+    const draggedHasChildren =
+      draggedStep.parentStepId === null &&
+      (stepsRef.current.find((s) => s.id === draggedId)?.subSteps?.length ??
+        0) > 0;
+    const isGroupReorder =
+      draggedHasChildren &&
+      preview.kind === "reorder" &&
+      preview.parentStepId === null;
+    if (isGroupReorder) {
+      // Outline from the target root header through its last child.
+      const targetRootId = flat[hoverFlat].parentStepId ?? flat[hoverFlat].id;
+      const groupStart = flat.findIndex((s) => s.id === targetRootId);
+      let groupEnd = groupStart;
+      while (
+        groupEnd + 1 < flat.length &&
+        flat[groupEnd + 1].parentStepId === targetRootId
+      ) {
+        groupEnd++;
+      }
+      const startG = geometryRef.current.get(flat[groupStart].id);
+      const endG = geometryRef.current.get(flat[groupEnd].id);
+      if (startG && endG) {
+        setDropOutline({
+          top: toLocalTop(startG.absoluteY, listOriginRef.current),
+          height: endG.absoluteY + endG.height - startG.absoluteY,
+          kind: "group",
+        });
+      } else {
+        setDropOutline(null);
+      }
+    } else if (isNested) {
+      setDropOutline({ top: localTop, height: slotG.height, kind: "nested" });
+    } else {
+      const top =
+        hoverFlat > draggedFlat
+          ? slotG.absoluteY + slotG.height
+          : slotG.absoluteY;
+      setDropOutline({
+        top: toLocalTop(top, listOriginRef.current),
+        height: 3,
+        kind: "line",
+      });
+    }
+  }
+
+  function runAutoScrollFrame() {
+    autoScrollFrameRef.current = null;
+    const pointerY = lastDragAbsoluteYRef.current;
+    if (!dragScrollController || pointerY === null) return;
+    const metrics = dragScrollController.getMetrics();
+    const velocity = getAutoScrollVelocity(pointerY, metrics);
+    if (velocity === 0) return;
+    const nextOffset = clampScrollOffset(metrics.offsetY + velocity, metrics);
+    if (nextOffset === metrics.offsetY) return;
+    dragScrollController.scrollTo(nextOffset);
+    const scrollDelta = nextOffset - dragStartScrollOffsetRef.current;
+    dragScrollCompensation.value = scrollDelta;
+    updateDragHover(
+      getEffectiveTranslationY(
+        lastDragTranslationYRef.current,
+        nextOffset,
+        dragStartScrollOffsetRef.current,
+      ),
+    );
+    autoScrollFrameRef.current = requestAnimationFrame(runAutoScrollFrame);
+  }
+
+  function syncAutoScroll() {
+    const pointerY = lastDragAbsoluteYRef.current;
+    if (!dragScrollController || pointerY === null) {
+      stopAutoScroll();
+      return;
+    }
+    const velocity = getAutoScrollVelocity(
+      pointerY,
+      dragScrollController.getMetrics(),
+    );
+    if (velocity === 0) {
+      stopAutoScroll();
+    } else if (autoScrollFrameRef.current === null) {
+      autoScrollFrameRef.current = requestAnimationFrame(runAutoScrollFrame);
+    }
+  }
+
+  // --- Gesture handlers -----------------------------------------------------
+
+  function handleDragStart(rowId: string) {
+    // R15: remeasure the dragged row on drag start so the registry is fresh.
+    refreshGeometry(rowId);
+    draggedRowIdRef.current = rowId;
+    hoverRowIdRef.current = rowId;
+    hoverRowIdForDwellRef.current = rowId;
+    setDraggedRowId(rowId);
+    setIsDragging(true);
+    setArmedTargetId(null);
+    setDropOutline(null);
+    armedTargetIdRef.current = null;
+    lastDragTranslationYRef.current = 0;
+    lastDragAbsoluteYRef.current = null;
+    dragStartScrollOffsetRef.current =
+      dragScrollController?.getMetrics().offsetY ?? 0;
+    dragScrollCompensation.value = 0;
+    if (dwellTimerRef.current) {
+      clearTimeout(dwellTimerRef.current);
+      dwellTimerRef.current = null;
+    }
+    triggerDragStart();
+  }
+
+  function handleDragMove(translationY: number, absoluteY: number) {
+    lastDragTranslationYRef.current = translationY;
+    lastDragAbsoluteYRef.current = absoluteY;
+    const currentScrollY =
+      dragScrollController?.getMetrics().offsetY ??
+      dragStartScrollOffsetRef.current;
+    dragScrollCompensation.value =
+      currentScrollY - dragStartScrollOffsetRef.current;
+    // R14: normalize the pointer by the scroll delta when a controller is
+    // present so the screen-absolute registry does not go stale. Without a
+    // controller (Storybook) the delta is 0 and this is a passthrough.
+    const effective = dragScrollController
+      ? getEffectiveTranslationY(
+          translationY,
+          currentScrollY,
+          dragStartScrollOffsetRef.current,
+        )
+      : translationY;
+    updateDragHover(effective);
+    syncAutoScroll();
+  }
+
+  function handleDragEnd() {
+    stopAutoScroll();
+    if (dwellTimerRef.current) {
+      clearTimeout(dwellTimerRef.current);
+      dwellTimerRef.current = null;
+    }
+    const draggedId = draggedRowIdRef.current;
+    const hoverId = hoverRowIdRef.current;
+    if (draggedId && hoverId) {
+      const flat = flatStepsRef.current;
+      const draggedFlat = flat.findIndex((s) => s.id === draggedId);
+      const hoverFlat = flat.findIndex((s) => s.id === hoverId);
+      if (draggedFlat >= 0 && hoverFlat >= 0) {
+        const result = classifyDrop(
+          flat,
+          draggedFlat,
+          hoverFlat,
+          armedTargetIdRef.current,
+        );
+        let dispatched = false;
+        if (result.kind === "reorder") {
+          if (result.parentStepId === null) {
+            onReorderSteps(result.orderedIds);
+            dispatched = true;
+          } else {
+            onReorderSubSteps(result.parentStepId, result.orderedIds);
+            dispatched = true;
+          }
+        } else if (result.kind === "reparent") {
+          onReparentStep?.(result.stepId, result.newParentStepId);
+          dispatched = onReparentStep !== undefined;
+        }
+        if (dispatched) {
+          triggerDragDrop();
+          if (result.kind === "reparent") {
+            const stepTitle =
+              stepsRef.current.find((s) => s.id === result.stepId)?.title ??
+              result.stepId;
+            if (result.newParentStepId === null) {
+              AccessibilityInfo.announceForAccessibility(
+                announcePromote(stepTitle),
+              );
+            } else {
+              const parentTitle =
+                stepsRef.current.find((s) => s.id === result.newParentStepId)
+                  ?.title ?? "";
+              AccessibilityInfo.announceForAccessibility(
+                announceNestedUnder(stepTitle, parentTitle),
+              );
+            }
+          } else if (result.kind === "reorder") {
+            const draggedTitle =
+              stepsRef.current.find((s) => s.id === draggedId)?.title ??
+              draggedId;
+            AccessibilityInfo.announceForAccessibility(
+              announceReorder(
+                draggedTitle,
+                result.orderedIds.indexOf(draggedId) + 1,
+              ),
+            );
+          }
+        }
+      }
+    }
+    draggedRowIdRef.current = null;
+    hoverRowIdRef.current = null;
+    hoverRowIdForDwellRef.current = null;
+    setDraggedRowId(null);
+    setIsDragging(false);
+    armedTargetIdRef.current = null;
+    setArmedTargetId(null);
+    setDropOutline(null);
+    lastDragAbsoluteYRef.current = null;
+    dragScrollCompensation.value = 0;
+  }
+
+  // --- Sibling-scoped ↑/↓ (R8: never reparents) ----------------------------
+  function moveStep(rowId: string, direction: 1 | -1) {
+    if (editingIdRef.current !== null) return;
+    const flat = flatStepsRef.current;
+    const idx = flat.findIndex((s) => s.id === rowId);
+    if (idx < 0) return;
+    const step = flat[idx];
+    const parent = step.parentStepId ?? null;
+    const group = flat.filter((s) => (s.parentStepId ?? null) === parent);
+    const pos = group.findIndex((s) => s.id === rowId);
+    const swapWith = pos + direction;
+    if (swapWith < 0 || swapWith >= group.length) return;
+    const reordered = [...group];
+    [reordered[pos], reordered[swapWith]] = [
+      reordered[swapWith],
+      reordered[pos],
+    ];
+    const ids = reordered.map((s) => s.id);
+    if (parent === null) {
+      onReorderSteps(ids);
+    } else {
+      onReorderSubSteps(parent, ids);
+    }
+    triggerDragDrop();
+    const title = stepsRef.current.find((s) => s.id === rowId)?.title ?? rowId;
+    AccessibilityInfo.announceForAccessibility(
+      announceReorder(title, swapWith + 1),
+    );
+  }
+
+  function flatIndexForRowId(rowId: string): number {
+    return flatSteps.findIndex((s) => s.id === rowId);
+  }
+
+  return {
+    draggedRowId,
+    isDragging,
+    armedTargetId,
+    dropOutline,
+    dragScrollCompensation,
+    registerRowLayout,
+    registerRemeasure,
+    registerListOrigin,
+    refreshGeometry,
+    canDragRow,
+    handleDragStart,
+    handleDragMove,
+    handleDragEnd,
+    moveStep,
+    flatIndexForRowId,
+  };
+}
+
+// Re-export for consumers that previously imported from useEditGoalDrag.
+export { reorderStepIds };

--- a/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDragTypes.ts
+++ b/apps/native-rd/src/components/EditGoalView/useEditGoalHierarchyDragTypes.ts
@@ -1,0 +1,55 @@
+import type { SharedValue } from "react-native-reanimated";
+import type { DragScrollController } from "../StepList/dragAutoScroll";
+import type { EditGoalStep } from "./EditGoalView";
+
+/**
+ * Shared types for the hierarchy drag coordinator (issue #496, finding 5
+ * split). Kept in a tiny separate module so the pure helpers
+ * (`hierarchyDragHelpers.ts`) can import the types without importing the hook
+ * itself (which would create a circular dependency).
+ */
+
+export interface RowGeometry {
+  absoluteY: number;
+  height: number;
+}
+
+export type DropOutlineKind = "line" | "nested" | "group";
+
+export interface DropOutline {
+  top: number;
+  height: number;
+  kind: DropOutlineKind;
+}
+
+export interface UseEditGoalHierarchyDragParams {
+  steps: readonly EditGoalStep[];
+  onReorderSteps: (orderedStepIds: string[]) => void;
+  onReorderSubSteps: (
+    parentStepId: string,
+    orderedSubStepIds: string[],
+  ) => void;
+  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
+  dragScrollController?: DragScrollController;
+  editingId?: string | null;
+  announceReorder?: (stepTitle: string, position: number) => string;
+  announcePromote?: (stepTitle: string) => string;
+  announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
+}
+
+export interface UseEditGoalHierarchyDrag {
+  draggedRowId: string | null;
+  isDragging: boolean;
+  armedTargetId: string | null;
+  dropOutline: DropOutline | null;
+  dragScrollCompensation: SharedValue<number>;
+  registerRowLayout: (rowId: string, geometry: RowGeometry) => void;
+  registerRemeasure: (rowId: string, fn: (() => void) | null) => void;
+  registerListOrigin: (originY: number) => void;
+  registerListOriginRemeasure: (fn: (() => void) | null) => void;
+  canDragRow: (rowId: string) => boolean;
+  handleDragStart: (rowId: string) => void;
+  handleDragMove: (translationY: number, absoluteY: number) => void;
+  handleDragEnd: () => void;
+  moveStep: (rowId: string, direction: 1 | -1) => void;
+}

--- a/apps/native-rd/src/components/EditGoalView/useHierarchyAutoScroll.ts
+++ b/apps/native-rd/src/components/EditGoalView/useHierarchyAutoScroll.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import type { SharedValue } from "react-native-reanimated";
+import {
+  clampScrollOffset,
+  getAutoScrollVelocity,
+  getEffectiveTranslationY,
+  type DragScrollController,
+} from "../StepList/dragAutoScroll";
+
+/** Edge auto-scroll state isolated from hierarchy/reparent decisions. */
+export function useHierarchyAutoScroll(
+  controller: DragScrollController | undefined,
+  compensation: SharedValue<number>,
+  updateHover: (effectiveTranslationY: number) => void,
+) {
+  const updateHoverRef = useRef(updateHover);
+  updateHoverRef.current = updateHover;
+  const lastTranslationRef = useRef(0);
+  const lastAbsoluteYRef = useRef<number | null>(null);
+  const startOffsetRef = useRef(0);
+  const frameRef = useRef<number | null>(null);
+
+  function stop() {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }
+
+  function runFrame() {
+    frameRef.current = null;
+    const pointerY = lastAbsoluteYRef.current;
+    if (!controller || pointerY === null) return;
+    const metrics = controller.getMetrics();
+    const velocity = getAutoScrollVelocity(pointerY, metrics);
+    if (velocity === 0) return;
+    const nextOffset = clampScrollOffset(metrics.offsetY + velocity, metrics);
+    if (nextOffset === metrics.offsetY) return;
+    controller.scrollTo(nextOffset);
+    compensation.value = nextOffset - startOffsetRef.current;
+    updateHoverRef.current(
+      getEffectiveTranslationY(
+        lastTranslationRef.current,
+        nextOffset,
+        startOffsetRef.current,
+      ),
+    );
+    frameRef.current = requestAnimationFrame(runFrame);
+  }
+
+  function sync() {
+    const pointerY = lastAbsoluteYRef.current;
+    if (!controller || pointerY === null) return stop();
+    const velocity = getAutoScrollVelocity(pointerY, controller.getMetrics());
+    if (velocity === 0) stop();
+    else if (frameRef.current === null)
+      frameRef.current = requestAnimationFrame(runFrame);
+  }
+
+  function start() {
+    stop();
+    lastTranslationRef.current = 0;
+    lastAbsoluteYRef.current = null;
+    startOffsetRef.current = controller?.getMetrics().offsetY ?? 0;
+    compensation.value = 0;
+  }
+
+  function move(translationY: number, absoluteY: number) {
+    lastTranslationRef.current = translationY;
+    lastAbsoluteYRef.current = absoluteY;
+    const currentOffset =
+      controller?.getMetrics().offsetY ?? startOffsetRef.current;
+    compensation.value = currentOffset - startOffsetRef.current;
+    updateHoverRef.current(
+      controller
+        ? getEffectiveTranslationY(
+            translationY,
+            currentOffset,
+            startOffsetRef.current,
+          )
+        : translationY,
+    );
+    sync();
+  }
+
+  function reset() {
+    stop();
+    lastAbsoluteYRef.current = null;
+    compensation.value = 0;
+  }
+
+  useEffect(() => stop, []);
+
+  return { start, move, stop, reset };
+}

--- a/apps/native-rd/src/components/EditGoalView/useHierarchyGeometryRegistry.ts
+++ b/apps/native-rd/src/components/EditGoalView/useHierarchyGeometryRegistry.ts
@@ -1,0 +1,43 @@
+import { useRef } from "react";
+import type { RowGeometry } from "./useEditGoalHierarchyDragTypes";
+
+/** Shared absolute-coordinate registry for root and sub-step drag rows. */
+export function useHierarchyGeometryRegistry() {
+  const geometryRef = useRef<Map<string, RowGeometry>>(new Map());
+  const listOriginRef = useRef(0);
+  const remeasureRef = useRef<Map<string, () => void>>(new Map());
+  const listOriginRemeasureRef = useRef<(() => void) | null>(null);
+
+  function registerRowLayout(rowId: string, geometry: RowGeometry) {
+    geometryRef.current.set(rowId, geometry);
+  }
+
+  function registerRemeasure(rowId: string, remeasure: (() => void) | null) {
+    if (remeasure) remeasureRef.current.set(rowId, remeasure);
+    else remeasureRef.current.delete(rowId);
+  }
+
+  function registerListOrigin(originY: number) {
+    listOriginRef.current = originY;
+  }
+
+  function registerListOriginRemeasure(remeasure: (() => void) | null) {
+    listOriginRemeasureRef.current = remeasure;
+  }
+
+  /** Refresh one coordinate frame after a manual scroll and before dragging. */
+  function refreshAllGeometry() {
+    listOriginRemeasureRef.current?.();
+    for (const remeasure of remeasureRef.current.values()) remeasure();
+  }
+
+  return {
+    geometryRef,
+    listOriginRef,
+    registerRowLayout,
+    registerRemeasure,
+    registerListOrigin,
+    registerListOriginRemeasure,
+    refreshAllGeometry,
+  };
+}

--- a/apps/native-rd/src/components/EditGoalView/useRowGeometryRegistration.ts
+++ b/apps/native-rd/src/components/EditGoalView/useRowGeometryRegistration.ts
@@ -1,0 +1,51 @@
+/**
+ * useRowGeometryRegistration — shared hook that registers a row's
+ * screen-absolute geometry into the hierarchy coordinator's registry
+ * (issue #496, finding 5). Extracted from the duplicated `measureAndRegister`
+ * + `useEffect` pattern that was copy-pasted in EditGoalStepRow and
+ * EditGoalSubStepRow.
+ *
+ * R3/R15: `onLayout` alone reports parent-relative `y`; `measureInWindow`
+ * provides the screen-absolute `y` the coordinator's hover math needs. The
+ * remeasure callback is registered so drag-start can refresh this row's
+ * geometry (the registry never goes stale after manual scroll — finding 2).
+ *
+ * @param rowId      Stable id of the row (step or sub-step).
+ * @param ref        React ref to the View whose band should be measured.
+ * @param register   Coordinator callback that stores `{ absoluteY, height }`.
+ * @param registerRemeasure Coordinator callback that stores a remeasure fn.
+ * @returns `measureAndRegister` — pass to the View's `onLayout`.
+ */
+import { useEffect, useRef } from "react";
+import type { View } from "react-native";
+import type { RowGeometry } from "./useEditGoalHierarchyDragTypes";
+
+export function useRowGeometryRegistration(
+  rowId: string,
+  register: (rowId: string, geometry: RowGeometry) => void,
+  registerRemeasure: (rowId: string, fn: (() => void) | null) => void,
+) {
+  const ref = useRef<View>(null);
+
+  function measureAndRegister() {
+    const node = ref.current as unknown as {
+      measureInWindow?: (
+        cb: (x: number, y: number, w: number, h: number) => void,
+      ) => void;
+    } | null;
+    if (node?.measureInWindow) {
+      node.measureInWindow((_x, y, _w, h) => {
+        register(rowId, { absoluteY: y, height: h });
+      });
+    }
+  }
+
+  useEffect(() => {
+    registerRemeasure(rowId, measureAndRegister);
+    return () => registerRemeasure(rowId, null);
+    // register/registerRemeasure read refs on the coordinator; rowId is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rowId]);
+
+  return { ref, measureAndRegister };
+}

--- a/apps/native-rd/src/components/EditGoalView/useRowGeometryRegistration.ts
+++ b/apps/native-rd/src/components/EditGoalView/useRowGeometryRegistration.ts
@@ -10,11 +10,11 @@
  * remeasure callback is registered so drag-start can refresh this row's
  * geometry (the registry never goes stale after manual scroll — finding 2).
  *
- * @param rowId      Stable id of the row (step or sub-step).
- * @param ref        React ref to the View whose band should be measured.
- * @param register   Coordinator callback that stores `{ absoluteY, height }`.
+ * @param rowId Stable id of the row (step or sub-step).
+ * @param register Coordinator callback that stores `{ absoluteY, height }`.
  * @param registerRemeasure Coordinator callback that stores a remeasure fn.
- * @returns `measureAndRegister` — pass to the View's `onLayout`.
+ * @returns The created View `ref` and `measureAndRegister` callback to pass to
+ * the measured View's `ref` and `onLayout` props.
  */
 import { useEffect, useRef } from "react";
 import type { View } from "react-native";

--- a/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.stories.tsx
+++ b/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.stories.tsx
@@ -4,6 +4,7 @@ import { Text, useWindowDimensions, View } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { NewGoalWizard, type NewGoalWizardStep } from "./NewGoalWizard";
 import type { EditGoalStep, EditGoalSubStep } from "../EditGoalView";
+import { applyReparent } from "../EditGoalView/applyReparent";
 import { EvidenceType } from "../../db";
 import type { EvidenceTypeValue } from "../../types/evidence";
 
@@ -338,6 +339,59 @@ export const BuildStep: Story = {
 export const BuildStepWithSubSteps: Story = {
   render: () => (
     <InteractiveBuildStep initialSteps={SAMPLE_STEPS_WITH_SUBSTEPS} />
+  ),
+};
+
+/**
+ * Build step with reparent enabled (#496): the wizard forwards onReparentStep
+ * to EditGoalStepList, so a leaf root can be nested (Nest under… picker or
+ * drag/dwell) and a sub-step can be un-nested. Stateful via applyReparent so
+ * the reviewer sees the real nesting change. Requires a screen reader or
+ * reduced motion to surface the accessible Nest under… / Un-nest controls.
+ */
+function InteractiveBuildStepReparent() {
+  const { steps, setSteps, callbacks } = useInteractiveSteps(
+    SAMPLE_STEPS_WITH_SUBSTEPS,
+  );
+  return (
+    <PhoneStage>
+      <NewGoalWizard
+        currentStep="build"
+        goalTitle="Build a birdhouse"
+        onGoalTitleChange={noop}
+        stepCount={steps.length}
+        onBack={noop}
+        onClose={noop}
+        onNext={noop}
+        onQuickAdd={noop}
+        onStartWorking={noop}
+        steps={steps}
+        {...callbacks}
+        onReparentStep={(stepId, newParentId) =>
+          setSteps((prev) => applyReparent(prev, stepId, newParentId))
+        }
+      />
+    </PhoneStage>
+  );
+}
+
+export const BuildStepReparent: Story = {
+  render: () => (
+    <View>
+      <Text
+        style={{
+          fontSize: 12,
+          fontStyle: "italic",
+          padding: 12,
+        }}
+      >
+        Reparent is enabled on the build step: long-press a leaf root and dwell
+        on another root ~220ms to nest it, or enable a screen reader / reduced
+        motion to use the “Nest under…” picker and “Un-nest” button. A
+        parent-with-children cannot be demoted (snap-back).
+      </Text>
+      <InteractiveBuildStepReparent />
+    </View>
   ),
 };
 

--- a/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.tsx
+++ b/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.tsx
@@ -111,6 +111,9 @@ export interface NewGoalWizardProps {
     parentStepId: string,
     orderedSubStepIds: string[],
   ) => void;
+  /** Fired on a drag-reparent / nest-under / un-nest (#496). Optional; when
+   * omitted the build step collapses to sibling reorder only. */
+  onReparentStep?: (stepId: string, newParentStepId: string | null) => void;
   /** Appends a step titled from EditGoalStepList's inline "Add step..." input (D3). */
   onAddStep?: (title: string) => void;
   onStepTitleChange?: (stepId: string, title: string) => void;
@@ -199,6 +202,14 @@ export interface NewGoalWizardProps {
   deleteSubStepConfirmTitle?: string;
   /** Confirm-modal message when deleting a sub-step (receives the sub-step title). */
   deleteSubStepConfirmMessage?: (title: string) => string;
+  // --- Nest-under / un-nest copy (#496, forwarded to EditGoalStepList) ---
+  nestUnderTriggerA11yLabel?: string;
+  nestUnderPickerTitle?: string;
+  nestUnderRowLabel?: (targetTitle: string) => string;
+  nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  unNestA11yLabel?: string;
+  announcePromote?: (stepTitle: string) => string;
+  announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
   /** Footer CTA on the build step — distinct copy from nextLabel (D7). */
   buildReadyLabel?: string;
   readyHeadline?: string;
@@ -259,6 +270,7 @@ export function NewGoalWizard({
   steps = [],
   onReorderSteps = noop,
   onReorderSubSteps = noop,
+  onReparentStep,
   onAddStep = noop,
   onStepTitleChange = noop,
   onStepEvidenceChange = noop,
@@ -309,6 +321,13 @@ export function NewGoalWizard({
   deleteStepConfirmMessage,
   deleteSubStepConfirmTitle,
   deleteSubStepConfirmMessage,
+  nestUnderTriggerA11yLabel,
+  nestUnderPickerTitle,
+  nestUnderRowLabel,
+  nestUnderRowA11yLabel,
+  unNestA11yLabel,
+  announcePromote,
+  announceNestedUnder,
   buildReadyLabel = "I'm ready →",
   readyHeadline = "You're set.",
   stepCountSummary = defaultStepCountSummary,
@@ -574,6 +593,7 @@ export function NewGoalWizard({
                 steps={steps}
                 onReorderSteps={onReorderSteps}
                 onReorderSubSteps={onReorderSubSteps}
+                onReparentStep={onReparentStep}
                 onAddStep={onAddStep}
                 onStepTitleChange={onStepTitleChange}
                 onEvidenceChipPress={setEditingEvidenceId}
@@ -596,6 +616,13 @@ export function NewGoalWizard({
                 deleteStepConfirmMessage={deleteStepConfirmMessage}
                 deleteSubStepConfirmTitle={deleteSubStepConfirmTitle}
                 deleteSubStepConfirmMessage={deleteSubStepConfirmMessage}
+                nestUnderTriggerA11yLabel={nestUnderTriggerA11yLabel}
+                nestUnderPickerTitle={nestUnderPickerTitle}
+                nestUnderRowLabel={nestUnderRowLabel}
+                nestUnderRowA11yLabel={nestUnderRowA11yLabel}
+                unNestA11yLabel={unNestA11yLabel}
+                announcePromote={announcePromote}
+                announceNestedUnder={announceNestedUnder}
               />
             </ScrollView>
           </View>

--- a/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.tsx
+++ b/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.tsx
@@ -207,6 +207,7 @@ export interface NewGoalWizardProps {
   nestUnderPickerTitle?: string;
   nestUnderRowLabel?: (targetTitle: string) => string;
   nestUnderRowA11yLabel?: (targetTitle: string) => string;
+  nestUnderCancelLabel?: string;
   unNestA11yLabel?: string;
   announcePromote?: (stepTitle: string) => string;
   announceNestedUnder?: (stepTitle: string, parentTitle: string) => string;
@@ -325,6 +326,7 @@ export function NewGoalWizard({
   nestUnderPickerTitle,
   nestUnderRowLabel,
   nestUnderRowA11yLabel,
+  nestUnderCancelLabel,
   unNestA11yLabel,
   announcePromote,
   announceNestedUnder,
@@ -620,6 +622,7 @@ export function NewGoalWizard({
                 nestUnderPickerTitle={nestUnderPickerTitle}
                 nestUnderRowLabel={nestUnderRowLabel}
                 nestUnderRowA11yLabel={nestUnderRowA11yLabel}
+                nestUnderCancelLabel={nestUnderCancelLabel}
                 unNestA11yLabel={unNestA11yLabel}
                 announcePromote={announcePromote}
                 announceNestedUnder={announceNestedUnder}

--- a/apps/native-rd/src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx
+++ b/apps/native-rd/src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx
@@ -774,4 +774,47 @@ describe("NewGoalWizard", () => {
       screen.getByRole("button", { name: "Quick add, skip to the list" }),
     ).toBeOnTheScreen();
   });
+
+  describe("build step · reparent (#496)", () => {
+    it("forwards onReparentStep: nest-under picker dispatches through the wizard", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      renderWizard({
+        currentStep: "build",
+        steps: BUILD_STEPS_WITH_SUB,
+        onReparentStep,
+      });
+      // s2 is a bare leaf root; it can nest under s1 (the parent).
+      fireEvent.press(screen.getByTestId("edit-goal-step-nest-under-s2"));
+      fireEvent.press(screen.getByTestId("edit-goal-step-nest-target-s2-s1"));
+      expect(onReparentStep).toHaveBeenCalledWith("s2", "s1");
+    });
+
+    it("forwards onReparentStep: a sub-step Un-nest dispatches through the wizard", () => {
+      mockAnimationPref = "none";
+      const onReparentStep = jest.fn();
+      renderWizard({
+        currentStep: "build",
+        steps: BUILD_STEPS_WITH_SUB,
+        onReparentStep,
+      });
+      fireEvent.press(screen.getByTestId("edit-goal-substep-un-nest-sub1"));
+      expect(onReparentStep).toHaveBeenCalledWith("sub1", null);
+    });
+
+    it("omitted onReparentStep: build step still reorders and renders no reparent controls", () => {
+      mockAnimationPref = "none";
+      const onReorderSteps = jest.fn();
+      renderWizard({
+        currentStep: "build",
+        steps: BUILD_STEPS,
+        onReorderSteps,
+        onReparentStep: undefined,
+      });
+      expect(screen.queryByTestId("edit-goal-step-nest-under-s1")).toBeNull();
+      // Reorder still works (sibling reorder only).
+      fireEvent.press(screen.getByLabelText('Move "Sand the edges" down'));
+      expect(onReorderSteps).toHaveBeenCalledWith(["s2", "s1"]);
+    });
+  });
 });

--- a/apps/native-rd/src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx
+++ b/apps/native-rd/src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx
@@ -802,6 +802,18 @@ describe("NewGoalWizard", () => {
       expect(onReparentStep).toHaveBeenCalledWith("sub1", null);
     });
 
+    it("forwards custom nest-under cancel copy", () => {
+      mockAnimationPref = "none";
+      renderWizard({
+        currentStep: "build",
+        steps: BUILD_STEPS_WITH_SUB,
+        onReparentStep: jest.fn(),
+        nestUnderCancelLabel: "Not now",
+      });
+      fireEvent.press(screen.getByTestId("edit-goal-step-nest-under-s2"));
+      expect(screen.getByRole("button", { name: "Not now" })).toBeOnTheScreen();
+    });
+
     it("omitted onReparentStep: build step still reorders and renders no reparent controls", () => {
       mockAnimationPref = "none";
       const onReorderSteps = jest.fn();


### PR DESCRIPTION
## Summary

- Preserve Edit Goal promote, demote, and move-between-parent behavior in the redesigned component contract.
- Add equivalent non-gesture hierarchy controls for screen-reader and reduced-motion use.
- Harden drag geometry and dwell targeting, including narrow layouts where every fallback control is visible.

## Changes

- Replaced isolated parent/sub-step drag hooks with one flattened hierarchy coordinator backed by the existing `classifyDrop` behavior.
- Added reparent contract forwarding through `EditGoalView` and `NewGoalWizard`, plus stateful Storybook scenarios for valid and invalid operations.
- Added accessible Nest-under and Un-nest paths with configurable copy; hierarchy actions now use a dedicated line so arrows cannot cover evidence.
- Refreshed all row geometry at drag start, constrained dwell arming to the measured header band, and split coordinator responsibilities into focused helpers.
- Added pure, hook, component, wizard, and visual-story regression coverage.

## Intent Verification

- [x] A child can be promoted to a root (`onReparentStep(id, null)` fires from the redesigned list, via drag-above-parent and via the Un-nest button).
- [x] A leaf root can be nested under a valid root (`onReparentStep(id, target)` fires; ineligible targets are refused).
- [x] A child can move between valid parents with correct sibling ordinals.
- [x] A parent-with-children and any depth>1 operation is refused (no callback fires; snap-back; no Nest-under control renders).
- [x] Equivalent non-gesture controls (Nest-under picker + Un-nest button) are available to screen-reader / reduced-motion users.
- [x] A child row is wired to the shared hierarchy drag coordinator.
- [x] Component tests cover callback payloads and hierarchy guards.
- [x] `NewGoalWizard` reuses and forwards the same optional reparent contract.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Reuse `classifyDrop` unchanged | Keeps the one-level hierarchy rules shared with the existing editor. |
| Use one always-called flattened hierarchy coordinator | Allows root and child gestures to share one coordinate and dispatch path without conditional hooks. |
| Register row geometry in screen-absolute coordinates and convert outlines locally | Prevents cross-parent and scrolling coordinate drift. |
| Keep `onReparentStep(stepId, parentId \| null)` optional | Preserves reorder-only consumers while matching the existing integration contract. |
| Keep arrow controls sibling-only and provide explicit Nest-under / Un-nest actions | Makes hierarchy changes predictable for screen-reader and reduced-motion users. |

## Test Plan

- [x] `bun run type-check`
- [x] `bun run lint`
- [x] `bun run test` — 209 suites, 9,888 tests
- [x] `bun run build`
- [x] Storybook `AccessibleNestControls` verified at the compact app width; evidence remains unobstructed with all hierarchy controls visible.

---

Closes #496

Generated with Codex
