### PR TITLE
feat(native-rd): FinishBakingStage no-key/error/retry/success states (#499)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-499-finish-flow-no-key-failure-retry.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-499-finish-flow-no-key-failure-retry.md
@@ -1,0 +1,148 @@
+# Development Plan: Issue #499
+
+## Issue Summary
+
+**Title**: [Storybook] Finish flow — no-key, failure, and retry states
+**Type**: feature (Storybook state-modeling — no app wiring)
+**Complexity**: MEDIUM (sits right at the SMALL/MEDIUM boundary)
+**Estimated Lines**: ~380–450 lines across 4 files (2 modified, 2 already-existing files extended), no new files/folders
+
+## Intent Verification
+
+- [ ] `FinishBakingStage` rendered with `status="no-key"` shows the no-key message via `accessibilityRole="alert"` **and** a visible, enabled "Continue without a badge"-style action — never a spinner-only dead end (old `CompletionFlowScreen` no-key branch had no action at all).
+- [ ] `FinishBakingStage` rendered with `status="error"` shows the caller-supplied `errorMessage` via `accessibilityRole="alert"` and a `Retry` `Button` whose `onPress` invokes `onRetry` — verified to fire exactly once even under two rapid presses before the caller's `status` prop changes (internal `retryPending` guard).
+- [ ] The Retry button's `accessibilityState.busy`/`disabled` flip `true` synchronously on press (via `Button`'s existing `loading` prop), before any parent re-render.
+- [ ] `status="success"` renders the badge at full opacity (no dim, no spinner) with a distinct success label — a real, observable sub-state, not an instant cut to `FinishRevealStage`.
+- [ ] `FinishFlow.stories.tsx`'s `AllThemesMatrix` gains baking-stage cells (success/no-key/error) across all 7 `ScopedTheme` columns.
+- [ ] The interactive flow story (`InteractiveFinishFlow`) demonstrates `baking → error → tap Retry → busy → success → reveal`, and while any busy phase is showing, no actionable control is rendered anywhere in the harness that could re-fire a bake (no Retry/exit button mounted during busy phases).
+
+## Dependencies
+
+| Issue | Title                                                                     | Status                                                 | Type                                                                   |
+| ----- | ------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| #470  | [Storybook] Finishing flow 1/3 — celebrate + baking + reveal stages       | ✅ Closed & merged (PR #481)                           | Hard prerequisite — ships `FinishBakingStage`                          |
+| #472  | [Storybook] Finishing flow 3/3 — interactive flow story + AllThemesMatrix | ✅ Closed & merged (PR #487)                           | Hard prerequisite — ships `FinishFlow.stories.tsx` + `AllThemesMatrix` |
+| #384  | Epic: Full Ride redesign                                                  | 🟢 Open (epic, not a blocker)                          | Parent epic                                                            |
+| #449  | [Integrate] Finishing flow — retire the old completion path               | 🟢 Open, blocked by #472 (met) — not a blocker of #499 | Downstream consumer of this issue's contract                           |
+
+No "Blocked by"/"Depends on"/checkbox dependency markers in the issue body. `#449`'s own body lists it as "Blocked by #472" (already merged) — #499 is a forward prerequisite for #449, not the reverse. Both files this issue extends (`FinishBakingStage`, `FinishFlow.stories.tsx`) already exist in the tree, confirmed by direct read.
+
+**Status**: ✅ All dependencies met.
+
+**has_blockers**: false
+
+## Objective
+
+Model `FinishBakingStage`'s baking interstitial as a real state union — in-progress phases, no-key, error, retry, and a distinct success hand-off — instead of the single hardcoded spinner it renders today. Preserve the _semantics_ of the old `CompletionFlowScreen`'s bake-status handling (no-key permanent-failure messaging, terminal-error copy + retry, alert/live-region a11y) inside the new component's contract, add a non-dead-ending escape for no-key (a real gap in the old flow), extend the interactive flow story to click through failure → retry → success, and add the new states to `AllThemesMatrix`. Storybook/state-surface only — real `useCreateBadge`/`useUserKey` wiring and navigation stay #449's job.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                                                             | Alternatives Considered                                                                               | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Extend `FinishBakingStage` in place with a `status` prop union mirroring `useCreateBadge`'s `BadgeCreationStatus` (minus the pre-render `idle`/`loading`/`done`) rather than a new sibling component                                                                 | New `FinishBakingResultStage` component alongside the existing one                                    | One interstitial owns "what's happening while baking," matching #470's D1 (one component per stage); keeps #449's wiring a near-verbatim pass-through of the real hook's `status`/`error`/`retryBake`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| D2  | Stay i18n-free — new copy (`errorMessage` caller-supplied, `noKeyLabel`, `retryLabel`, `successLabel`, `noKeyActionLabel`) are props with English defaults, no internal `useTranslation`                                                                             | Call `useTranslation(["completion", "common"])` internally, matching old `CompletionFlowScreen`       | Matches #470's D2 for every other Finish\*Stage component — keeps the component Storybook-renderable with zero i18n provider setup. #449 threads real `t()` output through these props, same plan as #470 D2 documents for the other three stages. Existing `en/completion.json` `badge.*` keys and `common:actions.retry` stay available for #449 to reuse verbatim if it chooses — this issue does not add or change any i18n resource files.                                                                                                                                                                                                                                                                                               |
+| D3  | Error copy/icon color uses the existing `theme.colors.error` token, same as `BadgeOverflowMenu`/`EditGoalOverflowMenu`/`VideoRecorder`/`VoiceMemoScreen`                                                                                                             | Introduce a new token, or a per-theme override                                                        | `theme.colors.error` is the established destructive/error color across the codebase already. Note (pre-existing, not introduced by this issue): `src/themes/adapter.ts` hardcodes `error: pkgPalette.error` for every color mode and no `variantOverrides` entry touches it (`grep -n "error" src/themes/variants.ts` → no matches), so it is flat across all 7 product themes even though `packages/design-tokens/src/themes/*.json` carries distinct per-theme `error` values that the adapter doesn't consume. This is an existing token-wiring gap, unrelated to and out of scope for this issue (see Not in Scope).                                                                                                                      |
+| D4  | No-key gets a new, explicit escape affordance: optional `onExitWithoutBadge` callback + `exitLabel` copy prop (default "Continue without a badge"), rendered as a `Button variant="secondary"` beside the no-key message                                             | Leave no-key as message-only (old behavior); or reuse `onRetry` for no-key too                        | Old `CompletionFlowScreen`'s no-key branch rendered a static, actionless message — a genuine dead end once the signing key is confirmed absent. `useCreateBadge.retryBake()` is explicitly gated to `status === "error"` only (never fires from `"no-key"` — see the hook's doc comment and early-return), so reusing `onRetry` here would misrepresent what the callback actually does. A distinct exit callback satisfies "explicit and non-dead-ending" without inventing a fake retry. Exact destination (e.g., back to the goal, evidence preserved) is a navigation decision for #449; this issue only exposes the seam. **Flagged in Open Questions** — this is the one place this plan makes a product call that old code never made. |
+| D5  | Duplicate-tap guard on Retry is internal component state (`retryPending`, set `true` synchronously inside the `onPress` handler before calling `onRetry`, reset whenever the `status` prop leaves `"error"`), driving `Button`'s existing `loading`/`disabled` props | Rely solely on the parent unmounting the Retry button once `status` changes away from `"error"`       | The parent-unmount path already prevents duplicate dispatch _between_ renders, but a double-press registered within the same tick (before the parent's state update commits) could still call `onRetry` twice. The internal guard is synchronous and needs no caller coordination — satisfies "prevent duplicate bake actions while work is active" at the component boundary, matching how `Button`'s own `loading` prop already works for every other in-flight action in the codebase.                                                                                                                                                                                                                                                     |
+| D6  | `success` is a real, distinct visual sub-state — full-opacity badge (no dim, no spinner) + `successLabel` — not an instant jump straight to `FinishRevealStage`                                                                                                      | Skip a success visual; auto-advance `baking → reveal` exactly as today                                | The acceptance criteria explicitly require `AllThemesMatrix` coverage of a `success` state and phrase the contract as "Retry returns to a busy state and can transition to reveal only after success" — both require an observable, matrix-able moment between the busy phases and the reveal stage.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| D7  | `AllThemesMatrix` in `FinishFlow.stories.tsx` gains three additional per-theme `FinishBakingStage` cells (`success`/`no-key`/`error`)                                                                                                                                | Leave `FinishBakingStage` out of the matrix, per #472's original note that it "adds no matrix signal" | #472's D3 note applied to the plain busy spinner, styled off flat `theme.colors.background`. The new no-key/error content pairs `theme.colors.error` against theme-varying background/text/border colors — exactly the kind of signal `AllThemesMatrix` exists to catch, especially for Bold Ink (`highContrast`, AAA 7:1) and Still Water (`autismFriendly`, muted, no shadows). Superseding, not contradicting, #472's original note (that note was correct for the surface that existed at the time).                                                                                                                                                                                                                                      |
+| D8  | Busy sub-phases (`building`/`signing`/`storing`/`baking`) all render identically — one generic `label` (default "Baking your badge…"), no per-phase copy                                                                                                             | Show distinct text per phase ("Signing…", "Saving…", etc.)                                            | Matches the _old_ `CompletionFlowScreen` precedent exactly: `isBadgeCreating` already collapsed all four hook sub-statuses into one generic "Creating your badge…" message. No product signal was ever surfaced per sub-phase; inventing four new copy strings here would be scope creep beyond "retain full functionality."                                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+## Affected Areas
+
+- `src/components/FinishBakingStage/FinishBakingStage.tsx`: add `status`, `errorMessage`, `retryLabel`, `onRetry`, `noKeyLabel`, `noKeyActionLabel`, `onExitWithoutBadge`, `successLabel` props; branch render on `status` (busy / no-key / error / success); internal `retryPending` guard.
+- `src/components/FinishBakingStage/FinishBakingStage.styles.ts`: add style blocks for the no-key/error/success containers (reusing existing spacing/color tokens, mirroring `CompletionFlowScreen.styles.ts`'s `badgeStatus`/`badgeErrorContainer` shapes).
+- `src/components/FinishBakingStage/FinishBakingStage.stories.tsx`: rename/keep `Default` (busy), add `Success`, `NoKey`, `ErrorState` (with a local-`useState` retry-to-success demo).
+- `src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx`: extend with coverage for every new status branch, a11y roles, and the duplicate-tap guard.
+- `src/stories/finish/FinishFlow.stories.tsx`: add a `bakeOutcome` prop to `InteractiveFinishFlow` (`"success" | "no-key" | "error"`), two new exported stories (`NoKey`, `FailureThenRetry`) exercising the full click-through, and three new per-theme cells in `AllThemesMatrix`.
+
+No changes to `CompletionFlowScreen.tsx`, `useCreateBadge.ts`, `useUserKey.ts`, navigation, or any i18n resource file — all out of scope per the issue's own "keep real `useCreateBadge`... in #449" instruction.
+
+## Implementation Plan
+
+### Step 1: Model the status union in `FinishBakingStage`
+
+**Files**: `src/components/FinishBakingStage/FinishBakingStage.tsx`, `src/components/FinishBakingStage/FinishBakingStage.styles.ts`
+**Commit**: `feat(finish-flow): model FinishBakingStage no-key/error/retry/success states`
+**Changes**:
+
+- [ ] Add `export type FinishBakingPhase = "building" | "signing" | "baking" | "storing"` and `export type FinishBakingStatus = FinishBakingPhase | "no-key" | "error" | "success"`.
+- [ ] Add props: `status?: FinishBakingStatus` (default `"baking"`, preserves existing `Default` story behavior), `successLabel?: string` (default `"Badge created!"`), `noKeyLabel?: string` (default `"Badge signing key unavailable"` — matches old `completion:badge.noKeyMessage` copy), `noKeyActionLabel?: string` (default `"Continue without a badge"`), `onExitWithoutBadge?: () => void`, `errorMessage?: string | null`, `retryLabel?: string` (default `"Retry"` — matches `common:actions.retry`), `onRetry?: () => void`.
+- [ ] Busy branch (status is a `FinishBakingPhase`): unchanged existing render (dimmed badge + `ActivityIndicator` + `label`, `accessibilityLiveRegion="polite"`).
+- [ ] Success branch: full-opacity badge (no `badgeDim` wrapper), no spinner, `successLabel` text; `accessibilityLiveRegion="polite"` announcing `successLabel`.
+- [ ] No-key branch: dimmed badge retained (bake never completed), `noKeyLabel` text in a wrapper with `accessibilityRole="alert"` + `accessibilityLabel={noKeyLabel}` (mirrors old `CompletionFlowScreen`'s `badgeStatus`/`accessibilityRole="alert"` treatment); render `Button variant="secondary" label={noKeyActionLabel} onPress={onExitWithoutBadge}` only when `onExitWithoutBadge` is provided.
+- [ ] Error branch: dimmed badge retained, `errorMessage` text in an `accessibilityRole="alert"` wrapper (mirrors old `badgeErrorContainer`/`badgeStatus`), `Button variant="secondary" label={retryLabel} loading={retryPending} onPress={handleRetryPress}` rendered only when `onRetry` is provided.
+- [ ] `retryPending` local state (`useState(false)`); `handleRetryPress` sets it `true` then calls `onRetry()`; a `useEffect` resets it to `false` whenever `status` changes away from `"error"` (covers both a successful re-arm and a repeat error from the same retry).
+- [ ] Styles: add `successContainer`/`noKeyContainer`/`errorContainer` (column, `gap: theme.space[3]`, matching `CompletionFlowScreen.styles.ts`'s `badgeErrorContainer` shape) and reuse `theme.colors.error` for the error message's text color only (icon/badge stay as-is — no new red badge tinting).
+
+### Step 2: Tests
+
+**Files**: `src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx`
+**Commit**: `test(finish-flow): cover FinishBakingStage status branches`
+**Changes**:
+
+- [ ] Existing busy-state tests continue to pass unchanged (default `status` stays `"baking"`).
+- [ ] `status="success"`: badge renders at full opacity (no `badgeDim` style applied — assert via style array/testID), no `ActivityIndicator`, `successLabel` text present.
+- [ ] `status="no-key"`: `accessibilityRole="alert"` wrapper present with `noKeyLabel`; `onExitWithoutBadge` fires on the action button press; button is entirely absent when `onExitWithoutBadge` is omitted (no dead click target rendered).
+- [ ] `status="error"`: `accessibilityRole="alert"` wrapper present with the caller's `errorMessage`; `onRetry` fires on Retry press; Retry button absent when `onRetry` is omitted.
+- [ ] Duplicate-tap guard: fire two rapid presses on Retry before re-rendering with a new `status` — `onRetry` is called exactly once, and the button's `accessibilityState.busy`/`disabled` are both `true` after the first press (`fireEvent.press` twice, assert mock call count === 1).
+- [ ] `retryPending` resets: re-render with `status="error"` again after the guard tripped — Retry is pressable again (regression guard against a stuck-disabled state).
+
+### Step 3: Per-status Storybook stories
+
+**Files**: `src/components/FinishBakingStage/FinishBakingStage.stories.tsx`
+**Commit**: `feat(finish-flow): FinishBakingStage per-status stories`
+**Changes**:
+
+- [ ] Keep `Default` (busy, unchanged).
+- [ ] Add `Success` (`status="success"`).
+- [ ] Add `NoKey` (`status="no-key"`, `onExitWithoutBadge` stub).
+- [ ] Add `ErrorState` — small local-`useState` wrapper so pressing Retry visibly flips `status` back to `"baking"` then, after a short timeout, to `"success"` (demonstrates the full recovery loop in isolation, mirroring `FinishCelebrateStage.stories.tsx`'s `ClosingNoteOpen` local-state pattern).
+
+### Step 4: Extend the interactive flow story + AllThemesMatrix
+
+**Files**: `src/stories/finish/FinishFlow.stories.tsx`
+**Commit**: `feat(finish-flow): exercise failure→retry→success in the flow story + AllThemesMatrix`
+**Changes**:
+
+- [ ] Add `bakeOutcome?: "success" | "no-key" | "error"` prop to `InteractiveFinishFlowProps` (default `"success"`, preserving `Default`/`ReducedMotion`/`LongContent` behavior unchanged).
+- [ ] Add internal `bakeStatus` state (`FinishBakingStatus`), seeded to `"building"` on entering the `"baking"` stage; on the existing `BAKE_DURATION_MS` timer: `"success"` outcome → `bakeStatus="success"`, then a short second timer flips `stage` to `"reveal"`; `"no-key"` outcome → `bakeStatus="no-key"` (terminal, no further timer); `"error"` outcome → `bakeStatus="error"` (terminal until Retry).
+- [ ] Wire `onRetry` in the harness: sets `bakeStatus="building"`, then after `BAKE_DURATION_MS` resolves to `"success"` and advances to reveal — demonstrating the full `error → retry → success → reveal` loop end to end.
+- [ ] Wire `onExitWithoutBadge` to a no-op (matches every other harness callback — `onViewBadge`/`onBackToGoals` are already no-ops; real navigation is #449's job).
+- [ ] New exported stories: `NoKey` (`bakeOutcome="no-key"`) and `FailureThenRetry` (`bakeOutcome="error"`).
+- [ ] `AllThemesMatrix`: add three more per-column `ScopedTheme` cells (`FinishBakingStage` with `status="success"`/`"no-key"`/`"error"`, all `pointerEvents="none"` like the existing Design/Reveal cells), updating the stale "Celebrate/baking... add no matrix signal" comment per D7.
+
+## Testing Strategy
+
+- [ ] Unit tests for `FinishBakingStage` (Jest 30, `@testing-library/react-native` v13), run via `bun run test --testPathPatterns "FinishBakingStage"` — never `bun test`/plain `npx jest`.
+- [ ] Manual/visual: open Storybook under `Iteration B/Finish/FinishBakingStage` — confirm `Success`/`NoKey`/`ErrorState` render correctly; under `Iteration B/Finish/Flow` — click through `FailureThenRetry` end to end (baking → error copy + Retry visible → tap Retry → busy again → success → reveal) and confirm `NoKey` shows the escape action with no further transition.
+- [ ] Manual/visual: `AllThemesMatrix` — confirm the error message stays legible against all 7 themes' backgrounds, in particular Bold Ink (`highContrast`) and Still Water (`autismFriendly`).
+- [ ] What this issue's tests will **not** show: real `useCreateBadge`/`useUserKey` status transitions, real retry-of-key-generation, real navigation on "Continue without a badge" or post-reveal exits, and any i18n-translated copy (component stays English-literal props per D2) — all of that remains #449's job, by design.
+
+## Not in Scope
+
+| Item                                                                                                              | Reason                                                                                                                                                    | Follow-up                                                               |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Real `useCreateBadge`/`useUserKey` wiring (passing the hook's live `status`/`error`/`retryBake` into these props) | Issue's own "keep real hooks in #449" instruction                                                                                                         | #449                                                                    |
+| Real navigation for `onExitWithoutBadge` (e.g., back to the goal, badge modal dismissal)                          | Bare callback prop; navigation is a screen/container concern                                                                                              | #449                                                                    |
+| i18n — real `t()` copy through these new props                                                                    | Matches #470 D2's established i18n-free convention for every Finish\*Stage component                                                                      | #449                                                                    |
+| Per-sub-phase busy copy ("Signing…", "Saving…", etc.)                                                             | Old code never surfaced this distinction either (D8)                                                                                                      | none                                                                    |
+| Fixing `theme.colors.error`'s flat (non-per-theme) value                                                          | Pre-existing token-wiring gap in `src/themes/adapter.ts`, unrelated to this issue                                                                         | none — worth a design-tokens follow-up if a theme audit (#383) flags it |
+| A real "retry key generation" action for no-key                                                                   | `useCreateBadge.retryBake()` is explicitly gated to `"error"` only; no-key needs a different mechanism (or none) that #449/`useUserKey` would have to own | #449, or a new issue if key regeneration itself needs a retry path      |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+
+- [2026-07-21] D5 guard implemented as a `retryFiredRef` (synchronous) backing the `retryPending` state, not state alone. Two native taps in one frame (before React commits the disabled Button) would both slip past a stale-closure state check — the ref guarantees `onRetry` fires exactly once, while `retryPending` still drives `Button`'s `loading`/`busy`/`disabled`. Faithful to the plan's stated intent ("synchronous internal guard").
+- [2026-07-21] Added `testID="finish-baking-badge-dim"` to the dim wrapper so the success-state test can assert full-opacity (wrapper absent) via testID per Step 2's "assert via style array/testID".
+- [2026-07-21] The status-reset `useEffect` (component) and the baking-seed `useEffect` (flow story) each trip the `setState-synchronously-within-an-effect` lint **warning** (0 errors). Left as-is: the pattern appears in 28 other repo files (hooks/screens/stories), the cascades are bounded (deps don't re-trigger), and both resets are genuinely prop-transition-driven.
+
+## Open Questions
+
+_Both resolved by Joe on 2026-07-21 (start-issue Phase 3). No plan changes required — both confirmed the plan's stated defaults._
+
+- **D4 (no-key escape)** — ✅ **RESOLVED: add the exit CTA prop.** Ship the new `onExitWithoutBadge` callback + "Continue without a badge" secondary `Button` beside the no-key alert (Step 1 / Step 4 as written). The component only exposes the seam; the real navigation destination stays #449's job.
+- **Success/no-key/exit copy wording** — ✅ **RESOLVED: use the plan's invented defaults** as overridable prop defaults (`"Badge created!"`, `"Badge signing key unavailable"`, `"Continue without a badge"`, `"Retry"`, `"Baking your badge…"`). Wording is not locked — #449 refines it when real `t()` copy is threaded through these props.

--- a/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.stories.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.stories.tsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { createDefaultBadgeDesign } from "../../badges/types";
-import { FinishBakingStage } from "./FinishBakingStage";
+import {
+  FinishBakingStage,
+  type FinishBakingStatus,
+} from "./FinishBakingStage";
 
 const badgeDesign = createDefaultBadgeDesign("Rewire the workshop");
 
@@ -15,10 +18,70 @@ export default meta;
 
 type Story = StoryObj<typeof FinishBakingStage>;
 
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <View style={{ flex: 1, height: 640 }}>{children}</View>
+);
+
+/** In-flight busy interstitial — dimmed badge, spinner, mono label. */
 export const Default: Story = {
   render: () => (
-    <View style={{ flex: 1, height: 640 }}>
+    <Frame>
       <FinishBakingStage badgeDesign={badgeDesign} />
-    </View>
+    </Frame>
   ),
+};
+
+/** Distinct success sub-state — full-opacity badge, no spinner (D6). */
+export const Success: Story = {
+  render: () => (
+    <Frame>
+      <FinishBakingStage badgeDesign={badgeDesign} status="success" />
+    </Frame>
+  ),
+};
+
+/** No-key permanent failure with the escape affordance (D4). */
+export const NoKey: Story = {
+  render: () => (
+    <Frame>
+      <FinishBakingStage
+        badgeDesign={badgeDesign}
+        status="no-key"
+        onExitWithoutBadge={() => {}}
+      />
+    </Frame>
+  ),
+};
+
+const RETRY_TO_SUCCESS_MS = 900;
+
+/**
+ * Terminal error with a working Retry that visibly loops
+ * error → busy → success in isolation — mirrors FinishCelebrateStage's
+ * local-state story pattern so the recovery path is clickable without the
+ * full flow harness.
+ */
+function ErrorStateDemo() {
+  const [status, setStatus] = useState<FinishBakingStatus>("error");
+
+  useEffect(() => {
+    if (status !== "baking") return;
+    const timer = setTimeout(() => setStatus("success"), RETRY_TO_SUCCESS_MS);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  return (
+    <Frame>
+      <FinishBakingStage
+        badgeDesign={badgeDesign}
+        status={status}
+        errorMessage="We couldn't finish baking your badge. Please try again."
+        onRetry={() => setStatus("baking")}
+      />
+    </Frame>
+  );
+}
+
+export const ErrorState: Story = {
+  render: () => <ErrorStateDemo />,
 };

--- a/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.styles.ts
+++ b/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.styles.ts
@@ -15,5 +15,17 @@ export const styles = StyleSheet.create((theme) => ({
   },
   label: {
     color: theme.colors.textSecondary,
+    textAlign: "center",
+  },
+  // Stacks the no-key/error alert above its escape/retry action, mirroring
+  // CompletionFlowScreen.styles.ts's `badgeErrorContainer` shape.
+  messageContainer: {
+    width: "100%",
+    alignItems: "center",
+    gap: theme.space[3],
+  },
+  errorText: {
+    color: theme.colors.error,
+    textAlign: "center",
   },
 }));

--- a/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.tsx
@@ -1,38 +1,200 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, View } from "react-native";
 import { useUnistyles } from "react-native-unistyles";
 
 import { BadgeRenderer } from "../../badges/BadgeRenderer";
 import { type BadgeDesign } from "../../badges/types";
+import { Button } from "../Button";
 import { Text } from "../Text";
 import { styles } from "./FinishBakingStage.styles";
 
 const DEFAULT_BADGE_SIZE = 146;
 
+/**
+ * The in-flight bake sub-statuses. Mirror `useCreateBadge`'s
+ * `BadgeCreationStatus` (minus the pre-render `idle`/`loading`/`done`) so #449
+ * can thread the hook's live `status` straight through. All four render
+ * identically (D8) — no per-phase copy.
+ */
+export type FinishBakingPhase = "building" | "signing" | "baking" | "storing";
+
+/** Full render-state union for the baking interstitial. */
+export type FinishBakingStatus =
+  | FinishBakingPhase
+  | "no-key"
+  | "error"
+  | "success";
+
 export interface FinishBakingStageProps {
-  /** Badge design to preview (dimmed) while the badge is baking. */
+  /** Badge design to preview while the badge is baking / on success. */
   badgeDesign: BadgeDesign;
-  /** Mono status label ("Baking your badge…"). */
+  /** Mono status label for the busy phases ("Baking your badge…"). */
   label?: string;
   /** Preview size in logical pixels. */
   badgeSize?: number;
+  /**
+   * Which sub-state to render. Defaults to `"baking"` so existing callers that
+   * pass no status keep the plain busy interstitial. Real hook wiring is #449.
+   */
+  status?: FinishBakingStatus;
+  /** Success-state label (full-opacity badge, no spinner). */
+  successLabel?: string;
+  /** No-key permanent-failure message (shown as an a11y alert). */
+  noKeyLabel?: string;
+  /** Label for the no-key escape action. */
+  noKeyActionLabel?: string;
+  /**
+   * Escape affordance for the no-key state — the one non-dead-ending path the
+   * old completion flow lacked (D4). The button only renders when provided;
+   * the navigation destination is #449's job.
+   */
+  onExitWithoutBadge?: () => void;
+  /** Caller-supplied terminal-error copy (shown as an a11y alert). */
+  errorMessage?: string | null;
+  /** Retry-button label for the error state. */
+  retryLabel?: string;
+  /**
+   * Retry callback for the error state. The button only renders when provided.
+   * Fires at most once per error until `status` leaves `"error"` (D5).
+   */
+  onRetry?: () => void;
 }
 
 /**
- * Baking interstitial of the finishing flow. Shows the just-designed badge at
- * reduced opacity with a native spinner and a "Baking your badge…" label.
- * The spinner is RN's platform `ActivityIndicator` (D9) rather than a custom
- * JS rotate loop, so there is no animation-preference concern. Presentational
- * only — the label is a static prop; real bake-status wiring is the integration
- * issue's job (#449). See dev plan for issue #470.
+ * Baking interstitial of the finishing flow, modeled as a real state union:
+ * the in-flight busy phases show the just-designed badge at reduced opacity
+ * with a native spinner; `success` shows it at full opacity with a success
+ * label; `no-key` and `error` surface an a11y `alert` with an optional escape
+ * or retry action. Presentational only — copy is caller-supplied props with
+ * English defaults (D2) and real `useCreateBadge`/navigation wiring stays #449's
+ * job. See dev plans for issues #470 and #499.
  */
 export function FinishBakingStage({
   badgeDesign,
   label = "Baking your badge…",
   badgeSize = DEFAULT_BADGE_SIZE,
+  status = "baking",
+  successLabel = "Badge created!",
+  noKeyLabel = "Badge signing key unavailable",
+  noKeyActionLabel = "Continue without a badge",
+  onExitWithoutBadge,
+  errorMessage,
+  retryLabel = "Retry",
+  onRetry,
 }: FinishBakingStageProps) {
   const { theme } = useUnistyles();
 
+  // Duplicate-tap guard (D5). The ref makes the guard synchronous so two taps
+  // landing in the same frame — before React commits the disabled Button —
+  // still fire `onRetry` exactly once. The state drives `Button`'s `loading`
+  // prop, flipping `accessibilityState.busy`/`disabled` on the next render.
+  const retryFiredRef = useRef(false);
+  const [retryPending, setRetryPending] = useState(false);
+
+  useEffect(() => {
+    // Re-arm whenever we leave the error state — covers both a successful
+    // re-bake and a repeat error surfaced by the same retry.
+    if (status !== "error") {
+      retryFiredRef.current = false;
+      setRetryPending(false);
+    }
+  }, [status]);
+
+  const handleRetryPress = () => {
+    if (retryFiredRef.current) return;
+    retryFiredRef.current = true;
+    setRetryPending(true);
+    onRetry?.();
+  };
+
+  const badge = (
+    <BadgeRenderer
+      design={badgeDesign}
+      size={badgeSize}
+      testID="finish-baking-badge"
+    />
+  );
+
+  if (status === "success") {
+    return (
+      <View
+        style={styles.container}
+        accessible
+        accessibilityRole="none"
+        accessibilityLiveRegion="polite"
+        accessibilityLabel={successLabel}
+        testID="finish-baking-stage"
+      >
+        {badge}
+        <Text variant="mono" style={styles.label}>
+          {successLabel}
+        </Text>
+      </View>
+    );
+  }
+
+  if (status === "no-key") {
+    return (
+      <View style={styles.container} testID="finish-baking-stage">
+        <View style={styles.badgeDim} testID="finish-baking-badge-dim">
+          {badge}
+        </View>
+        <View style={styles.messageContainer}>
+          <View
+            accessible
+            accessibilityRole="alert"
+            accessibilityLabel={noKeyLabel}
+            testID="finish-baking-no-key-alert"
+          >
+            <Text variant="mono" style={styles.label}>
+              {noKeyLabel}
+            </Text>
+          </View>
+          {onExitWithoutBadge ? (
+            <Button
+              label={noKeyActionLabel}
+              onPress={onExitWithoutBadge}
+              variant="secondary"
+              testID="finish-baking-exit-button"
+            />
+          ) : null}
+        </View>
+      </View>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <View style={styles.container} testID="finish-baking-stage">
+        <View style={styles.badgeDim} testID="finish-baking-badge-dim">
+          {badge}
+        </View>
+        <View style={styles.messageContainer}>
+          <View
+            accessible
+            accessibilityRole="alert"
+            accessibilityLabel={errorMessage ?? undefined}
+            testID="finish-baking-error-alert"
+          >
+            <Text variant="mono" style={styles.errorText}>
+              {errorMessage}
+            </Text>
+          </View>
+          {onRetry ? (
+            <Button
+              label={retryLabel}
+              onPress={handleRetryPress}
+              variant="secondary"
+              loading={retryPending}
+              testID="finish-baking-retry-button"
+            />
+          ) : null}
+        </View>
+      </View>
+    );
+  }
+
+  // Busy phases (building/signing/baking/storing) — unchanged interstitial.
   return (
     <View
       style={styles.container}
@@ -42,12 +204,8 @@ export function FinishBakingStage({
       accessibilityLabel={label}
       testID="finish-baking-stage"
     >
-      <View style={styles.badgeDim}>
-        <BadgeRenderer
-          design={badgeDesign}
-          size={badgeSize}
-          testID="finish-baking-badge"
-        />
+      <View style={styles.badgeDim} testID="finish-baking-badge-dim">
+        {badge}
       </View>
       <ActivityIndicator size="small" color={theme.colors.text} />
       <Text variant="mono" style={styles.label}>

--- a/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.tsx
@@ -9,16 +9,21 @@ import { Text } from "../Text";
 import { styles } from "./FinishBakingStage.styles";
 
 const DEFAULT_BADGE_SIZE = 146;
+const DEFAULT_ERROR_MESSAGE = "We couldn't finish baking your badge.";
 
 /**
- * The in-flight bake sub-statuses. Mirror `useCreateBadge`'s
- * `BadgeCreationStatus` (minus the pre-render `idle`/`loading`/`done`) so #449
- * can thread the hook's live `status` straight through. All four render
- * identically (D8) — no per-phase copy.
+ * The four in-flight bake phases — the busy subset of `useCreateBadge`'s
+ * `BadgeCreationStatus`. All four render identically (D8) — no per-phase copy.
  */
 export type FinishBakingPhase = "building" | "signing" | "baking" | "storing";
 
-/** Full render-state union for the baking interstitial. */
+/**
+ * Full render-state union for the baking interstitial: the busy phases plus the
+ * three terminal states. Mirrors `BadgeCreationStatus` with `idle`/`loading`
+ * dropped (nothing to render pre-bake) and `done` surfaced as `success`, so
+ * #449 maps the hook's live `status` onto this (a near-verbatim pass-through,
+ * modulo that one rename).
+ */
 export type FinishBakingStatus =
   | FinishBakingPhase
   | "no-key"
@@ -49,7 +54,11 @@ export interface FinishBakingStageProps {
    * the navigation destination is #449's job.
    */
   onExitWithoutBadge?: () => void;
-  /** Caller-supplied terminal-error copy (shown as an a11y alert). */
+  /**
+   * Caller-supplied terminal-error copy (shown as an a11y alert). Falls back to
+   * a generic English default so the `error` state can never surface a
+   * label-less alert; #449 threads real `t()` copy through here.
+   */
   errorMessage?: string | null;
   /** Retry-button label for the error state. */
   retryLabel?: string;
@@ -164,6 +173,9 @@ export function FinishBakingStage({
   }
 
   if (status === "error") {
+    // Coalesce null/undefined to a generic default so the alert always carries
+    // an accessible label — never a label-less, empty-text alert.
+    const errorText = errorMessage ?? DEFAULT_ERROR_MESSAGE;
     return (
       <View style={styles.container} testID="finish-baking-stage">
         <View style={styles.badgeDim} testID="finish-baking-badge-dim">
@@ -173,11 +185,11 @@ export function FinishBakingStage({
           <View
             accessible
             accessibilityRole="alert"
-            accessibilityLabel={errorMessage ?? undefined}
+            accessibilityLabel={errorText}
             testID="finish-baking-error-alert"
           >
             <Text variant="mono" style={styles.errorText}>
-              {errorMessage}
+              {errorText}
             </Text>
           </View>
           {onRetry ? (

--- a/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/FinishBakingStage.tsx
@@ -173,9 +173,13 @@ export function FinishBakingStage({
   }
 
   if (status === "error") {
-    // Coalesce null/undefined to a generic default so the alert always carries
-    // an accessible label — never a label-less, empty-text alert.
-    const errorText = errorMessage ?? DEFAULT_ERROR_MESSAGE;
+    // Coalesce null/undefined *and* empty/whitespace-only strings to a generic
+    // default so the alert always carries an accessible label — never a
+    // label-less, empty-text alert.
+    const errorText =
+      errorMessage != null && errorMessage.trim().length > 0
+        ? errorMessage
+        : DEFAULT_ERROR_MESSAGE;
     return (
       <View style={styles.container} testID="finish-baking-stage">
         <View style={styles.badgeDim} testID="finish-baking-badge-dim">

--- a/apps/native-rd/src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx
@@ -133,15 +133,27 @@ describe("FinishBakingStage", () => {
       ).toBeOnTheScreen();
     });
 
-    it("falls back to a default message so the alert is never label-less", () => {
-      renderWithProviders(
-        <FinishBakingStage badgeDesign={badgeDesign} status="error" />,
-      );
-      const alert = screen.getByTestId("finish-baking-error-alert");
-      expect(alert.props.accessibilityRole).toBe("alert");
-      expect(typeof alert.props.accessibilityLabel).toBe("string");
-      expect(alert.props.accessibilityLabel.length).toBeGreaterThan(0);
-    });
+    it.each([
+      ["undefined", undefined],
+      ["null", null],
+      ["empty string", ""],
+      ["whitespace-only", "   "],
+    ])(
+      "falls back to a default message when errorMessage is %s, so the alert is never label-less",
+      (_label, errorMessage) => {
+        renderWithProviders(
+          <FinishBakingStage
+            badgeDesign={badgeDesign}
+            status="error"
+            errorMessage={errorMessage}
+          />,
+        );
+        const alert = screen.getByTestId("finish-baking-error-alert");
+        expect(alert.props.accessibilityRole).toBe("alert");
+        expect(typeof alert.props.accessibilityLabel).toBe("string");
+        expect(alert.props.accessibilityLabel.trim().length).toBeGreaterThan(0);
+      },
+    );
 
     it("fires onRetry when Retry is pressed", () => {
       const onRetry = jest.fn();
@@ -207,6 +219,10 @@ describe("FinishBakingStage", () => {
       while (node && typeof node.props.onPress !== "function") {
         node = node.parent;
       }
+      // Fail loudly here if the traversal never finds the Pressable's onPress
+      // (e.g. Button's internals changed) rather than throwing an opaque
+      // "onPress is not a function" when we invoke it below.
+      expect(typeof node?.props.onPress).toBe("function");
       const onPress = node?.props.onPress as () => void;
       act(() => {
         onPress();

--- a/apps/native-rd/src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx
@@ -1,32 +1,205 @@
 import React from "react";
 import { ActivityIndicator } from "react-native";
 
-import { renderWithProviders, screen } from "../../../__tests__/test-utils";
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+} from "../../../__tests__/test-utils";
 import { createDefaultBadgeDesign } from "../../../badges/types";
 import { FinishBakingStage } from "../FinishBakingStage";
 
 const badgeDesign = createDefaultBadgeDesign("Rewire the workshop");
 
 describe("FinishBakingStage", () => {
-  it("renders the badge preview, spinner, and label", () => {
-    renderWithProviders(<FinishBakingStage badgeDesign={badgeDesign} />);
-    expect(screen.getByTestId("finish-baking-badge")).toBeOnTheScreen();
-    expect(screen.getByText("Baking your badge…")).toBeOnTheScreen();
-    // getByType throws if absent, so a truthy result confirms the spinner rendered.
-    expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+  describe("busy (default) state", () => {
+    it("renders the badge preview, spinner, and label", () => {
+      renderWithProviders(<FinishBakingStage badgeDesign={badgeDesign} />);
+      expect(screen.getByTestId("finish-baking-badge")).toBeOnTheScreen();
+      expect(screen.getByText("Baking your badge…")).toBeOnTheScreen();
+      // getByType throws if absent, so a truthy result confirms the spinner rendered.
+      expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+    });
+
+    it("announces the baking state via a polite live region", () => {
+      renderWithProviders(<FinishBakingStage badgeDesign={badgeDesign} />);
+      const region = screen.getByTestId("finish-baking-stage");
+      expect(region.props.accessibilityLiveRegion).toBe("polite");
+      expect(region.props.accessibilityLabel).toBe("Baking your badge…");
+    });
+
+    it("uses the provided label", () => {
+      renderWithProviders(
+        <FinishBakingStage badgeDesign={badgeDesign} label="Sealing it in…" />,
+      );
+      expect(screen.getByText("Sealing it in…")).toBeOnTheScreen();
+    });
+
+    it("dims the badge while a busy phase is showing", () => {
+      renderWithProviders(
+        <FinishBakingStage badgeDesign={badgeDesign} status="signing" />,
+      );
+      expect(screen.getByTestId("finish-baking-badge-dim")).toBeOnTheScreen();
+    });
   });
 
-  it("announces the baking state via a polite live region", () => {
-    renderWithProviders(<FinishBakingStage badgeDesign={badgeDesign} />);
-    const region = screen.getByTestId("finish-baking-stage");
-    expect(region.props.accessibilityLiveRegion).toBe("polite");
-    expect(region.props.accessibilityLabel).toBe("Baking your badge…");
+  describe("success state", () => {
+    it("renders the badge at full opacity (no dim wrapper) with the success label and no spinner", () => {
+      renderWithProviders(
+        <FinishBakingStage badgeDesign={badgeDesign} status="success" />,
+      );
+      expect(screen.getByTestId("finish-baking-badge")).toBeOnTheScreen();
+      expect(screen.queryByTestId("finish-baking-badge-dim")).toBeNull();
+      expect(screen.getByText("Badge created!")).toBeOnTheScreen();
+      expect(screen.UNSAFE_queryByType(ActivityIndicator)).toBeNull();
+    });
+
+    it("announces the success label via a polite live region", () => {
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="success"
+          successLabel="All done!"
+        />,
+      );
+      const region = screen.getByTestId("finish-baking-stage");
+      expect(region.props.accessibilityLiveRegion).toBe("polite");
+      expect(region.props.accessibilityLabel).toBe("All done!");
+    });
   });
 
-  it("uses the provided label", () => {
-    renderWithProviders(
-      <FinishBakingStage badgeDesign={badgeDesign} label="Sealing it in…" />,
-    );
-    expect(screen.getByText("Sealing it in…")).toBeOnTheScreen();
+  describe("no-key state", () => {
+    it("surfaces the no-key message as an alert", () => {
+      renderWithProviders(
+        <FinishBakingStage badgeDesign={badgeDesign} status="no-key" />,
+      );
+      const alert = screen.getByTestId("finish-baking-no-key-alert");
+      expect(alert.props.accessibilityRole).toBe("alert");
+      expect(alert.props.accessibilityLabel).toBe(
+        "Badge signing key unavailable",
+      );
+      expect(
+        screen.getByText("Badge signing key unavailable"),
+      ).toBeOnTheScreen();
+    });
+
+    it("fires onExitWithoutBadge when the escape action is pressed", () => {
+      const onExitWithoutBadge = jest.fn();
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="no-key"
+          onExitWithoutBadge={onExitWithoutBadge}
+        />,
+      );
+      fireEvent.press(screen.getByTestId("finish-baking-exit-button"));
+      expect(onExitWithoutBadge).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders no escape action when onExitWithoutBadge is omitted", () => {
+      renderWithProviders(
+        <FinishBakingStage badgeDesign={badgeDesign} status="no-key" />,
+      );
+      expect(screen.queryByTestId("finish-baking-exit-button")).toBeNull();
+    });
+  });
+
+  describe("error state", () => {
+    it("surfaces the caller-supplied error message as an alert", () => {
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Something went wrong while baking."
+        />,
+      );
+      const alert = screen.getByTestId("finish-baking-error-alert");
+      expect(alert.props.accessibilityRole).toBe("alert");
+      expect(alert.props.accessibilityLabel).toBe(
+        "Something went wrong while baking.",
+      );
+      expect(
+        screen.getByText("Something went wrong while baking."),
+      ).toBeOnTheScreen();
+    });
+
+    it("fires onRetry when Retry is pressed", () => {
+      const onRetry = jest.fn();
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Bake failed."
+          onRetry={onRetry}
+        />,
+      );
+      fireEvent.press(screen.getByTestId("finish-baking-retry-button"));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders no Retry button when onRetry is omitted", () => {
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Bake failed."
+        />,
+      );
+      expect(screen.queryByTestId("finish-baking-retry-button")).toBeNull();
+    });
+
+    it("fires onRetry exactly once under two rapid presses and marks the button busy/disabled", () => {
+      const onRetry = jest.fn();
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Bake failed."
+          onRetry={onRetry}
+        />,
+      );
+      const retry = screen.getByTestId("finish-baking-retry-button");
+      fireEvent.press(retry);
+      fireEvent.press(retry);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      expect(retry.props.accessibilityState.busy).toBe(true);
+      expect(retry.props.accessibilityState.disabled).toBe(true);
+    });
+
+    it("re-arms Retry after the status leaves and re-enters error", () => {
+      const onRetry = jest.fn();
+      const { rerender } = renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Bake failed."
+          onRetry={onRetry}
+        />,
+      );
+      fireEvent.press(screen.getByTestId("finish-baking-retry-button"));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+
+      // Retry re-armed the bake → busy phase → fails again → back to error.
+      rerender(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="baking"
+          onRetry={onRetry}
+        />,
+      );
+      rerender(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Bake failed again."
+          onRetry={onRetry}
+        />,
+      );
+
+      const retry = screen.getByTestId("finish-baking-retry-button");
+      expect(retry.props.accessibilityState.busy).toBe(false);
+      fireEvent.press(retry);
+      expect(onRetry).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/native-rd/src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx
+++ b/apps/native-rd/src/components/FinishBakingStage/__tests__/FinishBakingStage.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ActivityIndicator } from "react-native";
 
 import {
+  act,
   fireEvent,
   renderWithProviders,
   screen,
@@ -35,12 +36,21 @@ describe("FinishBakingStage", () => {
       expect(screen.getByText("Sealing it in…")).toBeOnTheScreen();
     });
 
-    it("dims the badge while a busy phase is showing", () => {
-      renderWithProviders(
-        <FinishBakingStage badgeDesign={badgeDesign} status="signing" />,
-      );
-      expect(screen.getByTestId("finish-baking-badge-dim")).toBeOnTheScreen();
-    });
+    // D8: all four in-flight phases render the identical busy interstitial.
+    it.each(["building", "signing", "baking", "storing"] as const)(
+      "renders the dimmed badge, spinner, and polite live region for the %s phase",
+      (phase) => {
+        renderWithProviders(
+          <FinishBakingStage badgeDesign={badgeDesign} status={phase} />,
+        );
+        expect(screen.getByTestId("finish-baking-badge-dim")).toBeOnTheScreen();
+        expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+        expect(
+          screen.getByTestId("finish-baking-stage").props
+            .accessibilityLiveRegion,
+        ).toBe("polite");
+      },
+    );
   });
 
   describe("success state", () => {
@@ -123,6 +133,16 @@ describe("FinishBakingStage", () => {
       ).toBeOnTheScreen();
     });
 
+    it("falls back to a default message so the alert is never label-less", () => {
+      renderWithProviders(
+        <FinishBakingStage badgeDesign={badgeDesign} status="error" />,
+      );
+      const alert = screen.getByTestId("finish-baking-error-alert");
+      expect(alert.props.accessibilityRole).toBe("alert");
+      expect(typeof alert.props.accessibilityLabel).toBe("string");
+      expect(alert.props.accessibilityLabel.length).toBeGreaterThan(0);
+    });
+
     it("fires onRetry when Retry is pressed", () => {
       const onRetry = jest.fn();
       renderWithProviders(
@@ -148,7 +168,7 @@ describe("FinishBakingStage", () => {
       expect(screen.queryByTestId("finish-baking-retry-button")).toBeNull();
     });
 
-    it("fires onRetry exactly once under two rapid presses and marks the button busy/disabled", () => {
+    it("marks the button busy/disabled after the first press (Button loading contract)", () => {
       const onRetry = jest.fn();
       renderWithProviders(
         <FinishBakingStage
@@ -160,10 +180,39 @@ describe("FinishBakingStage", () => {
       );
       const retry = screen.getByTestId("finish-baking-retry-button");
       fireEvent.press(retry);
-      fireEvent.press(retry);
       expect(onRetry).toHaveBeenCalledTimes(1);
       expect(retry.props.accessibilityState.busy).toBe(true);
       expect(retry.props.accessibilityState.disabled).toBe(true);
+    });
+
+    it("fires onRetry exactly once for two presses landing in the same frame (retryFiredRef guard)", () => {
+      // Isolates the synchronous ref guard, not the Button's disabled state:
+      // fireEvent.press flushes React between calls, so a second fireEvent.press
+      // would be absorbed by the now-disabled Button and pass even if the ref
+      // were removed. Reaching for the composite Pressable's onPress (which is
+      // handleRetryPress) and invoking it twice inside one act() reproduces two
+      // taps in a single frame — only retryFiredRef stops the duplicate dispatch.
+      const onRetry = jest.fn();
+      renderWithProviders(
+        <FinishBakingStage
+          badgeDesign={badgeDesign}
+          status="error"
+          errorMessage="Bake failed."
+          onRetry={onRetry}
+        />,
+      );
+      // getByTestId returns the host View; the onPress handler lives on the
+      // composite Pressable above it, so walk up to the first ancestor carrying it.
+      let node = screen.getByTestId("finish-baking-retry-button").parent;
+      while (node && typeof node.props.onPress !== "function") {
+        node = node.parent;
+      }
+      const onPress = node?.props.onPress as () => void;
+      act(() => {
+        onPress();
+        onPress();
+      });
+      expect(onRetry).toHaveBeenCalledTimes(1);
     });
 
     it("re-arms Retry after the status leaves and re-enters error", () => {

--- a/apps/native-rd/src/components/FinishBakingStage/index.ts
+++ b/apps/native-rd/src/components/FinishBakingStage/index.ts
@@ -1,2 +1,6 @@
 export { FinishBakingStage } from "./FinishBakingStage";
-export type { FinishBakingStageProps } from "./FinishBakingStage";
+export type {
+  FinishBakingStageProps,
+  FinishBakingPhase,
+  FinishBakingStatus,
+} from "./FinishBakingStage";

--- a/apps/native-rd/src/stories/finish/FinishFlow.stories.tsx
+++ b/apps/native-rd/src/stories/finish/FinishFlow.stories.tsx
@@ -5,7 +5,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { FinishCelebrateStage } from "../../components/FinishCelebrateStage";
 import { FinishDesignStage } from "../../components/FinishDesignStage";
-import { FinishBakingStage } from "../../components/FinishBakingStage";
+import {
+  FinishBakingStage,
+  type FinishBakingStatus,
+} from "../../components/FinishBakingStage";
 import { FinishRevealStage } from "../../components/FinishRevealStage";
 import { createDefaultBadgeDesign, type BadgeDesign } from "../../badges/types";
 import type { AnimationPref } from "../../hooks/useAnimationPref";
@@ -21,12 +24,20 @@ type Story = StoryObj;
 /** The four sequential stages of the finishing flow. */
 type FlowStage = "celebrate" | "design" | "baking" | "reveal";
 
+/** How the modeled bake resolves — the seam #449 replaces with real hook state. */
+type BakeOutcome = "success" | "no-key" | "error";
+
 const GOAL_TITLE = "Rewire the workshop";
 // Deliberately off-palette (not in ColorPicker's ACCENT_COLORS) so the extra
 // "goal" swatch renders as a distinct entry in the design stage — same
 // fixture-hex convention as FinishDesignStage.stories.tsx.
 const GOAL_COLOR = "#e11d48";
 const EARNED_DATE_LABEL = "Jun 23, 2026";
+
+// Fixture copy for the modeled error state — English literal, mirroring the
+// component's own defaults (D2). #449 threads real t() output through here.
+const BAKE_ERROR_MESSAGE =
+  "We couldn't finish baking your badge. Please try again.";
 
 // Threads the goal title into the celebrate summary so the same string surfaces
 // on celebrate (summary), design (header subtitle), and reveal (heading) —
@@ -37,6 +48,9 @@ const makeSummary = (title: string) =>
 // Auto-advance duration for baking → reveal, matching the canonical prototype's
 // own bake() handler (Finishing Flow A Prototype.dc.html: setTimeout(…, 1100)).
 const BAKE_DURATION_MS = 1100;
+// Brief hold on the success sub-state before advancing to reveal, so the
+// distinct "Badge created!" moment (D6) is observable, not an instant cut.
+const SUCCESS_HOLD_MS = 700;
 
 interface InteractiveFinishFlowProps {
   /** Passed straight through to the reveal stage's pop-in (D2/#470 contract). */
@@ -49,13 +63,20 @@ interface InteractiveFinishFlowProps {
   initialNoteOpen?: boolean;
   /** Merged over the seeded default design (e.g. a long bottom label). */
   designOverrides?: Partial<BadgeDesign>;
+  /**
+   * How the modeled bake resolves. `"success"` auto-advances to reveal;
+   * `"no-key"` and `"error"` are terminal until the user acts (exit / retry).
+   */
+  bakeOutcome?: BakeOutcome;
 }
 
 /**
  * Story-local harness chaining the four already-shipped Finish*Stage components
  * through `useState` — no app navigation, no `useCreateBadge`, no real bake.
- * A single `design`/`goalTitle` threads through every stage; baking auto-
- * advances to reveal after a fixed timer (D2). Integration is #449's job.
+ * A single `design`/`goalTitle` threads through every stage; the modeled bake
+ * resolves per `bakeOutcome` (success auto-advances to reveal; error offers a
+ * working Retry that loops back through busy → success → reveal). Integration
+ * is #449's job.
  */
 function InteractiveFinishFlow({
   animationPref = "full",
@@ -63,6 +84,7 @@ function InteractiveFinishFlow({
   initialClosingNote = "",
   initialNoteOpen = false,
   designOverrides,
+  bakeOutcome = "success",
 }: InteractiveFinishFlowProps) {
   const [stage, setStage] = useState<FlowStage>("celebrate");
   const [closingNote, setClosingNote] = useState(initialClosingNote);
@@ -70,13 +92,31 @@ function InteractiveFinishFlow({
     ...createDefaultBadgeDesign(goalTitle, GOAL_COLOR),
     ...designOverrides,
   }));
+  const [bakeStatus, setBakeStatus] = useState<FinishBakingStatus>("building");
+  // Which outcome the current busy phase resolves to. Seeded from bakeOutcome
+  // on entering baking; a Retry always re-targets "success".
+  const [bakeTarget, setBakeTarget] = useState<BakeOutcome>(bakeOutcome);
 
-  // Auto-advance baking → reveal with no tap, mirroring the prototype's timer.
+  // Entering the baking stage (re)seeds a fresh busy phase.
   useEffect(() => {
     if (stage !== "baking") return;
-    const timer = setTimeout(() => setStage("reveal"), BAKE_DURATION_MS);
+    setBakeTarget(bakeOutcome);
+    setBakeStatus("building");
+  }, [stage, bakeOutcome]);
+
+  // Resolve a busy phase to its target after the bake timer.
+  useEffect(() => {
+    if (bakeStatus !== "building") return;
+    const timer = setTimeout(() => setBakeStatus(bakeTarget), BAKE_DURATION_MS);
     return () => clearTimeout(timer);
-  }, [stage]);
+  }, [bakeStatus, bakeTarget]);
+
+  // A resolved success briefly holds, then advances to the reveal stage.
+  useEffect(() => {
+    if (bakeStatus !== "success") return;
+    const timer = setTimeout(() => setStage("reveal"), SUCCESS_HOLD_MS);
+    return () => clearTimeout(timer);
+  }, [bakeStatus]);
 
   return (
     <View style={{ flex: 1, height: 640 }}>
@@ -99,7 +139,22 @@ function InteractiveFinishFlow({
           onBake={() => setStage("baking")}
         />
       )}
-      {stage === "baking" && <FinishBakingStage badgeDesign={design} />}
+      {stage === "baking" && (
+        <FinishBakingStage
+          badgeDesign={design}
+          status={bakeStatus}
+          errorMessage={BAKE_ERROR_MESSAGE}
+          // Retry re-targets success and loops back through busy → reveal,
+          // demonstrating the full error → retry → success → reveal recovery.
+          onRetry={() => {
+            setBakeTarget("success");
+            setBakeStatus("building");
+          }}
+          // No-op escape seam — real navigation is #449's job, matching the
+          // reveal stage's onViewBadge/onBackToGoals no-ops.
+          onExitWithoutBadge={() => {}}
+        />
+      )}
       {stage === "reveal" && (
         <FinishRevealStage
           badgeDesign={design}
@@ -115,8 +170,8 @@ function InteractiveFinishFlow({
 }
 
 /** Full sequence: press "Design your badge →", edit the badge, press "Bake my
- * badge", and the baking interstitial auto-advances to the reveal after 1100ms.
- * The threaded `design`/`goalTitle` is the same value at every stage. */
+ * badge", the baking interstitial resolves to success and auto-advances to the
+ * reveal. The threaded `design`/`goalTitle` is the same value at every stage. */
 export const Default: Story = {
   render: () => <InteractiveFinishFlow />,
 };
@@ -141,19 +196,33 @@ export const LongContent: Story = {
   ),
 };
 
+/** Bake resolves to the no-key permanent failure — the interstitial surfaces
+ * the escape affordance ("Continue without a badge") and does not advance. */
+export const NoKey: Story = {
+  render: () => <InteractiveFinishFlow bakeOutcome="no-key" />,
+};
+
+/** Bake fails, the error copy + Retry appear; tapping Retry returns to a busy
+ * phase, resolves to success, and advances to reveal — the full recovery loop. */
+export const FailureThenRetry: Story = {
+  render: () => <InteractiveFinishFlow bakeOutcome="error" />,
+};
+
 // ---------------------------------------------------------------------------
-// AllThemesMatrix — the two stages that carry theme-varying chrome tokens,
-// side by side across all 7 product themes (D3). Design owns
+// AllThemesMatrix — the stages that carry theme-varying chrome/state tokens,
+// side by side across all 7 product themes. Design owns
 // `chrome.screenHeaderBg/Fg/Border`; reveal owns `chrome.celebrationBg/Fg`
-// (#419). Celebrate/baking both style off plain `colors.background`, so they
-// add no matrix signal and are omitted.
+// (#419). The baking stage's success/no-key/error content pairs
+// `colors.error` against theme-varying background/text/border, so its three
+// resolved states are matrix-worthy (D7 — superseding #472's original note,
+// which was correct for the plain busy spinner that added no signal).
 //
 // A live per-cell `ScopedTheme` matrix is safe here — unlike the
 // NewGoalWizard/EditGoalView toolbar-switcher fallback, which exists because
 // those compose a hook that setStates after mount and defeats ScopedTheme on
-// web. All four Finish*Stage components are useState-only/prop-driven, and the
-// reveal pop-in uses a reanimated shared value (not React setState), so no
-// post-mount re-render reverts a cell to the toolbar theme.
+// web. All Finish*Stage cells below are prop-driven (no post-mount setState),
+// and the reveal pop-in uses a reanimated shared value (not React setState),
+// so no post-mount re-render reverts a cell to the toolbar theme.
 // ---------------------------------------------------------------------------
 
 // Human-facing mood label for each of the 7 product themes — mirror of the
@@ -168,7 +237,7 @@ const MOOD_NAMES: Record<ThemeName, string> = {
   "light-lowInfo": "Clean Signal",
 };
 
-// Shared, non-interactive fixture design threaded into both matrix rows —
+// Shared, non-interactive fixture design threaded into every matrix row —
 // same seed as the flow story (goal color + title), so the matrix and the
 // interactive flow show the same badge.
 const MATRIX_DESIGN: BadgeDesign = createDefaultBadgeDesign(
@@ -207,6 +276,33 @@ export const AllThemesMatrix: Story = {
                   animationPref="none"
                   onViewBadge={noop}
                   onBackToGoals={noop}
+                />
+              </View>
+            </ScopedTheme>
+            <ScopedTheme name={name}>
+              <View style={styles.matrixCell} pointerEvents="none">
+                <FinishBakingStage
+                  badgeDesign={MATRIX_DESIGN}
+                  status="success"
+                />
+              </View>
+            </ScopedTheme>
+            <ScopedTheme name={name}>
+              <View style={styles.matrixCell} pointerEvents="none">
+                <FinishBakingStage
+                  badgeDesign={MATRIX_DESIGN}
+                  status="no-key"
+                  onExitWithoutBadge={noop}
+                />
+              </View>
+            </ScopedTheme>
+            <ScopedTheme name={name}>
+              <View style={styles.matrixCell} pointerEvents="none">
+                <FinishBakingStage
+                  badgeDesign={MATRIX_DESIGN}
+                  status="error"
+                  errorMessage={BAKE_ERROR_MESSAGE}
+                  onRetry={noop}
                 />
               </View>
             </ScopedTheme>

--- a/apps/native-rd/src/stories/finish/FinishFlow.stories.tsx
+++ b/apps/native-rd/src/stories/finish/FinishFlow.stories.tsx
@@ -34,8 +34,9 @@ const GOAL_TITLE = "Rewire the workshop";
 const GOAL_COLOR = "#e11d48";
 const EARNED_DATE_LABEL = "Jun 23, 2026";
 
-// Fixture copy for the modeled error state — English literal, mirroring the
-// component's own defaults (D2). #449 threads real t() output through here.
+// Fixture copy for the modeled error state — English literal, in keeping with
+// D2's caller-supplied-copy convention. #449 threads real t() output through
+// here.
 const BAKE_ERROR_MESSAGE =
   "We couldn't finish baking your badge. Please try again.";
 
@@ -104,19 +105,23 @@ function InteractiveFinishFlow({
     setBakeStatus("building");
   }, [stage, bakeOutcome]);
 
-  // Resolve a busy phase to its target after the bake timer.
+  // Resolve a busy phase to its target after the bake timer. Gated on `stage`
+  // too: `bakeStatus` seeds to "building", so without the stage guard this
+  // timer would fire at mount (on celebrate) and drive the flow forward before
+  // the user ever reaches baking.
   useEffect(() => {
-    if (bakeStatus !== "building") return;
+    if (stage !== "baking" || bakeStatus !== "building") return;
     const timer = setTimeout(() => setBakeStatus(bakeTarget), BAKE_DURATION_MS);
     return () => clearTimeout(timer);
-  }, [bakeStatus, bakeTarget]);
+  }, [stage, bakeStatus, bakeTarget]);
 
-  // A resolved success briefly holds, then advances to the reveal stage.
+  // A resolved success briefly holds, then advances to the reveal stage. Also
+  // stage-gated so a stale "success" can't yank a user off another stage.
   useEffect(() => {
-    if (bakeStatus !== "success") return;
+    if (stage !== "baking" || bakeStatus !== "success") return;
     const timer = setTimeout(() => setStage("reveal"), SUCCESS_HOLD_MS);
     return () => clearTimeout(timer);
-  }, [bakeStatus]);
+  }, [stage, bakeStatus]);
 
   return (
     <View style={{ flex: 1, height: 640 }}>
@@ -212,17 +217,19 @@ export const FailureThenRetry: Story = {
 // AllThemesMatrix — the stages that carry theme-varying chrome/state tokens,
 // side by side across all 7 product themes. Design owns
 // `chrome.screenHeaderBg/Fg/Border`; reveal owns `chrome.celebrationBg/Fg`
-// (#419). The baking stage's success/no-key/error content pairs
-// `colors.error` against theme-varying background/text/border, so its three
-// resolved states are matrix-worthy (D7 — superseding #472's original note,
-// which was correct for the plain busy spinner that added no signal).
+// (#419). The baking stage's error cell pairs `colors.error` against the theme
+// background, and all three resolved states (success/no-key/error) add
+// theme-varying secondary-Button/text/border chrome — the matrix signal the
+// plain busy spinner lacked (D7 — superseding #472's original note, which was
+// correct for that spinner).
 //
 // A live per-cell `ScopedTheme` matrix is safe here — unlike the
 // NewGoalWizard/EditGoalView toolbar-switcher fallback, which exists because
 // those compose a hook that setStates after mount and defeats ScopedTheme on
-// web. All Finish*Stage cells below are prop-driven (no post-mount setState),
-// and the reveal pop-in uses a reanimated shared value (not React setState),
-// so no post-mount re-render reverts a cell to the toolbar theme.
+// web. The reveal pop-in uses a reanimated shared value (not React setState),
+// and `FinishBakingStage`'s only setState is a synchronous same-value
+// `retryPending` reset on mount that React bails out of — so no post-mount
+// re-render reverts a cell to the toolbar theme.
 // ---------------------------------------------------------------------------
 
 // Human-facing mood label for each of the 7 product themes — mirror of the


### PR DESCRIPTION
## Summary

- Models `FinishBakingStage`'s baking interstitial as a real state union (busy phases / no-key / error / success) instead of a single hardcoded spinner.
- Preserves the old `CompletionFlowScreen` bake-status semantics (no-key message, terminal-error copy + retry, alert/live-region a11y) inside the new component contract, and adds a non-dead-ending escape for no-key.
- Extends the interactive flow story to click through failure → retry → success, and adds the three new states to `AllThemesMatrix`.
- Storybook/state-surface only — real `useCreateBadge`/`useUserKey` wiring and navigation stay #449's job.

## Changes

- **`FinishBakingStage.tsx`**: `status` prop union + `successLabel`/`noKeyLabel`/`noKeyActionLabel`/`onExitWithoutBadge`/`errorMessage`/`retryLabel`/`onRetry` props; branch render on status; synchronous `retryFiredRef` duplicate-tap guard backing the `retryPending` state that drives `Button`'s `loading`/`busy`/`disabled`.
- **`FinishBakingStage.styles.ts`**: `messageContainer` (alert-over-action) + `errorText` (`theme.colors.error`).
- **`index.ts`**: export `FinishBakingPhase`/`FinishBakingStatus` types.
- **`FinishBakingStage.stories.tsx`**: `Success`, `NoKey`, `ErrorState` (local-state retry→success loop).
- **`FinishFlow.stories.tsx`**: `bakeOutcome` prop + modeled `bakeStatus`; `NoKey` + `FailureThenRetry` stories; success/no-key/error baking cells across all 7 themes in `AllThemesMatrix`.
- **Tests**: 14 cases across every status branch, a11y alert roles, the duplicate-tap guard, and retry re-arm.

## Intent Verification

- [x] `status="no-key"` shows the no-key message via `accessibilityRole="alert"` **and** a visible "Continue without a badge"-style action — never a spinner-only dead end.
- [x] `status="error"` shows the caller-supplied `errorMessage` via `accessibilityRole="alert"` and a `Retry` `Button` whose `onPress` invokes `onRetry` — fires exactly once even under two rapid presses (synchronous `retryFiredRef` guard backing `retryPending`).
- [x] The Retry button's `accessibilityState.busy`/`disabled` flip `true` on press (via `Button`'s `loading` prop).
- [x] `status="success"` renders the badge at full opacity (no dim, no spinner) with a distinct success label — a real, observable sub-state.
- [x] `FinishFlow.stories.tsx`'s `AllThemesMatrix` gains baking-stage cells (success/no-key/error) across all 7 `ScopedTheme` columns.
- [x] The interactive flow story demonstrates `baking → error → tap Retry → busy → success → reveal`; no actionable control is mounted during busy phases.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Extend `FinishBakingStage` in place with a `status` union mirroring `useCreateBadge`'s `BadgeCreationStatus` | One interstitial owns "what's happening while baking"; keeps #449 a near-verbatim pass-through of the real hook. |
| Stay i18n-free — new copy are props with English defaults | Matches #470 D2 for every other Finish*Stage component; #449 threads real `t()` through these props. |
| Error text uses `theme.colors.error` | Established destructive/error color across the codebase. |
| No-key gets an explicit `onExitWithoutBadge` escape (not a fake retry) | `useCreateBadge.retryBake()` is gated to `"error"` only; reusing `onRetry` would misrepresent it. Closes a real dead end in the old flow. |
| Duplicate-tap guard is internal, synchronous | Prevents a double-press in the same tick from firing `onRetry` twice, with no caller coordination. |
| `success` is a distinct visual sub-state | Acceptance criteria require matrix coverage + an observable moment before reveal. |
| `AllThemesMatrix` gains 3 baking cells | no-key/error content pairs `colors.error` against theme-varying chrome — real matrix signal (supersedes #472's note about the plain spinner). |

## Discovery Log

- [2026-07-21] D5 guard implemented as a `retryFiredRef` (synchronous) backing the `retryPending` state, not state alone. Two native taps in one frame (before React commits the disabled Button) would both slip past a stale-closure state check — the ref guarantees `onRetry` fires exactly once, while `retryPending` still drives `Button`'s `loading`/`busy`/`disabled`. Faithful to the plan's stated intent.
- [2026-07-21] Added `testID="finish-baking-badge-dim"` to the dim wrapper so the success-state test can assert full-opacity (wrapper absent) via testID.
- [2026-07-21] The status-reset `useEffect` (component) and the baking-seed `useEffect` (flow story) each trip the `setState-synchronously-within-an-effect` lint **warning** (0 errors). Left as-is: the pattern appears in 28 other repo files, the cascades are bounded, and both resets are prop-transition-driven.

## Test Plan

- [x] Type-check passes (`bun run type-check`)
- [x] Lint passes — 0 errors (`bun run lint`)
- [x] Tests pass — 14/14 (`bun run test --testPathPatterns FinishBakingStage`)
- [x] Build script (no-op for native-rd)
- [ ] Visual: Storybook `Iteration B/Finish/FinishBakingStage` (Success/NoKey/ErrorState) + `Iteration B/Finish/Flow` (FailureThenRetry, NoKey) + `AllThemesMatrix` legibility across all 7 themes

---

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwnWPe9YNCTpkTNGgHMBqy