### PR TITLE
fix(timeline): adopt prototype state words — Done / Set aside / Working / Up next (#453)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-453-timeline-state-words.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-453-timeline-state-words.md
@@ -1,0 +1,110 @@
+# Development Plan: Issue #453
+
+## Issue Summary
+
+**Title**: fix(timeline): adopt prototype state words — Done / Set aside / Working / Up next
+**Type**: fix (i18n copy + label routing; no new UI, no data changes)
+**Complexity**: LOW–MEDIUM (the code change is small; the scope question in Q1 is the real work)
+**Estimated Lines**: ~90–140 lines including tests/stories — above the issue's own "~50–80 LOC" estimate, because `badgeI18nKey` turns out to have **four** consumers rather than the one the issue assumed (see Discovery Log).
+
+## Status
+
+Branch `feat/issue-453-timeline-state-words` cut from `main` @ `3214556f`. Plan written; **no implementation yet**. Q1 and Q2 below need answers before Step 2 lands.
+
+## Why now
+
+#453's own body says "Land before or with #378 so the assembled Timeline ships the right words." That did not happen — #378 merged as PR #517 (`3214556f`, 2026-07-25). The assembled Timeline screen therefore ships **two vocabularies on one screen** today:
+
+| Surface                                    | Renders                                       | Words shown                                      |
+| ------------------------------------------ | --------------------------------------------- | ------------------------------------------------ |
+| `TimelineBreakdownBar` legend chips (#451) | `common:timelineBreakdown.legend.*`           | "3 done · 1 in motion · 4 to come · 1 set aside" |
+| `TimelineStep` state pill (`StateWord`)    | `common:stepCard.status.*` via `badgeI18nKey` | "Completed / In Progress / Pending / Paused"     |
+| `TimelineNode` `StateBadge`                | `common:stepCard.status.*` via `badgeI18nKey` | "Completed / In Progress / Pending / Paused"     |
+
+Neither pill vocabulary matches the prototype words this issue mandates. Closing #453 makes the screen speak one language.
+
+## Objective
+
+Route the Timeline's **step state words** to new `timelineJourney`-namespaced keys reading **Done / Set aside / Working / Up next**, without disturbing the `common:stepCard.status.*` words that `StepCard`, `FocusCurrentTaskCard`, and `FocusParkedState` still depend on. Colors keep travelling through #406's `stepStateColorMap` unchanged.
+
+## Discovery Log
+
+Verified against `main` @ `3214556f`:
+
+1. **`badgeI18nKey` has four consumers, not one.** The issue scopes itself to "`TimelineStep`'s `StateWord` pill", but `grep -rn badgeI18nKey src` returns:
+   - `src/components/TimelineNode/TimelineNode.tsx:136` — `StateBadge`, a **visible** text badge (not a11y-only)
+   - `src/components/TimelineStep/TimelineStep.tsx:73` — parent-row pill
+   - `src/components/TimelineStep/TimelineStep.tsx:177` — child-row pill
+   - `src/components/FocusCurrentTaskCard/FocusCurrentTaskCard.parts.tsx:33` — Focus surface, **must not change** (see Q1)
+2. **The map is typed to the `common` namespace.** `stepStateColorMap.ts:31` declares `export type StepStateBadgeKey = \`common:stepCard.status.${StepStateMapKey}\``, and each of the four entries (lines 63/69/75/88) sets `badgeI18nKey` to that shape. Any new key set needs its own template-literal type or the compile-time guarantee is lost.
+3. **`StepStateMapKey` is exactly four states** — `completed`, `in-progress`, `pending`, `paused` — so the new key group is a 1:1 replacement with no gaps.
+4. **The prototypes disagree on the `pending` word** (Q2). `Timeline A Prototype.dc.html` and `Timeline Directions.dc.html` say **"To do"**; the issue title and body say **"Up next"**, which appears in `Add Evidence Nav.dc.html`. The issue cites `App Shell.dc.html` ~line 250 as the source of all four words, but grepping App Shell finds "Done", "Set aside", "Working" — and no "Up next".
+5. **The legend's separate vocabulary is deliberate, not drift.** `Timeline Directions.dc.html` contains "in motion" and "to come" _alongside_ "Working" and "To do" — the prototype intends counts ("4 to come") to read differently from pills ("Up next"). This reverses the concern I raised when recommending the issue: **do not** fold the `timelineBreakdown.legend.*` words into this change.
+6. **`FocusParkedState` deliberately renders `common:stepCard.status.paused`** — recorded as decision D4 in `issue-450-focus-progress-strip-parked.md`, with the user resolving it to Title-Case "Paused" for app-wide consistency. Repointing `badgeI18nKey` globally would silently overturn that decision.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                   | Alternatives Considered                                                                                                                     | Rationale                                                                                                                                                                                                                                                                                               |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Add a **second** typed key field to `stepStateColorMap` — `stateWordI18nKey: \`timelineJourney:step.stateWord.${StepStateMapKey}\``— and leave`badgeI18nKey` untouched.                                    | (a) Repoint `badgeI18nKey` at the new keys; (b) a `TimelineStep`-local resolver function mirroring `TimelineBreakdownBar`'s `legendI18nKey` | (a) leaks the Timeline words into `StepCard` + both Focus surfaces and overturns #450 D4. (b) works for `TimelineStep` but `TimelineNode` needs the same words (Q1), and a resolver duplicated across two files is exactly the drift `stepStateColorMap` exists to prevent. One map, two labelled uses. |
+| D2  | New keys live under `timelineJourney:step.stateWord.*`, siblings of the existing `step.status.*` group.                                                                                                    | Reuse/rename the existing `timelineJourney:step.status.*` group (already "Done / Active / Pending")                                         | `step.status.*` is consumed by the screen's own a11y strings; repurposing it mid-flight would couple two unrelated edits. A new group makes the diff reviewable and the old group's fate a separate cleanup (see Follow-ups).                                                                           |
+| D3  | English + `_register/timelineJourney.yml` only. Regenerate `pseudo/` in this PR via `bun run gen:pseudo` (the `locale-parity` test gates on en↔pseudo). Never hand-edit `de/` — the i18n-sync bot owns it. | Hand-translate `de/`                                                                                                                        | Repo hard rule, restated in the issue. A `de/` commit appearing on the PR from the bot is expected.                                                                                                                                                                                                     |
+| D4  | `StepCard`'s own keys stay untouched.                                                                                                                                                                      | Migrate StepCard too                                                                                                                        | Issue is explicit: StepCard is old language being replaced by #377/#466, "not worth churning."                                                                                                                                                                                                          |
+| D5  | Register note goes in `_register/timelineJourney.yml`, and it must state that the pill words are intentionally **not** the legend words.                                                                   | Leave the register silent                                                                                                                   | Two similar-but-different vocabularies in one namespace is precisely what a translator will "helpfully" unify. The `common.yml` legend note added in #517 already guards the other side.                                                                                                                |
+
+## Open Questions — answer before Step 2
+
+**Q1 — Does `TimelineNode`'s `StateBadge` adopt the new words too?**
+`TimelineNode.tsx:136` renders a visible badge from `badgeI18nKey`. It sits on the Timeline screen next to `TimelineStep`'s pill, so leaving it behind trades the current inconsistency for a subtler one ("Done" pill above a "Completed" badge). But `TimelineNode` is imported by more than the Timeline screen — `grep -rl TimelineNode src` also hits `FocusProgressStrip`, `FocusCurrentTaskCard.parts.tsx`, `FinishLine`, and `TimelineBreakdownBar`. **Most of those import `stepStateColorMap`/`stepStateNodeBg` from the `TimelineNode/` directory rather than rendering the component**, but that must be confirmed per-file before switching `StateBadge` — if any Focus surface renders an actual `<TimelineNode>`, the new words leak into Focus.
+_Recommendation:_ switch `StateBadge` as well, **after** confirming only `TimelineJourneyScreen`/`TimelineStep` render the component. Step 0 below does that check.
+
+**Q2 — "Up next" or "To do" for `pending`?**
+Issue title and body say "Up next"; the two Timeline prototypes say "To do". _Recommendation:_ ship **"Up next"** — the issue title is the recorded decision from the 2026-07-02 readiness review and "To do" collides with generic task-app phrasing. Flag it in the PR body so the reviewer can veto cheaply (it's a one-line change to one JSON value).
+
+**Q3 — Casing.** Prototype pills render lowercase in some places ("set aside"). #450 D4 already resolved the analogous question in favour of Title-Case for app-wide consistency. _Recommendation:_ Title-Case — "Done / Set aside / Working / Up next" exactly as the issue title writes them.
+
+## Affected Areas
+
+- `src/components/TimelineNode/stepStateColorMap.ts` — new `StepStateWordKey` template-literal type + `stateWordI18nKey` on all four entries.
+- `src/components/TimelineStep/TimelineStep.tsx` — lines 73 and 177 switch to `stateWordI18nKey`. The `useTranslation` call already loads `["common", "timelineJourney"]`, so no namespace change needed.
+- `src/components/TimelineNode/TimelineNode.tsx` — `StateBadge` switches (pending Q1); its `useTranslation(["common"])` gains `"timelineJourney"`.
+- `src/i18n/resources/en/timelineJourney.json` — new `step.stateWord` group.
+- `src/i18n/resources/_register/timelineJourney.yml` — voice note per D5.
+- `src/i18n/resources/pseudo/timelineJourney.json` — regenerated.
+- Tests/stories asserting the old strings: `src/components/TimelineStep/__tests__/TimelineStep.test.tsx`, `src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx`, plus `TimelineNode`'s own tests/stories if Q1 lands. `TimelineJourneyScreen.tsx` also matched the grep for old label strings — check whether that's a literal or a comment before editing.
+
+## Commit Plan
+
+| #   | Commit                                                                     | Contents                                                                                                        |
+| --- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 0   | _(no commit)_                                                              | Answer Q1 by auditing every `TimelineNode` importer: does it render the component or only import the map?       |
+| 1   | `feat(i18n): add timelineJourney step state words (#453)`                  | `en/timelineJourney.json` group + `_register` note (D5) + regenerated `pseudo/`. No consumers yet — inert.      |
+| 2   | `feat(timeline): route step state pills to prototype state words (#453)`   | `stateWordI18nKey` on `stepStateColorMap`; `TimelineStep:73/177` switched; `TimelineNode.StateBadge` if Q1 yes. |
+| 3   | `test(timeline): assert prototype state words on timeline surfaces (#453)` | Update the assertions above; add one case per state so a future silent repoint fails loudly.                    |
+
+Keep them separate: commit 1 is reviewable as pure copy, commit 2 as pure routing.
+
+## Testing Strategy
+
+- `bun run test --testPathPatterns "TimelineStep|TimelineNode|TimelineJourneyScreen"` — never `bun test`, and the flag is `--testPathPatterns` (plural).
+- Assert the **rendered word**, not the key, for all four states on both surfaces — a test that only checks `t()` was called would pass through a wrong-namespace regression.
+- Confirm `StepCard` / `FocusCurrentTaskCard` / `FocusParkedState` tests still pass **unchanged**. If any of them start failing, D1 has been violated — something repointed `badgeI18nKey`.
+- `locale-parity` must stay green (that's what forces the `pseudo/` regeneration in commit 1).
+- Full gates before each commit: `bun run type-check` && `bun run lint`.
+- Visual: the Timeline screen across the 7 ND variants — the pills are `stepStateColorMap`-coloured and the new words are longer than the old ones in places ("Set aside" vs "Paused"), so watch for wrapping/clipping at `largeText` and `lowVision`.
+
+## Non-Goals
+
+- **Not** touching `common:timelineBreakdown.legend.*` — Discovery Log #5 shows the different legend words are intentional.
+- **Not** migrating `StepCard` (D4), and **not** touching Focus Mode's own copy — #466 owns that surface and is being worked in parallel in another worktree.
+- **Not** renaming the existing `timelineJourney:step.status.*` group (D2).
+
+## Follow-ups (file as issues, not chat)
+
+1. Once #466/#467 retire the old Focus chrome, `common:stepCard.status.*` may have no Timeline-adjacent consumers left — revisit whether `badgeI18nKey` and `stateWordI18nKey` should collapse back into one field.
+2. Decide the fate of the now-overlapping `timelineJourney:step.status.*` group (D2) — likely dead once the a11y strings are audited.
+3. `TimelineJourneyScreen.tsx` matched a grep for old state-label strings; if that's a hardcoded literal rather than a comment, it's a separate a11y-literal bug (candidate for the #455 cleanup sweep).
+
+## Coordination
+
+Another agent is working **#466** (Focus Mode rebuild 1/2) in a separate worktree. Files that issue was told not to touch are exactly this issue's surface area (`TimelineStep/**`, `stepStateColorMap.ts`, `en/common.json`, `en/timelineJourney.json`, `_register/common.yml`, `_register/timelineJourney.yml`). If #466 needs a state word, it adds one to `focusMode.json` — so a conflict here means one of us broke the boundary.

--- a/apps/native-rd/docs/plans/dev-plans/issue-453-timeline-state-words.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-453-timeline-state-words.md
@@ -9,9 +9,21 @@
 
 ## Status
 
-Branch `feat/issue-453-timeline-state-words` cut from `main` @ `3214556f`, pushed. Plan written and **all questions resolved (2026-07-25)** — see Resolved Questions. **No implementation yet.**
+Branch `feat/issue-453-timeline-state-words` cut from `main` @ `3214556f`. Plan written, **all questions resolved (2026-07-25)**, and **implemented (2026-07-25)** — all three commits landed as planned:
 
-**Resuming from a fresh context?** Start at Step 0 of the Commit Plan. Everything needed is in this file; nothing is waiting on the user. Read `apps/native-rd/CLAUDE.md` first for the hard rules (`bun run test` never `bun test`, `--testPathPatterns` plural, DCO sign-off on every commit, no hardcoded hex, no interactive CLI commands).
+| #   | Commit     | Subject                                                             |
+| --- | ---------- | ------------------------------------------------------------------- |
+| 1   | `3c12a55d` | `feat(i18n): add timelineJourney step state words`                  |
+| 2   | `9ab0c173` | `feat(timeline): route step state pills to prototype state words`   |
+| 3   | `d1466eb3` | `test(timeline): assert prototype state words on timeline surfaces` |
+
+Gates: `bun run type-check` clean, `bun run lint` 0 errors (222 pre-existing warnings), full `bun run test` green — **213 suites / 10022 tests**. `StepCard` / `FocusCurrentTaskCard` / `FocusParkedState` suites pass **untouched**, which is the check that D1 held.
+
+Not yet done: no PR (`/self-review` → `/finalize` still to run), and the **visual pass across the 7 ND variants is outstanding** — see Testing Strategy for what to look for ("Set aside" is longer than "Paused").
+
+### Step 0 audit result (Q1 decision rule → switch)
+
+`grep -rn "<TimelineNode"` finds three renderers: `TimelineStep.tsx:79` and `:181` (both Timeline), and `FinishLine.tsx:45` — which renders `isGoalNode` without `showStateBadge`, and a goal node never carries a `StateBadge` at all (`TimelineNode.tsx:118`). The Focus surfaces import only the map (`FocusCurrentTaskCard.parts.tsx:33` reads `badgeI18nKey`; nothing renders the component). **No non-Timeline renderer → `StateBadge` switched outright**, no `stateWordSource` prop needed, no follow-up owed.
 
 ## Why now
 
@@ -116,9 +128,10 @@ Keep them separate: commit 1 is reviewable as pure copy, commit 2 as pure routin
 
 ## Follow-ups (file as issues, not chat)
 
-1. Once #466/#467 retire the old Focus chrome, `common:stepCard.status.*` may have no Timeline-adjacent consumers left — revisit whether `badgeI18nKey` and `stateWordI18nKey` should collapse back into one field.
-2. Decide the fate of the now-overlapping `timelineJourney:step.status.*` group (D2) — likely dead once the a11y strings are audited.
-3. `TimelineJourneyScreen.tsx` matched a grep for old state-label strings; if that's a hardcoded literal rather than a comment, it's a separate a11y-literal bug (candidate for the #455 cleanup sweep).
+1. **Open — filed as #519.** Once #466/#467 retire the old Focus chrome, `common:stepCard.status.*` may have no Timeline-adjacent consumers left — revisit whether `badgeI18nKey` and `stateWordI18nKey` should collapse back into one field.
+2. **Open — filed as #520, and confirmed dead.** The `timelineJourney:step.status.*` group (D2) has **zero code consumers**: `grep -rn "step\.status"` over `src/` returns only `step.status` _data_ reads (`StepCard`, `FocusModeScreen`, tests) plus the resource files themselves. Nothing resolved it even before this change — the a11y-strings audit D2 deferred to is unnecessary, it can just be deleted (en + pseudo + register note).
+3. **Resolved, no issue needed.** The `TimelineJourneyScreen.tsx` grep hits are both prose comments (lines 45 and 50, describing the accent resolver), not display literals. No a11y-literal bug, nothing for the #455 sweep.
+4. **New — filed as #521.** `bun run gen:pseudo` is not idempotent on `main`: re-running it also rewrites padding in `pseudo/badgeDetail.json`, `pseudo/completion.json`, and `pseudo/editGoal.json` (dot-padding lengths only, no key changes — which is why `locale-parity` never caught it). Those three were reverted here to keep this PR's diff scoped to copy + routing. Someone should regenerate them on their own commit and check whether the generator's padding formula changed after those namespaces were last written.
 
 ## Coordination
 

--- a/apps/native-rd/docs/plans/dev-plans/issue-453-timeline-state-words.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-453-timeline-state-words.md
@@ -9,7 +9,9 @@
 
 ## Status
 
-Branch `feat/issue-453-timeline-state-words` cut from `main` @ `3214556f`. Plan written; **no implementation yet**. Q1 and Q2 below need answers before Step 2 lands.
+Branch `feat/issue-453-timeline-state-words` cut from `main` @ `3214556f`, pushed. Plan written and **all questions resolved (2026-07-25)** — see Resolved Questions. **No implementation yet.**
+
+**Resuming from a fresh context?** Start at Step 0 of the Commit Plan. Everything needed is in this file; nothing is waiting on the user. Read `apps/native-rd/CLAUDE.md` first for the hard rules (`bun run test` never `bun test`, `--testPathPatterns` plural, DCO sign-off on every commit, no hardcoded hex, no interactive CLI commands).
 
 ## Why now
 
@@ -52,22 +54,35 @@ Verified against `main` @ `3214556f`:
 | D4  | `StepCard`'s own keys stay untouched.                                                                                                                                                                      | Migrate StepCard too                                                                                                                        | Issue is explicit: StepCard is old language being replaced by #377/#466, "not worth churning."                                                                                                                                                                                                          |
 | D5  | Register note goes in `_register/timelineJourney.yml`, and it must state that the pill words are intentionally **not** the legend words.                                                                   | Leave the register silent                                                                                                                   | Two similar-but-different vocabularies in one namespace is precisely what a translator will "helpfully" unify. The `common.yml` legend note added in #517 already guards the other side.                                                                                                                |
 
-## Open Questions — answer before Step 2
+## Resolved Questions (user, 2026-07-25)
 
-**Q1 — Does `TimelineNode`'s `StateBadge` adopt the new words too?**
-`TimelineNode.tsx:136` renders a visible badge from `badgeI18nKey`. It sits on the Timeline screen next to `TimelineStep`'s pill, so leaving it behind trades the current inconsistency for a subtler one ("Done" pill above a "Completed" badge). But `TimelineNode` is imported by more than the Timeline screen — `grep -rl TimelineNode src` also hits `FocusProgressStrip`, `FocusCurrentTaskCard.parts.tsx`, `FinishLine`, and `TimelineBreakdownBar`. **Most of those import `stepStateColorMap`/`stepStateNodeBg` from the `TimelineNode/` directory rather than rendering the component**, but that must be confirmed per-file before switching `StateBadge` — if any Focus surface renders an actual `<TimelineNode>`, the new words leak into Focus.
-_Recommendation:_ switch `StateBadge` as well, **after** confirming only `TimelineJourneyScreen`/`TimelineStep` render the component. Step 0 below does that check.
+**Q1 — Does `TimelineNode`'s `StateBadge` adopt the new words too? → YES.**
+`TimelineNode.tsx:136` renders a visible badge from `badgeI18nKey`, sitting on the Timeline screen next to `TimelineStep`'s pill, so leaving it behind would trade the current inconsistency for a subtler one ("Done" pill above a "Completed" badge). Switch it.
 
-**Q2 — "Up next" or "To do" for `pending`?**
-Issue title and body say "Up next"; the two Timeline prototypes say "To do". _Recommendation:_ ship **"Up next"** — the issue title is the recorded decision from the 2026-07-02 readiness review and "To do" collides with generic task-app phrasing. Flag it in the PR body so the reviewer can veto cheaply (it's a one-line change to one JSON value).
+The Step 0 audit still runs, but it no longer decides _whether_ — only what to do if it finds a leak. `grep -rl TimelineNode src` hits `FocusProgressStrip`, `FocusCurrentTaskCard.parts.tsx`, `FinishLine`, and `TimelineBreakdownBar`; the expectation is that all of those import `stepStateColorMap`/`stepStateNodeBg` from the `TimelineNode/` **directory** rather than rendering the component. Decision rule, so this cannot reopen mid-implementation:
 
-**Q3 — Casing.** Prototype pills render lowercase in some places ("set aside"). #450 D4 already resolved the analogous question in favour of Title-Case for app-wide consistency. _Recommendation:_ Title-Case — "Done / Set aside / Working / Up next" exactly as the issue title writes them.
+- **No non-Timeline renderer of `<TimelineNode>`** (expected case) → switch `StateBadge` to `stateWordI18nKey` outright.
+- **A Focus surface does render `<TimelineNode>`** → do **not** switch `StateBadge`. Leave it on `badgeI18nKey`, ship the `TimelineStep` half only, and file a follow-up issue for a per-call-site label choice (a `stateWordSource`-style prop, or lifting the badge out of the shared node). Note it in the PR body. Do not invent the prop in this PR — it is scope creep on a copy fix.
+
+**Q2 — "Up next" or "To do" for `pending`? → "Up next".**
+The issue title is the recorded 2026-07-02 readiness-review decision, and "To do" collides with generic task-app phrasing. The two Timeline prototypes say "To do", so flag the divergence in the PR body — reverting is one JSON value if a reviewer disagrees.
+
+**Q3 — Casing → Title-Case**, exactly as the issue title writes them: "Done / Set aside / Working / Up next". Resolved by precedent rather than fresh decision: #450 D4 settled the analogous lowercase-mockup question in favour of app-wide Title-Case.
+
+**Final word list** (`timelineJourney:step.stateWord.*`):
+
+| `StepStateMapKey` | Word      |
+| ----------------- | --------- |
+| `completed`       | Done      |
+| `paused`          | Set aside |
+| `in-progress`     | Working   |
+| `pending`         | Up next   |
 
 ## Affected Areas
 
 - `src/components/TimelineNode/stepStateColorMap.ts` — new `StepStateWordKey` template-literal type + `stateWordI18nKey` on all four entries.
 - `src/components/TimelineStep/TimelineStep.tsx` — lines 73 and 177 switch to `stateWordI18nKey`. The `useTranslation` call already loads `["common", "timelineJourney"]`, so no namespace change needed.
-- `src/components/TimelineNode/TimelineNode.tsx` — `StateBadge` switches (pending Q1); its `useTranslation(["common"])` gains `"timelineJourney"`.
+- `src/components/TimelineNode/TimelineNode.tsx` — `StateBadge` switches (Q1 = yes); its `useTranslation(["common"])` at line 131 gains `"timelineJourney"`.
 - `src/i18n/resources/en/timelineJourney.json` — new `step.stateWord` group.
 - `src/i18n/resources/_register/timelineJourney.yml` — voice note per D5.
 - `src/i18n/resources/pseudo/timelineJourney.json` — regenerated.
@@ -75,12 +90,12 @@ Issue title and body say "Up next"; the two Timeline prototypes say "To do". _Re
 
 ## Commit Plan
 
-| #   | Commit                                                                     | Contents                                                                                                        |
-| --- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| 0   | _(no commit)_                                                              | Answer Q1 by auditing every `TimelineNode` importer: does it render the component or only import the map?       |
-| 1   | `feat(i18n): add timelineJourney step state words (#453)`                  | `en/timelineJourney.json` group + `_register` note (D5) + regenerated `pseudo/`. No consumers yet — inert.      |
-| 2   | `feat(timeline): route step state pills to prototype state words (#453)`   | `stateWordI18nKey` on `stepStateColorMap`; `TimelineStep:73/177` switched; `TimelineNode.StateBadge` if Q1 yes. |
-| 3   | `test(timeline): assert prototype state words on timeline surfaces (#453)` | Update the assertions above; add one case per state so a future silent repoint fails loudly.                    |
+| #   | Commit                                                                     | Contents                                                                                                                     |
+| --- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 0   | _(no commit)_                                                              | Audit every `TimelineNode` importer — renders `<TimelineNode>` or only imports the map? Apply the Q1 decision rule.          |
+| 1   | `feat(i18n): add timelineJourney step state words (#453)`                  | `en/timelineJourney.json` group (word list above) + `_register` note (D5) + regenerated `pseudo/`. No consumers yet — inert. |
+| 2   | `feat(timeline): route step state pills to prototype state words (#453)`   | `stateWordI18nKey` on `stepStateColorMap`; `TimelineStep:73/177` switched; `TimelineNode.StateBadge` switched per Q1.        |
+| 3   | `test(timeline): assert prototype state words on timeline surfaces (#453)` | Update the assertions above; add one case per state so a future silent repoint fails loudly.                                 |
 
 Keep them separate: commit 1 is reviewable as pure copy, commit 2 as pure routing.
 

--- a/apps/native-rd/src/components/TimelineNode/TimelineNode.tsx
+++ b/apps/native-rd/src/components/TimelineNode/TimelineNode.tsx
@@ -26,7 +26,7 @@ export interface TimelineNodeProps {
   label?: string;
   /**
    * When true (and not a goal node), render a state-word badge below the node,
-   * labelled from the `common` namespace via stepStateColorMap. Default-off so
+   * labelled from `timelineJourney` via stepStateColorMap (#453). Default-off so
    * live consumers — which already render a StatusBadge beside each node — stay
    * byte-identical; only stories opt in (#406 D7).
    */
@@ -128,12 +128,12 @@ export function TimelineNode({
 }
 
 function StateBadge({ status }: { status: StepStatus }) {
-  const { t } = useTranslation(["common"]);
+  const { t } = useTranslation(["timelineJourney"]);
 
   return (
     <View accessibilityRole="text" style={styles.stateBadge}>
       <Text style={styles.stateBadgeText}>
-        {t(stepStateColorMap[status].badgeI18nKey)}
+        {t(stepStateColorMap[status].stateWordI18nKey)}
       </Text>
     </View>
   );

--- a/apps/native-rd/src/components/TimelineNode/__tests__/TimelineNode.test.tsx
+++ b/apps/native-rd/src/components/TimelineNode/__tests__/TimelineNode.test.tsx
@@ -88,24 +88,33 @@ describe("TimelineNode", () => {
 
   // State-word badge (showStateBadge, #406 D7). Labels come from live i18n
   // (src/i18n/index.ts is a Jest setupFile), so these are the real `t()` values.
+  // The words are the prototype vocabulary from timelineJourney:step.stateWord.*
+  // (#453) — `staleWord` is the common:stepCard.status.* word the badge used to
+  // render, asserted absent so a silent repoint back to `badgeI18nKey` fails here
+  // rather than shipping two vocabularies onto one screen.
   it.each([
-    { status: "pending" as const, label: "Pending" },
-    { status: "in-progress" as const, label: "In Progress" },
-    { status: "paused" as const, label: "Paused" },
-    { status: "completed" as const, label: "Completed" },
+    { status: "pending" as const, label: "Up next", staleWord: "Pending" },
+    {
+      status: "in-progress" as const,
+      label: "Working",
+      staleWord: "In Progress",
+    },
+    { status: "paused" as const, label: "Set aside", staleWord: "Paused" },
+    { status: "completed" as const, label: "Done", staleWord: "Completed" },
   ])(
-    'renders the "$label" state badge for $status when showStateBadge',
-    ({ status, label }) => {
+    'renders the "$label" state badge for $status when showStateBadge, not "$staleWord"',
+    ({ status, label, staleWord }) => {
       renderWithProviders(
         <TimelineNode {...baseProps} status={status} showStateBadge />,
       );
       expect(screen.getByText(label)).toBeOnTheScreen();
+      expect(screen.queryByText(staleWord)).toBeNull();
     },
   );
 
   it("does not render the state badge by default (live-consumer no-regression)", () => {
     renderWithProviders(<TimelineNode {...baseProps} status="in-progress" />);
-    expect(screen.queryByText("In Progress")).toBeNull();
+    expect(screen.queryByText("Working")).toBeNull();
   });
 
   it("does not render the state badge on a goal node even when showStateBadge is set", () => {
@@ -117,6 +126,6 @@ describe("TimelineNode", () => {
         showStateBadge
       />,
     );
-    expect(screen.queryByText("Completed")).toBeNull();
+    expect(screen.queryByText("Done")).toBeNull();
   });
 });

--- a/apps/native-rd/src/components/TimelineNode/stepStateColorMap.ts
+++ b/apps/native-rd/src/components/TimelineNode/stepStateColorMap.ts
@@ -30,9 +30,31 @@ export type StepStateMapKey =
  */
 export type StepStateBadgeKey = `common:stepCard.status.${StepStateMapKey}`;
 
+/**
+ * Fully-namespaced i18n key for the Timeline's own state word — the prototype
+ * vocabulary "Done / Set aside / Working / Up next" (#453). Same
+ * template-literal shape as {@link StepStateBadgeKey}, different namespace.
+ */
+export type StepStateWordKey =
+  `timelineJourney:step.stateWord.${StepStateMapKey}`;
+
 interface StepStateBase {
-  /** i18n key (with namespace) for the state-word badge label. */
+  /**
+   * i18n key (with namespace) for the state-word badge label, in the older
+   * `common:stepCard.status.*` vocabulary ("Completed / In Progress / Pending /
+   * Paused"). Read by `StepCard` and the Focus surfaces. Timeline surfaces read
+   * {@link StepStateBase.stateWordI18nKey} instead — see the note there.
+   */
   badgeI18nKey: StepStateBadgeKey;
+  /**
+   * i18n key (with namespace) for the Timeline's state word (#453). Deliberately
+   * a second field rather than a repointed `badgeI18nKey`: the Timeline speaks
+   * the prototype's vocabulary while `StepCard` / `FocusCurrentTaskCard` /
+   * `FocusParkedState` keep theirs (the last of which is a recorded decision,
+   * #450 D4). One map, two labelled uses — so the two vocabularies cannot drift
+   * apart in separate per-component resolvers.
+   */
+  stateWordI18nKey: StepStateWordKey;
   /** Unicode glyph for the node interior, overriding the step number. */
   nodeGlyph?: string;
 }
@@ -61,18 +83,21 @@ export const stepStateColorMap: Record<StepStateMapKey, StepStateEntry> = {
     nodeBgKey: "journeyStepBg",
     nodeFgKey: "journeyStepFg",
     badgeI18nKey: "common:stepCard.status.pending",
+    stateWordI18nKey: "timelineJourney:step.stateWord.pending",
   },
   "in-progress": {
     source: "journey",
     nodeBgKey: "journeyStepActiveBg",
     nodeFgKey: "journeyStepActiveFg",
     badgeI18nKey: "common:stepCard.status.in-progress",
+    stateWordI18nKey: "timelineJourney:step.stateWord.in-progress",
   },
   completed: {
     source: "journey",
     nodeBgKey: "journeyStepCompleteBg",
     nodeFgKey: "journeyStepCompleteFg",
     badgeI18nKey: "common:stepCard.status.completed",
+    stateWordI18nKey: "timelineJourney:step.stateWord.completed",
     nodeGlyph: "✓",
   },
   paused: {
@@ -86,6 +111,7 @@ export const stepStateColorMap: Record<StepStateMapKey, StepStateEntry> = {
     nodeBgColorsFallback: "accentPurpleLight",
     nodeFgColorsFallback: "text",
     badgeI18nKey: "common:stepCard.status.paused",
+    stateWordI18nKey: "timelineJourney:step.stateWord.paused",
     nodeGlyph: "⏸",
   },
 };

--- a/apps/native-rd/src/components/TimelineStep/TimelineStep.tsx
+++ b/apps/native-rd/src/components/TimelineStep/TimelineStep.tsx
@@ -66,11 +66,12 @@ export function TimelineStep({
   defaultExpanded = false,
   subSteps = [],
 }: TimelineStepProps) {
-  const { t } = useTranslation(["common", "timelineJourney"]);
+  const { t } = useTranslation(["timelineJourney"]);
   const [expanded, setExpanded] = useState(defaultExpanded);
   // E (state) — the one #406 color language: the header state word reads from the
   // same map the node uses (stepStateColorMap), replacing the old StatusBadge.
-  const statusLabel = t(stepStateColorMap[step.status].badgeI18nKey);
+  // The word itself is the Timeline's own vocabulary (#453), not StepCard's.
+  const statusLabel = t(stepStateColorMap[step.status].stateWordI18nKey);
 
   return (
     <View style={styles.wrapper}>
@@ -169,12 +170,12 @@ function ChildRow({
   onNodePress: (stepIndex: number) => void;
   onEvidencePress: (evidenceId: string) => void;
 }) {
-  const { t } = useTranslation(["common", "timelineJourney"]);
+  const { t } = useTranslation(["timelineJourney"]);
   const [expanded, setExpanded] = useState(false);
   // #406 state word (E) replaces StatusBadge here too. Children carry no C/B
   // band (OQ-2); the evidence drawer below is pre-existing #293 behavior — the
   // prototype's E-only (no-drawer) child is a fidelity follow-up owned by #378.
-  const statusLabel = t(stepStateColorMap[child.status].badgeI18nKey);
+  const statusLabel = t(stepStateColorMap[child.status].stateWordI18nKey);
 
   return (
     <View style={styles.childRow}>

--- a/apps/native-rd/src/components/TimelineStep/__tests__/TimelineStep.test.tsx
+++ b/apps/native-rd/src/components/TimelineStep/__tests__/TimelineStep.test.tsx
@@ -36,13 +36,14 @@ describe("TimelineStep", () => {
   it("renders step title and state word", () => {
     renderWithProviders(<TimelineStep {...baseProps} />);
     expect(screen.getByText("Read the docs")).toBeOnTheScreen();
-    expect(screen.getByText("In Progress")).toBeOnTheScreen();
+    expect(screen.getByText("Working")).toBeOnTheScreen();
   });
 
   it.each([
-    { status: "completed" as const, label: "Completed" },
-    { status: "in-progress" as const, label: "In Progress" },
-    { status: "pending" as const, label: "Pending" },
+    { status: "completed" as const, label: "Done" },
+    { status: "in-progress" as const, label: "Working" },
+    { status: "pending" as const, label: "Up next" },
+    { status: "paused" as const, label: "Set aside" },
   ])('shows "$label" for $status status', ({ status, label }) => {
     renderWithProviders(
       <TimelineStep {...baseProps} step={{ ...baseStep, status }} />,
@@ -57,14 +58,14 @@ describe("TimelineStep", () => {
 
   it("expands evidence on header tap", () => {
     renderWithProviders(<TimelineStep {...baseProps} />);
-    fireEvent.press(screen.getByLabelText("Read the docs, In Progress"));
+    fireEvent.press(screen.getByLabelText("Read the docs, Working"));
     expect(screen.getByText("Progress photo")).toBeOnTheScreen();
     expect(screen.getByText("Useful article")).toBeOnTheScreen();
   });
 
   it("collapses evidence on second header tap", () => {
     renderWithProviders(<TimelineStep {...baseProps} />);
-    const header = screen.getByLabelText("Read the docs, In Progress");
+    const header = screen.getByLabelText("Read the docs, Working");
     fireEvent.press(header);
     expect(screen.getByText("Progress photo")).toBeOnTheScreen();
     fireEvent.press(header);
@@ -73,7 +74,7 @@ describe("TimelineStep", () => {
 
   it('shows "No evidence yet" when empty', () => {
     renderWithProviders(<TimelineStep {...baseProps} evidence={[]} />);
-    fireEvent.press(screen.getByLabelText("Read the docs, In Progress"));
+    fireEvent.press(screen.getByLabelText("Read the docs, Working"));
     expect(screen.getByText("No evidence yet")).toBeOnTheScreen();
   });
 
@@ -91,31 +92,55 @@ describe("TimelineStep", () => {
     renderWithProviders(
       <TimelineStep {...baseProps} onEvidencePress={onEvidencePress} />,
     );
-    fireEvent.press(screen.getByLabelText("Read the docs, In Progress"));
+    fireEvent.press(screen.getByLabelText("Read the docs, Working"));
     fireEvent.press(screen.getByLabelText("photo evidence: Progress photo"));
     expect(onEvidencePress).toHaveBeenCalledWith("ev-1");
     expect(onEvidencePress).toHaveBeenCalledTimes(1);
   });
 
   describe("metadata band + state word", () => {
-    // E — the header word reads from stepStateColorMap (common:stepCard.status.*),
-    // replacing the old StatusBadge vocabulary (timelineJourney:step.status.*).
-    // pending is "Pending" in both vocabularies, so it can't show the swap.
+    // E — the header word reads from stepStateColorMap, and since #453 it reads
+    // the map's `stateWordI18nKey` (timelineJourney:step.stateWord.*, the
+    // prototype vocabulary) rather than its `badgeI18nKey`
+    // (common:stepCard.status.*, which StepCard and the Focus surfaces still
+    // speak). Asserting the shared field's word is *absent* is the point: it is
+    // what makes a silent repoint of `badgeI18nKey` — the change that would drag
+    // StepCard's words back onto the timeline — fail here.
     it.each([
-      { status: "completed" as const, newWord: "Completed", oldWord: "Done" },
+      { status: "completed" as const, word: "Done", sharedWord: "Completed" },
       {
         status: "in-progress" as const,
-        newWord: "In Progress",
-        oldWord: "Active",
+        word: "Working",
+        sharedWord: "In Progress",
       },
+      { status: "pending" as const, word: "Up next", sharedWord: "Pending" },
+      { status: "paused" as const, word: "Set aside", sharedWord: "Paused" },
     ])(
-      "renders the #406 state word ($newWord), not the old StatusBadge word ($oldWord)",
-      ({ status, newWord, oldWord }) => {
+      "renders the #453 state word ($word), not the shared StepCard word ($sharedWord)",
+      ({ status, word, sharedWord }) => {
         renderWithProviders(
           <TimelineStep {...baseProps} step={{ ...baseStep, status }} />,
         );
-        expect(screen.getByText(newWord)).toBeOnTheScreen();
-        expect(screen.queryByText(oldWord)).toBeNull();
+        expect(screen.getByText(word)).toBeOnTheScreen();
+        expect(screen.queryByText(sharedWord)).toBeNull();
+      },
+    );
+
+    // #406's original guard, still live: the word must not come from the legacy
+    // StatusBadge group either (timelineJourney:step.status.* — "Done" / "Active"
+    // / "Pending"). `completed` can no longer demonstrate this — #453's word for
+    // it is also "Done" — so the two states whose vocabularies still differ
+    // carry the assertion.
+    it.each([
+      { status: "in-progress" as const, legacyWord: "Active" },
+      { status: "pending" as const, legacyWord: "Pending" },
+    ])(
+      "does not render the legacy StatusBadge word ($legacyWord) for $status",
+      ({ status, legacyWord }) => {
+        renderWithProviders(
+          <TimelineStep {...baseProps} step={{ ...baseStep, status }} />,
+        );
+        expect(screen.queryByText(legacyWord)).toBeNull();
       },
     );
 
@@ -317,10 +342,13 @@ describe("TimelineStep", () => {
       expect(screen.getByText("c")).toBeOnTheScreen();
     });
 
+    // Child rows read the same #453 state words as their parent — the two pill
+    // call sites are separate `t()` calls, so each needs its own coverage.
     it.each([
-      { status: "completed" as const, glyph: "✓", badge: "Completed" },
-      { status: "in-progress" as const, glyph: "a", badge: "In Progress" },
-      { status: "pending" as const, glyph: "a", badge: "Pending" },
+      { status: "completed" as const, glyph: "✓", badge: "Done" },
+      { status: "in-progress" as const, glyph: "a", badge: "Working" },
+      { status: "pending" as const, glyph: "a", badge: "Up next" },
+      { status: "paused" as const, glyph: "⏸", badge: "Set aside" },
     ])(
       "renders a $status sub-step with the right node glyph and state word",
       ({ status, glyph, badge }) => {

--- a/apps/native-rd/src/i18n/resources/_register/timelineJourney.yml
+++ b/apps/native-rd/src/i18n/resources/_register/timelineJourney.yml
@@ -17,6 +17,15 @@ notes:
   - Status labels are short and neutral. Use "Erledigt" / "Aktiv" /
     "Ausstehend" — not "Geschafft!" / "Du arbeitest dran!" / "Wartet
     auf dich".
+  - step.stateWord.* are the state pills on each timeline step, and on
+    the node's own state badge — "Erledigt" / "Zur Seite gelegt" / "In
+    Arbeit" / "Als Nächstes". They are deliberately NOT the same wording
+    as the count chips in common:timelineBreakdown.legend.* — the
+    prototype wants a pill on one step ("Als Nächstes") to read
+    differently from a tally of steps ("4 noch offen"). Do not unify the
+    two sets. Keep them short and neutral — "paused" is a deliberate
+    setting-aside, "pending" is simply not started yet, never
+    "überfällig"-style urgency.
   - This namespace carries no progress-ratio copy. Overall progress is
     shown by TimelineBreakdownBar, whose legend lives in
     common:timelineBreakdown.legend.* — translate it there, not here.

--- a/apps/native-rd/src/i18n/resources/de/timelineJourney.json
+++ b/apps/native-rd/src/i18n/resources/de/timelineJourney.json
@@ -15,6 +15,12 @@
       "active": "Aktiv",
       "pending": "Ausstehend"
     },
+    "stateWord": {
+      "completed": "Erledigt",
+      "paused": "Zur Seite gelegt",
+      "in-progress": "In Arbeit",
+      "pending": "Als Nächstes"
+    },
     "noEvidence": "Noch keine Belege",
     "metadata": {
       "after": "nach {{title}}",

--- a/apps/native-rd/src/i18n/resources/en/timelineJourney.json
+++ b/apps/native-rd/src/i18n/resources/en/timelineJourney.json
@@ -15,6 +15,12 @@
       "active": "Active",
       "pending": "Pending"
     },
+    "stateWord": {
+      "completed": "Done",
+      "paused": "Set aside",
+      "in-progress": "Working",
+      "pending": "Up next"
+    },
     "noEvidence": "No evidence yet",
     "metadata": {
       "after": "after {{title}}",

--- a/apps/native-rd/src/i18n/resources/pseudo/timelineJourney.json
+++ b/apps/native-rd/src/i18n/resources/pseudo/timelineJourney.json
@@ -15,6 +15,12 @@
       "active": "[Àçţïṽê··]",
       "pending": "[Þêñđïñğ···]"
     },
+    "stateWord": {
+      "completed": "[Đøñê··]",
+      "paused": "[Šêţ àšïđê····]",
+      "in-progress": "[Ŵøŕķïñğ···]",
+      "pending": "[Üþ ñêẋţ···]"
+    },
     "noEvidence": "[Ñø êṽïđêñçê ýêţ······]",
     "metadata": {
       "after": "[àƒţêŕ {{title}}······]",

--- a/apps/native-rd/src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx
+++ b/apps/native-rd/src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx
@@ -519,7 +519,7 @@ describe("TimelineJourneyScreen", () => {
     setupQueries({ stepEvidence: STEP_EVIDENCE });
     renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
     // Expand first step
-    fireEvent.press(screen.getByLabelText("Read docs, Completed"));
+    fireEvent.press(screen.getByLabelText("Read docs, Done"));
     expect(screen.getByText("Photo proof")).toBeOnTheScreen();
   });
 
@@ -527,24 +527,21 @@ describe("TimelineJourneyScreen", () => {
     it("never takes the in-progress accent, even as the first non-completed row", () => {
       setupQueries({ steps: STEPS_WITH_PAUSED });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
-      expect(screen.getAllByText("In Progress")).toHaveLength(1);
+      expect(screen.getAllByText("Working")).toHaveLength(1);
       // The accent skips the paused row and lands on the next pending one.
-      expect(
-        screen.getByLabelText("Next thing, In Progress"),
-      ).toBeOnTheScreen();
-      expect(
-        screen.queryByLabelText("Set aside thing, In Progress"),
-      ).toBeNull();
+      expect(screen.getByLabelText("Next thing, Working")).toBeOnTheScreen();
+      expect(screen.queryByLabelText("Set aside thing, Working")).toBeNull();
     });
 
     it('renders in the "paused" state language, not "pending"', () => {
       setupQueries({ steps: STEPS_WITH_PAUSED });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
-      // Pill + a11y label read Paused...
+      // Pill + a11y label read the paused word ("Set aside", #453) — the step's
+      // title happens to be "Set aside thing", hence the doubled label...
       expect(
-        screen.getByLabelText("Set aside thing, Paused"),
+        screen.getByLabelText("Set aside thing, Set aside"),
       ).toBeOnTheScreen();
-      expect(screen.queryByLabelText("Set aside thing, Pending")).toBeNull();
+      expect(screen.queryByLabelText("Set aside thing, Up next")).toBeNull();
       // ...and the node paints the shared paused glyph from stepStateColorMap
       // (#406) rather than its step number.
       expect(screen.getByText("⏸")).toBeOnTheScreen();
@@ -616,11 +613,11 @@ describe("TimelineJourneyScreen", () => {
     it("marks exactly one node in-progress — the first pending leaf", () => {
       setupQueries({ steps: STEPS_WITH_CHILDREN });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
-      // The in-progress accent surfaces as a single "In Progress" state word.
-      expect(screen.getAllByText("In Progress")).toHaveLength(1);
+      // The in-progress accent surfaces as a single "Working" state word.
+      expect(screen.getAllByText("Working")).toHaveLength(1);
       // ...and it is the first child, not the parent or the second child.
       const firstChild = screen.getByLabelText("Sub-step a: First sub-step");
-      expect(within(firstChild).getByText("In Progress")).toBeOnTheScreen();
+      expect(within(firstChild).getByText("Working")).toBeOnTheScreen();
     });
 
     it("counts every unit (parents + children) in the breakdown buckets", () => {
@@ -658,10 +655,10 @@ describe("TimelineJourneyScreen", () => {
       });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
       // Exactly one accent, and it is the child — not the completed parent.
-      expect(screen.getAllByText("In Progress")).toHaveLength(1);
+      expect(screen.getAllByText("Working")).toHaveLength(1);
       const child = screen.getByLabelText("Sub-step a: Still open");
-      expect(within(child).getByText("In Progress")).toBeOnTheScreen();
-      expect(screen.getByLabelText("Done parent, Completed")).toBeOnTheScreen();
+      expect(within(child).getByText("Working")).toBeOnTheScreen();
+      expect(screen.getByLabelText("Done parent, Done")).toBeOnTheScreen();
     });
 
     // Invite state: all children done but the parent is still open, so the
@@ -694,10 +691,8 @@ describe("TimelineJourneyScreen", () => {
       });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
       // The single accent sits on the parent header, not on either done child.
-      expect(screen.getAllByText("In Progress")).toHaveLength(1);
-      expect(
-        screen.getByLabelText("Open parent, In Progress"),
-      ).toBeOnTheScreen();
+      expect(screen.getAllByText("Working")).toHaveLength(1);
+      expect(screen.getByLabelText("Open parent, Working")).toBeOnTheScreen();
     });
 
     it("never accents a paused sub-step, even as the first non-completed leaf", () => {
@@ -727,12 +722,12 @@ describe("TimelineJourneyScreen", () => {
         ],
       });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
-      expect(screen.getAllByText("In Progress")).toHaveLength(1);
+      expect(screen.getAllByText("Working")).toHaveLength(1);
       // The accent skips the paused first child and lands on the second.
       const openSub = screen.getByLabelText("Sub-step b: Open sub");
-      expect(within(openSub).getByText("In Progress")).toBeOnTheScreen();
+      expect(within(openSub).getByText("Working")).toBeOnTheScreen();
       const pausedSub = screen.getByLabelText("Sub-step a: Set aside sub");
-      expect(within(pausedSub).getByText("Paused")).toBeOnTheScreen();
+      expect(within(pausedSub).getByText("Set aside")).toBeOnTheScreen();
     });
 
     it("shows no in-progress accent when every step is completed", () => {
@@ -755,7 +750,7 @@ describe("TimelineJourneyScreen", () => {
         ],
       });
       renderWithProviders(<TimelineJourneyScreen {...routeProps} />);
-      expect(screen.queryAllByText("In Progress")).toHaveLength(0);
+      expect(screen.queryAllByText("Working")).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Closes #453.

The Timeline's step pills now read the prototype vocabulary — **Done / Set aside / Working / Up next** — instead of StepCard's "Completed / In Progress / Pending / Paused".

#453 asked to land "before or with #378"; #378 merged first (PR #517), so the assembled Timeline has been shipping two vocabularies on one screen: the breakdown legend saying "3 done · 1 in motion · 4 to come · 1 set aside" above pills saying "Completed / In Progress / Pending / Paused". This makes the screen speak one language.

## What changed

| Commit | Contents |
| --- | --- |
| `3c12a55d` | `timelineJourney:step.stateWord.*` copy + register voice note + regenerated `pseudo/`. Inert — no consumer yet. |
| `9ab0c173` | `stateWordI18nKey` on `stepStateColorMap`; the three Timeline call sites switched. |
| `d1466eb3` | Assertions repointed to the new words, plus the per-state coverage that was missing. |
| `7d2820a1` | Plan file updated with the audit result and follow-up dispositions. |
| `543280af` | **Bot commit, not mine** — `de/timelineJourney.json`, added by the `Sync de/ from en/ (PR)` workflow after this PR opened. See Notes. |

Commits 1 and 2 are separated deliberately: the first reviews as pure copy, the second as pure routing.

## Two decisions worth a reviewer's attention

**1. Two label fields on the map, not one repointed field.**

`badgeI18nKey` was left exactly as it was, and `stateWordI18nKey` added beside it:

- `badgeI18nKey` → `common:stepCard.status.*` — still read by `StepCard`, `FocusCurrentTaskCard`, `FocusParkedState`
- `stateWordI18nKey` → `timelineJourney:step.stateWord.*` — read by `TimelineStep`'s two pills and `TimelineNode`'s `StateBadge`

The obvious change — repoint the one field — would have been wrong. `badgeI18nKey` turns out to have **four** consumers, not the one the issue assumed, and `FocusParkedState`'s "Paused" is a recorded decision (#450 D4, resolved in favour of Title-Case "Paused" for app-wide consistency). Repointing would have silently overturned it. One map with two labelled uses keeps both vocabularies honest without letting them drift into per-component resolver functions — which is the drift `stepStateColorMap` exists to prevent.

The check that this held: the `StepCard` / `FocusCurrentTaskCard` / `FocusParkedState` suites pass **untouched**. If a future change repoints `badgeI18nKey`, `TimelineNode`'s tests now fail loudly — they assert the StepCard word is *absent*.

Collapsing the two fields once #466/#467 retire the old Focus chrome is filed as #519.

**2. `TimelineNode`'s `StateBadge` switched too — slightly beyond the issue's stated scope.**

The issue scopes itself to "`TimelineStep`'s `StateWord` pill", but `TimelineNode.tsx` renders a *visible* `StateBadge` from the same map, sitting on the same screen. Leaving it behind would have traded the current inconsistency for a subtler one — a "Done" pill above a "Completed" badge.

Audited first: `<TimelineNode>` has three renderers — `TimelineStep` ×2 and `FinishLine`, which renders `isGoalNode` without `showStateBadge`, and a goal node never carries a badge at all. The Focus surfaces import the color map but never render the component. So no non-Timeline surface was affected and no per-call-site label prop was needed.

## Divergence you may want to overrule

`pending` reads **"Up next"**. The issue title records that as the 2026-07-02 readiness-review decision and it avoids colliding with generic task-app phrasing — but **both Timeline prototypes say "To do"** (`Timeline A Prototype.dc.html`, `Timeline Directions.dc.html`). "Up next" appears in `Add Evidence Nav.dc.html`. The issue cites `App Shell.dc.html` ~line 250 for all four words, but grepping it finds "Done", "Set aside", "Working" and no "Up next" at all.

Reverting is one JSON value in `en/timelineJourney.json` plus a `gen:pseudo`.

Casing is Title-Case per #450 D4's precedent on the same question.

## Deliberately not in scope

- **The breakdown legend keeps its own words.** `Timeline Directions.dc.html` contains "in motion" and "to come" *alongside* "Working" and "To do" — the prototype intends a tally of steps ("4 to come") to read differently from a pill on one step ("Up next"). This is intentional, not drift, and the register note in `_register/timelineJourney.yml` now says so explicitly, because two similar-but-different vocabularies in one namespace is exactly what a translator will "helpfully" unify.
- `StepCard`'s keys (per the issue — old language, #377/#466 replaces it).
- Renaming the pre-existing `timelineJourney:step.status.*` group. It turns out to have **zero** code consumers; deleting it is filed as #520.

## Verification

- `bun run type-check` clean; `bun run lint` 0 errors (222 pre-existing warnings).
- Full `bun run test`: **213 suites / 10022 tests green.**
- Tests assert the **rendered word**, not the key — a wrong-namespace regression that still called `t()` would otherwise pass.
- `locale-parity` green, which is what forced the `pseudo/` regeneration.

### Not verified — needs a human

**The 7-variant ND visual pass is outstanding.** "Set aside" is meaningfully wider than "Paused" in a fixed-width pill, so `largeText` and `lowVision` are where clipping would show. Tests can't catch that.

For the paused pill specifically it has to be checked in **Storybook** (`TimelineNode` → `Paused — with state badge`, and the `TimelineStep` stories), not in the running app: `pauseStep()` / `resumeStep()` exist and are exported from `src/db/index.ts`, but they have **zero callers** — nothing can produce a paused step yet. That affordance is owned by #466 ("Set aside ↔ Pick this back up via #417") and #467 (screen-level all-paused state). `paused` still had to be in this PR — `stepStateColorMap` is a `Record<StepStateMapKey, …>` and `stateWordI18nKey` is a template-literal type over the same four states, so an incomplete word list doesn't compile.

## Notes

- **`de/` was written by the i18n-sync bot, not by hand.** No commit authored here touches `de/`. After this PR opened, the `Sync de/ from en/ (PR)` workflow added `543280af` — author *and* committer `github-actions[bot]`, one file, the four `step.stateWord.*` keys only. That is the repo's hard rule working as designed (`de/` is bot-owned; hand-editing it is what's forbidden), and it is why the four German words appear in the diff without a human author.

  Worth noting the bot produced exactly the wording the D5 register note prescribes — "Erledigt / Zur Seite gelegt / In Arbeit / Als Nächstes" — so the note is doing the job it was added for. A reviewer who wants to change the German should change `_register/timelineJourney.yml` and let the bot re-run, not edit `de/` directly.
- `TimelineStep` no longer reads any `common:` key, so `common` was dropped from its `useTranslation` namespace list.
- Re-running `gen:pseudo` also rewrites dot-padding in `pseudo/badgeDetail.json`, `pseudo/completion.json`, and `pseudo/editGoal.json` — pre-existing drift on `main`, no key changes, which is why `locale-parity` never caught it. Reverted here to keep this diff scoped; filed as #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B6AtU3QguG2cCrt8W3crg
