### PR TITLE
fix(native-rd): no emoji for action/state — Phosphor icons + design system Rule 8

### DIFF
--- a/apps/native-rd/.agents/skills/neo-brutalist-design/SKILL.md
+++ b/apps/native-rd/.agents/skills/neo-brutalist-design/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: neo-brutalist-design
-description: Apply the rollercoaster.dev neo-brutalist design language to React Native components. Use when creating/reviewing components, fixing styles, or auditing visual consistency. Invoke with "review my component", "check my styles", "apply design system", or "audit design".
+description: Apply the rollercoaster.dev neo-brutalist design language to React Native components. Use when creating/reviewing components, fixing styles, choosing an icon, or auditing visual consistency. Also load before adding any glyph or emoji to the UI — action and state indicators must be Phosphor icons, never emoji (Rule 8). Invoke with "review my component", "check my styles", "apply design system", "audit design", or "which icon".
 metadata:
   author: rollercoaster.dev
-  version: "1.0.0"
+  version: "1.1.0"
   argument-hint: <file-or-pattern>
 ---
 
@@ -17,7 +17,7 @@ Bold, confident, accessible. Drama comes from **structure** (thick borders, hard
 
 ---
 
-## The 7 Rules
+## The 8 Rules
 
 ### 1. 2px Borders Everywhere
 
@@ -134,6 +134,106 @@ minHeight: 48; // Every pressable element
 ```
 
 No exceptions. Small visual elements (like icon buttons) can appear smaller visually but must have 48dp hit area.
+
+### 8. Icons Are Phosphor, Never Emoji
+
+**An emoji must never be the thing that encodes an action or a state.** When the
+glyph is the only carrier of meaning — a transport control, a bare status node, a
+button's affordance — it is a Phosphor icon from `phosphor-react-native`:
+
+```tsx
+import { Pause, Play } from "phosphor-react-native";
+
+const { theme } = useUnistyles();
+
+// CORRECT — themed, weighted, scales with the variant
+<Pause size={24} weight="bold" color={theme.colors.text} />
+
+// WRONG — the glyph IS the action; nothing else says play/pause
+<Text>{isPlaying ? "⏸" : "▶"}</Text>
+
+// WRONG — the glyph IS the state; a bare node interior with no label
+const nodeGlyph = { paused: "⏸" };
+```
+
+#### Deciding: icon or emoji
+
+Work through these in order. The first one that fires decides — stop there.
+
+1. **Would the user lose information if the glyph vanished?**
+   If yes → **icon**. This is the load-bearing test. A bare status node, a
+   transport toggle, a button whose glyph is the affordance: the glyph is the UI,
+   so it has to be themed and it has to survive the a11y variants.
+2. **Can it be `accessibilityElementsHidden` without harming the screen reader?**
+   If no → **icon**. If a glyph needs its own `accessibilityLabel`, it is content.
+   Decoration can always be hidden, because a visible label is already saying it.
+3. **Do several of them appear on screen at once, to be compared?**
+   If yes → **icon**. Sets seen together need one visual language: consistent
+   weight, optical size, stroke. Six emoji from six Unicode blocks (`📷 🎬 📝 🎤
+🔗 📎`) never line up — different bounding boxes, different visual weight,
+   different color families the theme cannot reconcile. A glyph that is only ever
+   shown one-at-a-time (the current mode, one per screen) has nothing to line up
+   against, so this question does not catch it.
+4. **Is it a one-off human moment — celebration, greeting, a warm aside?**
+   If yes → **emoji is fine.** A `🏅` on the badge-earned modal is warmth, and
+   Phosphor's `Medal` would read colder. This is the whole reason the rule is not
+   "no emoji anywhere".
+5. **Still unsure?** → **icon.** Icons are never _wrong_, only sometimes colder.
+   Emoji are wrong whenever they turn out to be load-bearing.
+
+| UI role                                                         | Use                                |
+| --------------------------------------------------------------- | ---------------------------------- |
+| Action / control (play, pause, delete, edit, add)               | **Icon**                           |
+| Status or state on its own (paused node, sync state)            | **Icon**                           |
+| Repeating type marker in a set (evidence types, file kinds)     | **Icon**                           |
+| Navigation and tab bars                                         | **Icon**                           |
+| Anything needing an `accessibilityLabel`                        | **Icon**                           |
+| Anything that must respond to `highContrast` / `autismFriendly` | **Icon**                           |
+| Accent beside a visible label that already says it              | Either — emoji OK                  |
+| Celebration / milestone moment                                  | Either — emoji OK                  |
+| Inside translated body copy                                     | **Emoji** (it is copy, not chrome) |
+
+Why the "icon" rows are not negotiable: emoji-presentation codepoints render in
+the platform's **color emoji font**. They ignore `color`, ignore the theme, and
+ignore all 7 accessibility variants — so `highContrast`, `autismFriendly`, and
+`lowVision` cannot touch them. A paused timeline node painted with `⏸` shows an
+iOS blue-grey pill sitting inside a themed node.
+
+The ND angle, since this app is built for it: `autismFriendly` and `lowInfo` exist
+to _reduce_ visual noise, and a saturated multi-color emoji is the loudest thing
+on the screen in a variant whose whole job is calm. `highContrast` promises 7:1
+and silently cannot deliver it on an emoji. An emoji is an opt-out from the
+accessibility system — fine for one deliberate warm moment, never for chrome.
+
+**Emoji that are currently fine:** decorative accents in celebration and info
+banners (`🏅` badge earned, `🏆` completion hero, `📅` dates banner), accents
+paired with a visible label (the `ModeIndicator` mode glyphs), the waiting marker
+`⏳`, and emoji inside translated copy (`"Hey there 👋"`).
+
+**Text-presentation glyphs are fine** — `✓ ✕ ★ → ↳ ↩ ⋯ ● ■` honor `color` and
+theme, so they are legitimate design-system marks.
+
+**The trap:** `⏸` (U+23F8), `▶` (U+25B6), `⏳` (U+23F3), `⚙` (U+2699) look
+typographic but are `Extended_Pictographic` — they get the emoji font. When
+auditing, decode `\u{...}` escapes before matching, or the escaped emoji
+(`"\u{1F4F7}"`) slip past `grep`.
+
+Icon sizing and weight, matching `src/navigation/FocusPillTabBar.tsx`:
+
+| Context                     | Size | Weight    |
+| --------------------------- | ---- | --------- |
+| Tab bar, nav, standard rows | 24   | `bold`    |
+| Inline with body text       | 16   | `bold`    |
+| Transport / media controls  | 24   | `fill`    |
+| Hero / empty-state          | 48+  | `duotone` |
+
+Curated badge-relevant icons already live in `src/badges/iconRegistry.ts` — add
+there rather than importing the whole library. A component that renders an icon
+should take it as `ReactNode`, never as a `string` icon name.
+
+Current violations are catalogued per-site in
+[`references/emoji-audit.md`](references/emoji-audit.md) — read it before
+touching any glyph so you don't migrate a Tier C decoration by mistake.
 
 ---
 
@@ -334,5 +434,6 @@ When reviewing a component for design compliance:
 - [ ] **Touch targets**: All pressables have `minHeight: 48`
 - [ ] **Typography**: Uses theme `textStyles` or `<Text variant>`, not manual assembly
 - [ ] **Colors**: Accents used as highlights, not large backgrounds
+- [ ] **Icons**: No emoji encoding an action or state — Phosphor icons with `theme` color (Rule 8). Decode `\u{...}` escapes when checking
 - [ ] **Accessibility**: `accessibilityRole`, `accessibilityLabel`, `accessibilityState`
 - [ ] **Tokens only**: No hardcoded colors, sizes, or spacing — all from `theme.*`

--- a/apps/native-rd/.agents/skills/neo-brutalist-design/references/emoji-audit.md
+++ b/apps/native-rd/.agents/skills/neo-brutalist-design/references/emoji-audit.md
@@ -19,34 +19,43 @@ touch it.
 
 ## Tier A — Violations: emoji encoding an action or a state
 
-Must migrate to Phosphor. Ordered by user-visible impact.
+**All three migrated to Phosphor.** Kept here as the worked examples of what the
+rule catches and how each was resolved.
 
-| #   | Site                                                   | Glyph   | What it encodes                              | Suggested Phosphor                    |
-| --- | ------------------------------------------------------ | ------- | -------------------------------------------- | ------------------------------------- |
-| A1  | `src/components/TimelineNode/stepStateColorMap.ts:115` | `⏸`     | **state** — `paused` step node (`nodeGlyph`) | `PauseCircle` / `Pause` weight `bold` |
-| A2  | `src/components/AudioPlayer/AudioPlayer.tsx:59`        | `⏸` `▶` | **action** — play/pause transport control    | `Pause` / `Play` weight `fill`        |
-| A3  | `src/screens/GoalsScreen/GoalsCockpit.tsx:150`         | `▶`     | **action** — resume goal (`<Button icon>`)   | `Play` weight `fill`                  |
+| #   | Site                                               | Was     | What it encoded                            | Now                                                       |
+| --- | -------------------------------------------------- | ------- | ------------------------------------------ | --------------------------------------------------------- |
+| A1  | `src/components/TimelineNode/stepStateColorMap.ts` | `⏸`     | **state** — `paused` step node             | `nodeIcon: Pause`, weight `bold`, `stepStateNodeFg` color |
+| A2  | `src/components/AudioPlayer/AudioPlayer.tsx`       | `⏸` `▶` | **action** — play/pause transport control  | `Pause` / `Play`, weight `fill`, `colors.background`      |
+| A3  | `src/screens/GoalsScreen/GoalsCockpit.tsx`         | `▶`     | **action** — resume goal (`<Button icon>`) | `Play`, weight `fill`, `colors.background`                |
 
-What makes these three different from the accent emoji in Tiers B and C: the
-glyph is the **only** thing communicating the action or state. There is no
-adjacent word doing the work. A1 is a bare node interior, A2 toggles meaning
-between two glyphs with no label, A3 is a `<Button icon>` sitting beside a label
-that says "Resume" but relies on the glyph for the play affordance.
+What made these three different from the accent emoji in Tiers B and C: the glyph
+was the **only** thing communicating the action or state. No adjacent word did
+the work. A1 was a bare node interior, A2 toggled meaning between two glyphs with
+no label, A3 sat beside a "Resume" label but carried the play affordance itself.
 
-Notes:
+How each was resolved:
 
-- **A1** is the screenshot's offender. It reaches the screen via
-  `TimelineNode.tsx:81` (`nodeGlyph`) and is asserted in
-  `TimelineNode/__tests__/TimelineNode.test.tsx:19`,
-  `TimelineStep/__tests__/TimelineStep.test.tsx:351`, and
-  `TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx:548`. Migrating
-  it means `nodeGlyph: string` becomes a component reference. Note the sibling
-  `completed` state at `:101` uses `✓` (Tier D, themed correctly) — so the map
-  only has this one bad entry, and `⏸` is visibly the odd one out on screen.
-- **A3** passes a string through `Button`'s `icon` prop. `Button.tsx:13` and
-  `:88` already carry comments about emoji glyphs mis-rendering and matching the
-  dark fill — evidence the string-icon path is the problem, not the choice of
-  glyph.
+- **A1** — the screenshot's offender. `StepStateBase` gained a `nodeIcon?: Icon`
+  field alongside the existing `nodeGlyph?: string`, and `TimelineNode` renders
+  the icon at `stepStateNodeFg(theme, status)` when one is set. `nodeGlyph`
+  survives for text-presentation marks: the sibling `completed` state still uses
+  `✓`, which honors `color` correctly. So the map now expresses both kinds
+  without the caller needing to know which is which. The icon carries
+  `testID="timeline-node-state-icon-{status}"` because an SVG cannot be asserted
+  with `getByText` the way the glyph could.
+- **A2** — the dead `playIcon` text style was deleted; `PLAY_ICON_SIZE = 16`
+  preserves the size it set.
+- **A3** — the structural fix the audit called for: `Button`'s `icon` prop widened
+  from `string` to `ReactNode`. Strings still route to the original `<Text>` run
+  (which is what makes `"+"` and `"✓"` callers work untouched, and what avoids the
+  Android glyph+font bug documented on the prop); elements render as-is with the
+  caller owning size and color, because only the caller knows the variant's
+  foreground. Empty strings render nothing rather than leaking a bare `""` child.
+
+Coverage: `TimelineNode`, `TimelineStep`, and `TimelineJourneyScreen` tests now
+assert the Pause icon by testID **and** that `⏸` is absent, so a regression back
+to the emoji fails rather than passing quietly. `Button` gained tests for the
+element path and the empty-string guard.
 
 ## Tier B — Judgment calls
 
@@ -146,11 +155,16 @@ reads themed green. Do not add them to Tier D.
 Not violations themselves, but they hard-assert the glyphs above and must move
 in the same commit as their Tier A/B source:
 
-- `src/components/TimelineNode/__tests__/TimelineNode.test.tsx:19` — `⏸`
-- `src/components/TimelineStep/__tests__/TimelineStep.test.tsx:351` — `⏸`
-- `src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx:548` — `⏸`
+Already handled with their Tier A source (listed for the record — these now assert
+the icon and the _absence_ of the emoji):
+
+- ~~`TimelineNode.test.tsx`~~, ~~`TimelineStep.test.tsx`~~,
+  ~~`TimelineJourneyScreen.test.tsx`~~ — were `⏸`
+- ~~`Button.test.tsx`~~ — was `▶`, now `"+"` plus an element-icon case
+
+Still pinned to Tier B/C glyphs:
+
 - `src/components/ModeIndicator/__tests__/ModeIndicator.test.tsx:34` — `📝`
-- `src/components/Button/__tests__/Button.test.tsx:34,37` — `▶`
 - `src/components/EvidenceThumbnail/__tests__/EvidenceThumbnail.test.tsx:114,131,154,168` — `📷` `🎬` `🎤`
 - `src/components/EmptyState/__tests__/EmptyState.test.tsx:13,14,19` — `📦`
 - `src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx:274,294,305` — `🏆` `📝`

--- a/apps/native-rd/.agents/skills/neo-brutalist-design/references/emoji-audit.md
+++ b/apps/native-rd/.agents/skills/neo-brutalist-design/references/emoji-audit.md
@@ -50,7 +50,10 @@ How each was resolved:
   (which is what makes `"+"` and `"✓"` callers work untouched, and what avoids the
   Android glyph+font bug documented on the prop); elements render as-is with the
   caller owning size and color, because only the caller knows the variant's
-  foreground. Empty strings render nothing rather than leaking a bare `""` child.
+  foreground. Branching on `typeof` rather than truthiness is what keeps a string
+  out of the element branch, where a bare `""` would be a text child outside a
+  `<Text>`; a separate `length > 0` check skips the run for `icon=""`, which would
+  otherwise be an empty `<Text>` still consuming the pressable's `gap`.
 
 Coverage: `TimelineNode`, `TimelineStep`, and `TimelineJourneyScreen` tests now
 assert the Pause icon by testID **and** that `⏸` is absent, so a regression back

--- a/apps/native-rd/.agents/skills/neo-brutalist-design/references/emoji-audit.md
+++ b/apps/native-rd/.agents/skills/neo-brutalist-design/references/emoji-audit.md
@@ -1,0 +1,195 @@
+# Emoji audit — action/state glyphs in native-rd
+
+Full inventory as of 2026-07-31 (branch `elastic-text`). Scanned every tracked
+`.ts`/`.tsx`/`.json` under `apps/native-rd/` and `packages/`, decoding `\u{...}`
+and `\uXXXX` escapes so escaped emoji are not missed, then filtered to
+`\p{Extended_Pictographic}` minus the typographic set (see Tier D).
+
+**The rule this audit backs:** emoji must never carry an **action** or a **state**.
+See `SKILL.md` → "Rule 8: Icons Are Phosphor, Never Emoji".
+
+Why this is not cosmetic: emoji-presentation codepoints get the platform's color
+font, so they ignore `color`, ignore the theme, and ignore all 7 accessibility
+variants. `⏸` (U+23F8) in a paused timeline node renders as an iOS blue-grey
+pill — visible in the Timeline screenshot that opened this audit — instead of the
+node's `nodeFgColorsFallback: "text"`. `highContrast` and `autismFriendly` cannot
+touch it.
+
+---
+
+## Tier A — Violations: emoji encoding an action or a state
+
+Must migrate to Phosphor. Ordered by user-visible impact.
+
+| #   | Site                                                   | Glyph   | What it encodes                              | Suggested Phosphor                    |
+| --- | ------------------------------------------------------ | ------- | -------------------------------------------- | ------------------------------------- |
+| A1  | `src/components/TimelineNode/stepStateColorMap.ts:115` | `⏸`     | **state** — `paused` step node (`nodeGlyph`) | `PauseCircle` / `Pause` weight `bold` |
+| A2  | `src/components/AudioPlayer/AudioPlayer.tsx:59`        | `⏸` `▶` | **action** — play/pause transport control    | `Pause` / `Play` weight `fill`        |
+| A3  | `src/screens/GoalsScreen/GoalsCockpit.tsx:150`         | `▶`     | **action** — resume goal (`<Button icon>`)   | `Play` weight `fill`                  |
+
+What makes these three different from the accent emoji in Tiers B and C: the
+glyph is the **only** thing communicating the action or state. There is no
+adjacent word doing the work. A1 is a bare node interior, A2 toggles meaning
+between two glyphs with no label, A3 is a `<Button icon>` sitting beside a label
+that says "Resume" but relies on the glyph for the play affordance.
+
+Notes:
+
+- **A1** is the screenshot's offender. It reaches the screen via
+  `TimelineNode.tsx:81` (`nodeGlyph`) and is asserted in
+  `TimelineNode/__tests__/TimelineNode.test.tsx:19`,
+  `TimelineStep/__tests__/TimelineStep.test.tsx:351`, and
+  `TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx:548`. Migrating
+  it means `nodeGlyph: string` becomes a component reference. Note the sibling
+  `completed` state at `:101` uses `✓` (Tier D, themed correctly) — so the map
+  only has this one bad entry, and `⏸` is visibly the odd one out on screen.
+- **A3** passes a string through `Button`'s `icon` prop. `Button.tsx:13` and
+  `:88` already carry comments about emoji glyphs mis-rendering and matching the
+  dark fill — evidence the string-icon path is the problem, not the choice of
+  glyph.
+
+## Tier B — Judgment calls
+
+Neither of these is a Tier A violation — the glyph is not the sole carrier of
+meaning. Run them through the decision questions in `SKILL.md` → Rule 8 →
+"Deciding: icon or emoji" and they land differently, which is why they are split:
+
+- **B0 (mode indicator)** clears every question. One glyph on screen at a time, a
+  visible label beside it, a11y-hidden. Emoji is defensible; migrating is
+  optional tidying.
+- **B1 (evidence types)** fails question 3 — six of them render side by side in
+  lists and thumbnail strips, which is exactly the case where mismatched emoji
+  metrics show. Treat B1 as **should migrate**, just not urgently.
+
+### B0 — Mode indicator
+
+`src/components/ModeIndicator/ModeIndicator.tsx:15-18` — `📝` `🎯` `🎉` `📖`
+(edit / focus / complete / timeline).
+
+Mode is a state, but the emoji does not encode it: the component always renders
+the translated `label` beside the glyph, the glyph is
+`accessibilityElementsHidden`, and callers can already replace it via the `icon?:
+ImageSourcePropType` prop. So the word communicates the mode and the emoji
+decorates it — the same shape as the Tier C banner accents.
+
+Migrating is still the tidier end state (`PencilSimple` / `Target` / `Confetti` /
+`BookOpen` — `Target` and `Confetti` are already in
+`src/badges/iconRegistry.ts`), and the field being named `emoji:` makes it easy
+to find. Do it opportunistically, not as a fix.
+
+### B1 — Evidence type icons
+
+One source-of-truth pair drives most sites:
+
+| Source                                                        | Glyphs                        |
+| ------------------------------------------------------------- | ----------------------------- |
+| `src/constants/evidenceIcons.ts:5-10` (`EVIDENCE_TYPE_ICONS`) | `📷` `🎬` `📝` `🎤` `🔗` `📎` |
+| `src/types/evidence.ts:32-37` (`icon` on the type list)       | `📷` `🎬` `🎤` `📝` `🔗` `📎` |
+
+Consumers and independent duplicates:
+
+| Site                                                              | Glyph                         | Note                                                                                           |
+| ----------------------------------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/components/EvidenceThumbnail/EvidenceThumbnail.tsx:27-32`    | `📷` `🎤` `📝` `🔗` `📄` `🎬` | **third copy** of the map — diverges from `evidenceIcons.ts` (`file` is `📄` here, `📎` there) |
+| `src/components/TimelineEvidenceCard/TimelineEvidenceCard.tsx:43` | `📄`                          | fallback                                                                                       |
+| `src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx:747`   | `📄`                          | fallback                                                                                       |
+| `src/screens/CaptureFile/CaptureFile.tsx:30-41`                   | `📄` `📕` `🖼` `📊` `📝`      | mime-type → glyph switch                                                                       |
+| `src/screens/CaptureLinkScreen/CaptureLinkScreen.tsx:117`         | `🔗`                          | hard-coded                                                                                     |
+| `src/screens/VoiceMemoScreen/VoiceMemoScreen.tsx:130`             | `🎙`                          | hard-coded, surrogate-pair escape + `️`                                                         |
+| `src/components/EvidenceContent/FileContent.tsx:51`               | `📄`                          | hard-coded                                                                                     |
+
+Suggested Phosphor: `Camera` · `FilmSlate` · `NotePencil` · `Microphone` ·
+`LinkSimple` · `Paperclip` / `FileText`. Migrating the two source-of-truth maps
+plus deleting the `EvidenceThumbnail` duplicate covers most call sites at once.
+
+## Tier C — Allowed: decoration, celebration, waiting
+
+Confirmed in-scope-of-nothing. Leave as-is. Every one of these is already
+`accessibilityElementsHidden` / `importantForAccessibility="no"`, i.e. decoration
+by declaration.
+
+| Site                                                                    | Glyph     | Why allowed                     |
+| ----------------------------------------------------------------------- | --------- | ------------------------------- |
+| `src/components/EditGoalView/EditGoalStepRow.tsx:52`                    | `⏳`      | waiting — explicitly allowed    |
+| `src/components/FocusCurrentTaskCard/FocusCurrentTaskCard.parts.tsx:93` | `⏳`      | waiting — explicitly allowed    |
+| `src/screens/BadgeEarnedModal/BadgeEarnedModal.tsx:104`                 | `🏅`      | celebration moment              |
+| `src/screens/CompletionFlowScreen/CompletionFlowScreen.tsx:503,604`     | `🏆` `🎯` | celebration hero decoration     |
+| `src/components/FocusCurrentTaskCard/FocusCurrentTaskCard.tsx:360`      | `🏆`      | all-complete callout decoration |
+| `src/components/NewGoalWizard/NewGoalWizard.tsx:700`                    | `🏆`      | badge-note banner decoration    |
+| `src/components/EditGoalView/EditGoalView.tsx:493`                      | `📅`      | dates info-banner decoration    |
+| `src/components/FinishCelebrateStage/FinishCelebrateStage.tsx:119`      | `✍️`      | closing-note prompt accent      |
+| `src/i18n/resources/{en,de,pseudo}/welcome.json:3`                      | `👋`      | greeting copy, not UI chrome    |
+
+Two borderline calls worth a second look if the rule ever tightens:
+`FinishCelebrateStage:119` sits inside a `Pressable` (so it decorates an
+affordance), and `EditGoalView:493` / `NewGoalWizard:700` are banner accents that
+a Phosphor `CalendarBlank` / `Trophy` would render more consistently.
+
+## Tier D — Not emoji: typographic glyphs (out of scope)
+
+Deliberately excluded from the scan. These are text-presentation codepoints that
+honor `color` and theme, so they are legitimate under the design system:
+
+`✓` `✔` `✕` `✗` `★` `☆` `→` `←` `↑` `↓` `↳` `↩` `↻` `⋯` `✦` `◆` `·` `▲` `▼` `●` `○` `■` `□` `↔`
+
+Used at e.g. `stepStateColorMap.ts:101` (`nodeGlyph: "✓"`), `TimelineNode.tsx:81`
+(`★`), `Checkbox.tsx:46`, `SettingsDensityRows.tsx:65`, `ThemeSwitcher.tsx:198`,
+`StepList.tsx:754,855`, `VideoRecorder.tsx:349`.
+
+**Trap:** `⏸` (U+23F8), `▶` (U+25B6), `⏳` (U+23F3) and `⚙` (U+2699) look like
+this set but are `Extended_Pictographic` — platforms give them the color emoji
+font. That is why the Timeline pause reads blue-grey while the adjacent `✓`
+reads themed green. Do not add them to Tier D.
+
+## Tests and stories that pin emoji
+
+Not violations themselves, but they hard-assert the glyphs above and must move
+in the same commit as their Tier A/B source:
+
+- `src/components/TimelineNode/__tests__/TimelineNode.test.tsx:19` — `⏸`
+- `src/components/TimelineStep/__tests__/TimelineStep.test.tsx:351` — `⏸`
+- `src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx:548` — `⏸`
+- `src/components/ModeIndicator/__tests__/ModeIndicator.test.tsx:34` — `📝`
+- `src/components/Button/__tests__/Button.test.tsx:34,37` — `▶`
+- `src/components/EvidenceThumbnail/__tests__/EvidenceThumbnail.test.tsx:114,131,154,168` — `📷` `🎬` `🎤`
+- `src/components/EmptyState/__tests__/EmptyState.test.tsx:13,14,19` — `📦`
+- `src/components/NewGoalWizard/__tests__/NewGoalWizard.test.tsx:274,294,305` — `🏆` `📝`
+- `src/components/EmptyState/EmptyState.stories.tsx:39` — `🎯`
+- `src/components/IconButton/IconButton.stories.tsx:81` — `⚙`
+- `src/components/Confetti/Confetti.stories.tsx:30` — `🎉`
+
+Unrelated to UI, ignore: `badges/__tests__/badgeFilename.test.ts:18` and
+`badgeStorage.test.ts:133` use `🎉🎉🎉` as filename-sanitizer input, and
+`__tests__/eslint-rules/no-raw-jsx-strings.test.ts:34` uses `🏆` as rule fixture.
+
+Note `EmptyState` and `Button` both take `icon` as a **string** prop — that API
+shape is what invites emoji. Widening them to `ReactNode` is the structural fix.
+
+---
+
+## Reproducing this scan
+
+`grep` for emoji alone misses the escaped forms (`"\u{1F4F7}"`), which is where
+most of Tier B hides. Decode escapes first:
+
+```js
+const resolved = line
+  .replace(/\\u\{([0-9a-fA-F]+)\}/g, (_, h) =>
+    String.fromCodePoint(parseInt(h, 16)),
+  )
+  .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) =>
+    String.fromCharCode(parseInt(h, 16)),
+  );
+const hits = [...resolved].filter(
+  (c) => /\p{Extended_Pictographic}/u.test(c) && !TIER_D.has(c),
+);
+```
+
+## Follow-up: enforcement
+
+The audit is a snapshot; nothing stops the next `⏸`. The project already has a
+local ESLint plugin (`src/eslint-rules/`, wired in `eslint.config.js:26-32`) with
+`local/no-raw-jsx-strings` as the closest precedent. A `local/no-emoji-glyphs`
+rule flagging `Extended_Pictographic` in JSX text and string literals — with an
+allowlist comment for Tiers B and C — would make the rule self-enforcing. Not yet
+written.

--- a/apps/native-rd/src/components/AudioPlayer/AudioPlayer.styles.ts
+++ b/apps/native-rd/src/components/AudioPlayer/AudioPlayer.styles.ts
@@ -24,10 +24,6 @@ export const styles = StyleSheet.create((theme) => ({
   playButtonPressed: {
     opacity: 0.8,
   },
-  playIcon: {
-    fontSize: 16,
-    color: theme.colors.background,
-  },
   progressContainer: {
     flex: 1,
   },

--- a/apps/native-rd/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/apps/native-rd/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import { View, Pressable } from "react-native";
 import { useAudioPlayer, useAudioPlayerStatus } from "expo-audio";
+import { useUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
+import { Pause, Play } from "phosphor-react-native";
 import { Text } from "../Text";
 import { formatDuration } from "../../utils/format";
 import { styles } from "./AudioPlayer.styles";
+
+/** Matches the `fontSize: 16` the play/pause text glyph used before Rule 8. */
+const PLAY_ICON_SIZE = 16;
 
 export interface AudioPlayerProps {
   uri: string;
@@ -13,6 +18,7 @@ export interface AudioPlayerProps {
 
 export function AudioPlayer({ uri, durationMs }: AudioPlayerProps) {
   const { t } = useTranslation(["common"]);
+  const { theme } = useUnistyles();
   const player = useAudioPlayer(uri);
   const status = useAudioPlayerStatus(player);
 
@@ -56,7 +62,24 @@ export function AudioPlayer({ uri, durationMs }: AudioPlayerProps) {
           pressed && styles.playButtonPressed,
         ]}
       >
-        <Text style={styles.playIcon}>{isPlaying ? "\u23F8" : "\u25B6"}</Text>
+        {/* `fill` weight: a transport control reads as a solid play/pause mark,
+            not an outline. `colors.background` inverts against the button's
+            `accentPrimary` fill \u2014 the same token the replaced text glyph used.
+            Rule 8: `\u23F8`/`\u25B6` are emoji-presentation codepoints, so they ignored
+            that color and rendered in the platform emoji font instead. */}
+        {isPlaying ? (
+          <Pause
+            size={PLAY_ICON_SIZE}
+            weight="fill"
+            color={theme.colors.background}
+          />
+        ) : (
+          <Play
+            size={PLAY_ICON_SIZE}
+            weight="fill"
+            color={theme.colors.background}
+          />
+        )}
       </Pressable>
 
       <View style={styles.progressContainer}>

--- a/apps/native-rd/src/components/Button/Button.tsx
+++ b/apps/native-rd/src/components/Button/Button.tsx
@@ -65,15 +65,22 @@ export function Button({
   // A string icon gets its own <Text> run; an element renders as-is (see the
   // `icon` prop docs). `labelStyle` on that run carries only the variant's color
   // (no fontFamily), so the glyph tracks the label instead of the default text
-  // color — invisible on the primary button's dark fill. `length > 0` rather
-  // than a truthy check, so an empty string yields `false` — renderable —
-  // instead of a bare "" child, which RN rejects outside a <Text>.
+  // color — invisible on the primary button's dark fill.
+  //
+  // Two details, each doing a different job:
+  //   - Branching on `typeof icon === "string"` (not truthiness) is what keeps a
+  //     string out of the element branch. A bare "" returned from there would be
+  //     a string child outside a <Text>, which RN rejects.
+  //   - `icon.length > 0` skips the run for `icon=""`, which would otherwise be
+  //     an empty <Text> still consuming the pressable's `gap` and offsetting the
+  //     label. It yields `false`, which React ignores — nothing is rendered.
   const iconRun =
     typeof icon === "string"
       ? icon.length > 0 && (
           <Text
             style={[styles.icon(size), labelStyle]}
             accessibilityElementsHidden
+            testID="button-icon-run"
           >
             {icon}
           </Text>

--- a/apps/native-rd/src/components/Button/Button.tsx
+++ b/apps/native-rd/src/components/Button/Button.tsx
@@ -7,14 +7,21 @@ export type { ButtonVariant, ButtonSize };
 export interface ButtonProps {
   label: string;
   /**
-   * Optional leading icon (typically an emoji). Rendered as its own <Text>
-   * run, separate from the label. Keeping the emoji in a distinct run avoids
-   * an Android glyph-rendering bug where an emoji + custom font in a single
-   * Text run can drop the trailing label glyphs on some devices (the "🔗 Link"
-   * chip rendered icon-only). Treated as decorative — excluded from the a11y
-   * label, which stays the human-readable `label` text.
+   * Optional leading icon. Prefer a Phosphor element — `<Play size={20}
+   * weight="fill" color={...} />` — for anything conveying an action or state
+   * (design system Rule 8); the caller owns its size and color because only the
+   * caller knows the variant's foreground.
+   *
+   * A `string` is still accepted for text-presentation marks (`"+"`, `"✓"`) and
+   * gets wrapped in its own <Text> run, separate from the label. Keeping a glyph
+   * in a distinct run avoids an Android bug where a glyph + custom font in one
+   * Text run can drop the trailing label characters on some devices (the
+   * "🔗 Link" chip rendered icon-only).
+   *
+   * Either way the icon is decorative — excluded from the a11y label, which
+   * stays the human-readable `label` text.
    */
-  icon?: string;
+  icon?: React.ReactNode;
   onPress: () => void;
   variant?: ButtonVariant;
   size?: ButtonSize;
@@ -55,6 +62,24 @@ export function Button({
     destructive: styles.labelDestructive,
   }[variant];
 
+  // A string icon gets its own <Text> run; an element renders as-is (see the
+  // `icon` prop docs). `labelStyle` on that run carries only the variant's color
+  // (no fontFamily), so the glyph tracks the label instead of the default text
+  // color — invisible on the primary button's dark fill. `length > 0` rather
+  // than a truthy check, so an empty string yields `false` — renderable —
+  // instead of a bare "" child, which RN rejects outside a <Text>.
+  const iconRun =
+    typeof icon === "string"
+      ? icon.length > 0 && (
+          <Text
+            style={[styles.icon(size), labelStyle]}
+            accessibilityElementsHidden
+          >
+            {icon}
+          </Text>
+        )
+      : icon;
+
   return (
     <Pressable
       onPress={onPress}
@@ -81,18 +106,7 @@ export function Button({
         />
       ) : (
         <>
-          {icon ? (
-            // labelStyle carries only the variant's color (no fontFamily), so
-            // the icon tracks the label color instead of falling back to the
-            // default text color — which is invisible on the primary button's
-            // dark fill (the "▶" glyph that matched the background).
-            <Text
-              style={[styles.icon(size), labelStyle]}
-              accessibilityElementsHidden
-            >
-              {icon}
-            </Text>
-          ) : null}
+          {iconRun}
           <Text style={[styles.label(size), labelStyle]}>{label}</Text>
         </>
       )}

--- a/apps/native-rd/src/components/Button/__tests__/Button.test.tsx
+++ b/apps/native-rd/src/components/Button/__tests__/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet } from "react-native";
+import { StyleSheet, View } from "react-native";
 import {
   renderWithProviders,
   screen,
@@ -28,18 +28,44 @@ describe("Button", () => {
   });
 
   // Regression: the icon run carried no color, so it fell back to the default
-  // text color and rendered invisibly on the primary button's dark fill. The
-  // icon must track the label color.
-  it("colors the icon to match the label", () => {
-    renderWithProviders(<Button label="Resume" icon="▶" onPress={jest.fn()} />);
+  // text color and rendered invisibly on the primary button's dark fill. A
+  // string icon must track the label color.
+  it("colors a string icon to match the label", () => {
+    renderWithProviders(<Button label="Add" icon="+" onPress={jest.fn()} />);
     // The icon run is accessibilityElementsHidden, so opt hidden elements in.
     const iconColor = StyleSheet.flatten(
-      screen.getByText("▶", { includeHiddenElements: true }).props.style,
+      screen.getByText("+", { includeHiddenElements: true }).props.style,
     ).color;
     const labelColor = StyleSheet.flatten(
-      screen.getByText("Resume").props.style,
+      screen.getByText("Add").props.style,
     ).color;
     expect(iconColor).toBeTruthy();
     expect(iconColor).toBe(labelColor);
+  });
+
+  // The element path exists so action icons can be Phosphor components instead
+  // of emoji (design system Rule 8). An element must render as-is — wrapping it
+  // in the string path's <Text> would break both its layout and its color.
+  it("renders an element icon without wrapping it in a text run", () => {
+    renderWithProviders(
+      <Button
+        label="Resume"
+        icon={<View testID="button-icon-element" />}
+        onPress={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("button-icon-element", {
+        includeHiddenElements: true,
+      }),
+    ).toBeOnTheScreen();
+    expect(screen.getByText("Resume")).toBeOnTheScreen();
+  });
+
+  // An empty string must not reach the tree as a bare "" child (RN rejects
+  // strings outside <Text>) and must not open a gap where no icon exists.
+  it("renders no icon run for an empty string icon", () => {
+    renderWithProviders(<Button label="Plain" icon="" onPress={jest.fn()} />);
+    expect(screen.getByText("Plain")).toBeOnTheScreen();
   });
 });

--- a/apps/native-rd/src/components/Button/__tests__/Button.test.tsx
+++ b/apps/native-rd/src/components/Button/__tests__/Button.test.tsx
@@ -62,10 +62,22 @@ describe("Button", () => {
     expect(screen.getByText("Resume")).toBeOnTheScreen();
   });
 
-  // An empty string must not reach the tree as a bare "" child (RN rejects
-  // strings outside <Text>) and must not open a gap where no icon exists.
+  // `icon=""` must not render an empty <Text> run: it would consume the
+  // pressable's `gap` and offset the label as if an icon were there.
   it("renders no icon run for an empty string icon", () => {
     renderWithProviders(<Button label="Plain" icon="" onPress={jest.fn()} />);
+    expect(
+      screen.queryByTestId("button-icon-run", { includeHiddenElements: true }),
+    ).toBeNull();
     expect(screen.getByText("Plain")).toBeOnTheScreen();
+  });
+
+  // The counterpart: a non-empty string does produce the run, so the assertion
+  // above is pinning the guard rather than a testID that never exists.
+  it("renders the icon run for a non-empty string icon", () => {
+    renderWithProviders(<Button label="Add" icon="+" onPress={jest.fn()} />);
+    expect(
+      screen.getByTestId("button-icon-run", { includeHiddenElements: true }),
+    ).toBeOnTheScreen();
   });
 });

--- a/apps/native-rd/src/components/TimelineNode/TimelineNode.tsx
+++ b/apps/native-rd/src/components/TimelineNode/TimelineNode.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Pressable, Text, View } from "react-native";
+import { useUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import type { StepStatus } from "../../types/steps";
-import { stepStateColorMap } from "./stepStateColorMap";
+import { stepStateColorMap, stepStateNodeFg } from "./stepStateColorMap";
 import {
   styles,
   NODE_SIZE,
@@ -50,6 +51,7 @@ export function TimelineNode({
   celebrate = false,
 }: TimelineNodeProps) {
   const isSmall = size === "sm";
+  const { theme } = useUnistyles();
 
   const nodeStyle = [
     styles.node,
@@ -73,15 +75,36 @@ export function TimelineNode({
     !isGoalNode && status === "paused" && styles.pausedText,
   ];
 
-  // Interior precedence: goal star → state glyph → label → step number. The
-  // number/label fall through to "" (not "0" or "undefined") when a caller
-  // supplies neither, so a misconfigured node renders blank rather than a
+  // A Phosphor icon for states whose marker would otherwise need an
+  // emoji-presentation codepoint — `paused` is the only one today. Goal nodes
+  // never take a state icon; they own the star. Sized to match the text glyphs
+  // below (`✓` uses the same tokens) so the two states have one optical weight,
+  // and colored from the same `stepStateNodeFg` the text styles resolve — which
+  // is the whole point: the old `⏸` emoji ignored it (design system Rule 8).
+  const StateIcon = isGoalNode ? undefined : stepStateColorMap[status].nodeIcon;
+
+  // Interior precedence: goal star → state icon → state glyph → label → step
+  // number. The number/label fall through to "" (not "0" or "undefined") when a
+  // caller supplies neither, so a misconfigured node renders blank rather than a
   // misleading glyph.
-  const content = isGoalNode
-    ? "★"
-    : (stepStateColorMap[status].nodeGlyph ??
-      label ??
-      (stepNumber != null ? String(stepNumber) : ""));
+  const content = StateIcon ? (
+    <StateIcon
+      size={isSmall ? theme.size.xs : theme.size.sm}
+      weight="bold"
+      color={stepStateNodeFg(theme, status)}
+      // The interior marker is not text, so it cannot be asserted with
+      // getByText the way `✓` and the step number are.
+      testID={`timeline-node-state-icon-${status}`}
+    />
+  ) : (
+    <Text style={textStyle}>
+      {isGoalNode
+        ? "★"
+        : (stepStateColorMap[status].nodeGlyph ??
+          label ??
+          (stepNumber != null ? String(stepNumber) : ""))}
+    </Text>
+  );
 
   // Expand touch target to meet 44×44pt minimum
   const nodeSize = isGoalNode
@@ -98,7 +121,7 @@ export function TimelineNode({
       accessibilityLabel={accessibilityLabel}
       style={nodeStyle}
     >
-      <Text style={textStyle}>{content}</Text>
+      {content}
     </View>
   ) : (
     <Pressable
@@ -109,7 +132,7 @@ export function TimelineNode({
       accessibilityLabel={accessibilityLabel}
       style={({ pressed }) => [nodeStyle, pressed && styles.pressed]}
     >
-      <Text style={textStyle}>{content}</Text>
+      {content}
     </Pressable>
   );
 

--- a/apps/native-rd/src/components/TimelineNode/__tests__/TimelineNode.test.tsx
+++ b/apps/native-rd/src/components/TimelineNode/__tests__/TimelineNode.test.tsx
@@ -16,11 +16,29 @@ describe("TimelineNode", () => {
   it.each([
     { status: "pending" as const, expected: "1" },
     { status: "in-progress" as const, expected: "1" },
-    { status: "paused" as const, expected: "\u23f8" },
     { status: "completed" as const, expected: "\u2713" },
   ])('renders "$expected" for $status status', ({ status, expected }) => {
     renderWithProviders(<TimelineNode {...baseProps} status={status} />);
     expect(screen.getByText(expected)).toBeOnTheScreen();
+  });
+
+  // `paused` is the one state whose marker is a Phosphor icon rather than a
+  // text glyph, so it is asserted by testID. It used to render `\u23f8`, an
+  // emoji-presentation codepoint that ignored the node's foreground color in
+  // all 14 themes (design system Rule 8) \u2014 hence the second assertion.
+  it("renders a Pause icon, not an emoji, for paused status", () => {
+    renderWithProviders(<TimelineNode {...baseProps} status="paused" />);
+    expect(
+      screen.getByTestId("timeline-node-state-icon-paused"),
+    ).toBeOnTheScreen();
+    expect(screen.queryByText("\u23f8")).toBeNull();
+  });
+
+  it("the paused icon takes precedence over the step number", () => {
+    renderWithProviders(
+      <TimelineNode {...baseProps} status="paused" stepNumber={7} />,
+    );
+    expect(screen.queryByText("7")).toBeNull();
   });
 
   it("renders star for goal node", () => {

--- a/apps/native-rd/src/components/TimelineNode/stepStateColorMap.ts
+++ b/apps/native-rd/src/components/TimelineNode/stepStateColorMap.ts
@@ -12,6 +12,8 @@
  * exception — see the TODO on the `paused` entry below.
  */
 
+import type { Icon } from "phosphor-react-native";
+import { Pause } from "phosphor-react-native";
 import type { Colors } from "../../themes/colorModes";
 import type { Journey } from "../../themes/adapter";
 import type { ComposedTheme } from "../../themes/compose";
@@ -55,8 +57,20 @@ interface StepStateBase {
    * apart in separate per-component resolvers.
    */
   stateWordI18nKey: StepStateWordKey;
-  /** Unicode glyph for the node interior, overriding the step number. */
+  /**
+   * Text-presentation glyph for the node interior, overriding the step number.
+   * Only for codepoints that honor `color` (e.g. `✓`) so the glyph tracks
+   * `stepStateNodeFg`. Anything emoji-presentation renders in the platform's
+   * color emoji font and ignores the theme — use {@link StepStateBase.nodeIcon}
+   * for those (design system Rule 8).
+   */
   nodeGlyph?: string;
+  /**
+   * Phosphor icon for the node interior, overriding both `nodeGlyph` and the
+   * step number. Rendered at the resolved `stepStateNodeFg` color so the state
+   * reads correctly in all 14 themes — which a `⏸` emoji could not do.
+   */
+  nodeIcon?: Icon;
 }
 
 export type StepStateEntry = StepStateBase &
@@ -112,7 +126,7 @@ export const stepStateColorMap: Record<StepStateMapKey, StepStateEntry> = {
     nodeFgColorsFallback: "text",
     badgeI18nKey: "common:stepCard.status.paused",
     stateWordI18nKey: "timelineJourney:step.stateWord.paused",
-    nodeGlyph: "⏸",
+    nodeIcon: Pause,
   },
 };
 

--- a/apps/native-rd/src/components/TimelineStep/__tests__/TimelineStep.test.tsx
+++ b/apps/native-rd/src/components/TimelineStep/__tests__/TimelineStep.test.tsx
@@ -348,7 +348,6 @@ describe("TimelineStep", () => {
       { status: "completed" as const, glyph: "✓", badge: "Done" },
       { status: "in-progress" as const, glyph: "a", badge: "Working" },
       { status: "pending" as const, glyph: "a", badge: "Up next" },
-      { status: "paused" as const, glyph: "⏸", badge: "Set aside" },
     ])(
       "renders a $status sub-step with the right node glyph and state word",
       ({ status, glyph, badge }) => {
@@ -366,6 +365,26 @@ describe("TimelineStep", () => {
         expect(within(card).getByText(badge)).toBeOnTheScreen();
       },
     );
+
+    // Split out of the table above: paused marks its node with a Phosphor icon
+    // instead of a text glyph, so it needs getByTestId rather than getByText
+    // (design system Rule 8 — the former `⏸` ignored the theme).
+    it("renders a paused sub-step with the Pause node icon and state word", () => {
+      renderWithProviders(
+        <TimelineStep
+          {...baseProps}
+          subSteps={[
+            { id: "only", title: "Only child", status: "paused", evidence: [] },
+          ]}
+        />,
+      );
+      const node = screen.getByLabelText("Go to step a: Only child");
+      expect(
+        within(node).getByTestId("timeline-node-state-icon-paused"),
+      ).toBeOnTheScreen();
+      const card = screen.getByLabelText("Sub-step a: Only child");
+      expect(within(card).getByText("Set aside")).toBeOnTheScreen();
+    });
 
     it("expands a sub-step's evidence independently of the parent", () => {
       renderWithProviders(<TimelineStep {...baseProps} subSteps={subSteps} />);

--- a/apps/native-rd/src/screens/GoalsScreen/GoalsCockpit.tsx
+++ b/apps/native-rd/src/screens/GoalsScreen/GoalsCockpit.tsx
@@ -3,6 +3,7 @@ import { Pressable, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useUnistyles } from "react-native-unistyles";
 import Svg, { Circle } from "react-native-svg";
+import { Play } from "phosphor-react-native";
 import { ProgressRing } from "../../components/ProgressRing";
 import { ProgressBar } from "../../components/ProgressBar";
 import { Button } from "../../components/Button";
@@ -147,7 +148,17 @@ export function GoalsCockpit({
         <View style={styles.heroAction}>
           <Button
             label={resumeLabel}
-            icon="▶"
+            // `fill` reads as a solid play mark at the hero's scale. Sized to
+            // the lg label and colored `background` to match `labelPrimary` on
+            // the primary variant's dark fill — the `▶` this replaces could do
+            // neither, being an emoji-presentation codepoint (Rule 8).
+            icon={
+              <Play
+                size={theme.size.lg}
+                weight="fill"
+                color={theme.colors.background}
+              />
+            }
             size="lg"
             onPress={() => onStartResume(hero.id)}
             testID="goals-cockpit-start-resume"

--- a/apps/native-rd/src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx
+++ b/apps/native-rd/src/screens/TimelineJourneyScreen/__tests__/TimelineJourneyScreen.test.tsx
@@ -543,9 +543,13 @@ describe("TimelineJourneyScreen", () => {
         screen.getByLabelText("Set aside thing, Set aside"),
       ).toBeOnTheScreen();
       expect(screen.queryByLabelText("Set aside thing, Up next")).toBeNull();
-      // ...and the node paints the shared paused glyph from stepStateColorMap
-      // (#406) rather than its step number.
-      expect(screen.getByText("⏸")).toBeOnTheScreen();
+      // ...and the node paints the shared paused marker from stepStateColorMap
+      // (#406) rather than its step number. A Phosphor icon since Rule 8: the
+      // previous `⏸` rendered in the platform emoji font and ignored the theme.
+      expect(
+        screen.getByTestId("timeline-node-state-icon-paused"),
+      ).toBeOnTheScreen();
+      expect(screen.queryByText("⏸")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Why

The paused step in the Timeline rendered `⏸` (U+23F8). That is an emoji-presentation codepoint, so it draws in the platform's colour emoji font — it ignores `color`, the theme, and **all 7 accessibility variants**. The result was an iOS blue-grey pill sitting inside an otherwise themed node, with `highContrast`, `autismFriendly`, and `lowVision` unable to touch it.


Reported visually; the fix is the three sites where an emoji was the **only** thing communicating an action or a state, plus a design system rule so the next one gets caught in review.

## The rule

Added as **Rule 8** in the `neo-brutalist-design` skill (v1.0.0 → 1.1.0), stated as an ordered decision rather than a prohibition, because a blanket "no emoji" ban is wrong for this app:

1. Would the user lose information if the glyph vanished? → **icon**
2. Can it be `accessibilityElementsHidden` without hurting the screen reader? If no → **icon**
3. Do several appear on screen at once, to be compared? → **icon**
4. One-off human moment — celebration, greeting? → **emoji fine**
5. Unsure → **icon** (icons are never wrong, only colder; emoji are wrong the moment they turn out to be load-bearing)

Emoji stay legitimate for celebration moments (`🏅` on badge earned), accents beside a visible label, the waiting marker `⏳`, and translated copy (`"Hey there 👋"`).

`references/emoji-audit.md` catalogues **every** emoji site in the app, tiered — A (violations, all fixed here), B (judgment calls), C (allowed), D (text-presentation glyphs like `✓ ★ →`, out of scope). It also records the scan recipe: plain `grep` undercounts badly, because most type icons are escaped as `"\u{1F4F7}"`.

## What changed in code — Tier A only

| Site | Was | Now |
| --- | --- | --- |
| Timeline paused node | `⏸` | `nodeIcon: Pause`, weight `bold`, at `stepStateNodeFg` |
| AudioPlayer transport | `⏸` `▶` | `Pause` / `Play`, weight `fill`, `colors.background` |
| Goals cockpit resume | `▶` | `Play`, weight `fill`, `colors.background` |

Three notes on approach:

- **`nodeGlyph` was kept, not replaced.** `StepStateBase` gained `nodeIcon?: Icon` *alongside* it, because the sibling `completed` state's `✓` is text-presentation and honours `color` correctly. The map now expresses both kinds and callers need not know which is which.
- **`Button.icon` widened `string` → `ReactNode`** — the structural fix the audit called for, since a string-typed icon prop is what invites emoji. Strings still route to the original `<Text>` run, so the `"+"` and `"✓"` callers are untouched and the Android glyph+font bug documented on that prop stays avoided. Elements render as-is with the caller owning size and colour, because only the caller knows the variant's foreground. An empty string renders nothing rather than leaking a bare `""` child, which RN rejects outside a `<Text>`.
- **Tier B deliberately untouched** — the mode indicator sits beside a visible translated label, and evidence-type icons denote content type. Both are recorded as judgment calls, not violations. B1 (evidence types) is the one still worth doing: six of them render side by side in lists, which is exactly where mismatched emoji metrics show.

## Testing

- `type-check` clean, `lint` no new findings
- Full suite green: **213 suites / 10,032 tests**
- Timeline tests assert the Pause icon by `testID` **and** that `⏸` is absent, so regressing to the emoji fails rather than passing quietly. Phosphor forwards `testID` to the underlying `Svg` — verified by probe, since an SVG can't be found with `getByText` the way the glyph could.
- `Button` gained coverage for the element path and the empty-string guard.

## Not done — needs a human eye

**No visual verification.** This worktree has no `ios/` directory, so confirming it would need a full `prebuild` + `pod install` + native build. Everything above is static verification, and the fix is purely visual — so it wants a look before merge:

- **Timeline** — paused nodes, parent *and* sub-step rows (sub-nodes are 24px, icon 12px). The real test is whether the Pause reads at the same optical weight as the `✓` one row up.
- **Goals cockpit** — resume play icon inverted on the dark fill; the `+` button beside it is the string path and should look unchanged.
- **Voice-memo playback** — toggle play/pause, both states.
- **Theme sweep** — `highContrast` and `autismFriendly` especially, since those are where the emoji failed hardest.

Cheapest path: `TimelineNode.stories.tsx` has an **AllThemesMatrix** story rendering every state across all 14 themes in one view.

## Follow-ups

- `local/no-emoji-glyphs` ESLint rule — the audit is a snapshot; nothing stops the next `⏸`. The repo already has 7 local rules wired in `eslint.config.js`, with `local/no-raw-jsx-strings` as the closest precedent.
- Tier B1 migration, including a **third divergent copy** of the evidence-type map in `EvidenceThumbnail.tsx` (`file` is `📄` there, `📎` in `evidenceIcons.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmKL6HyfqrP3cAbJ5W7Utk
