### PR TITLE
feat(native-rd): BadgesScreen thin container (#405)

### DIFF
--- a/apps/native-rd/App.tsx
+++ b/apps/native-rd/App.tsx
@@ -1,4 +1,8 @@
 import { useMemo } from "react";
+import {
+  TopInsetColorProvider,
+  useTopInsetColorState,
+} from "./src/navigation/TopInsetColor";
 import { StatusBar } from "expo-status-bar";
 import { View } from "react-native";
 import {
@@ -46,6 +50,7 @@ function ThemedApp() {
   const { isFirstLaunch, markSeen } = useFirstLaunch();
   const { setTheme: persistingSetTheme } = useThemePersistence();
   const insets = useSafeAreaInsets();
+  const { topInsetColor, setTopInsetColor } = useTopInsetColorState();
   useDensity(); // Apply saved density to all themes on mount
   useAnimationPref(); // Initialize OS reduceMotion listener
 
@@ -91,12 +96,24 @@ function ThemedApp() {
     // clock/wifi/battery glyphs read as part of the header on every theme —
     // light glyphs on the near-black high-contrast/low-info headers, dark
     // glyphs on the light default header.
+    // A focused screen may claim the strip (useTopInsetColor) when it renders a
+    // full-bleed surface instead of a header band — then the glyph polarity
+    // follows that surface rather than the header foreground.
     const headerFgIsLight =
       getContrastRatio(theme.chrome.screenHeaderFg, "#000000") >
       getContrastRatio(theme.chrome.screenHeaderFg, "#ffffff");
+    const stripNeedsLightGlyphs = topInsetColor
+      ? getContrastRatio(topInsetColor, "#ffffff") >
+        getContrastRatio(topInsetColor, "#000000")
+      : headerFgIsLight;
     body = (
-      <View style={{ flex: 1, backgroundColor: theme.chrome.screenHeaderBg }}>
-        <StatusBar style={headerFgIsLight ? "light" : "dark"} />
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: topInsetColor ?? theme.chrome.screenHeaderBg,
+        }}
+      >
+        <StatusBar style={stripNeedsLightGlyphs ? "light" : "dark"} />
         <View
           style={{
             flex: 1,
@@ -105,9 +122,11 @@ function ThemedApp() {
           }}
         >
           <NavigationContainer theme={navTheme}>
-            <ToastProvider>
-              <TabNavigator />
-            </ToastProvider>
+            <TopInsetColorProvider onChange={setTopInsetColor}>
+              <ToastProvider>
+                <TabNavigator />
+              </ToastProvider>
+            </TopInsetColorProvider>
           </NavigationContainer>
         </View>
       </View>

--- a/apps/native-rd/docs/plans/dev-plans/issue-405-badges-thin-container.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-405-badges-thin-container.md
@@ -1,0 +1,130 @@
+# Development Plan: Issue #405
+
+## Issue Summary
+
+**Title**: [Integrate] BadgesScreen thin container
+**Type**: feature (integration step of Epic #384, Track A)
+**Complexity**: SMALL
+**Estimated Lines**: ~180 lines (mostly rewritten, net small)
+
+## Intent Verification
+
+- [ ] With ≥1 earned badge, `BadgesScreen` renders `BadgesWall` full-bleed with `spotlight` = the most recently created badge (`rows[0]`, query is `createdAt DESC`), `gallery` = every other earned badge, and `count` = total badge count — **no purple `ScreenHeader`** above it.
+- [ ] With 0 earned badges, `BadgesScreen` renders a plain `ScreenHeader` titled "Badges" above `BadgesWall`'s own built-in empty state (ghost badge + copy + CTA) — the old `EmptyState` component/copy path is gone.
+- [ ] Tapping the spotlight card or any gallery cell calls `navigation.navigate("BadgeDetail", { badgeId })` with that badge's id.
+- [ ] Tapping the empty-state "See my goals" CTA navigates to `GoalsTab` → `Goals`, identical to the pre-existing empty-state action.
+- [ ] A badge whose goal was deleted (`goalTitle` null) falls back to `badges:card.untitledFallback` in both the spotlight and gallery.
+- [ ] `bun run test --testPathPatterns BadgesScreen` green; `bun run type-check` + `bun run lint` clean.
+
+## Dependencies
+
+| Issue | Title                                       | Status          | Type                                 |
+| ----- | ------------------------------------------- | --------------- | ------------------------------------ |
+| #404  | [Storybook] BadgesWall view + story         | ✅ Met (CLOSED) | Blocker (implicit — wall must exist) |
+| #403  | [Storybook] BadgeWallCell primitive + story | ✅ Met (CLOSED) | Blocker (implicit — cell must exist) |
+
+No `Blocked by` / `Depends on` / `After` markers in the issue body; labeled `dep:independent`. Both prerequisite Storybook components are built and closed.
+
+**Status**: ✅ All dependencies met
+
+## Objective
+
+Replace `BadgesScreen`'s current `BadgeList`/`BadgeCard`/`FlatList` implementation with a thin container that queries `badgesWithGoalsQuery`, maps rows to the already-built `BadgesWall` presentational component's props, and wires navigation — no new visual UI, per the issue's "no un-storied UI" constraint.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                                                                                                                                | Alternatives Considered                                                                                                                                             | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | `ScreenHeader` renders **only** in the empty branch (`count === 0`), inside the same container component that owns the query — not in the outer `BadgesScreen` wrapper. When populated, no `ScreenHeader` is rendered at all; `BadgesWall`'s own `listHeader` (count tally + overline, `BadgesWall.tsx:198-256`) is the only header.    | Always render `ScreenHeader` (old behavior); conditionally change only its title text (GoalsScreen's literal pattern, `GoalsScreen.tsx:176-185`)                    | Issue explicitly states the populated wall is full-bleed and "owns its own count header — no purple `ScreenHeader` over it," while the empty mock still shows a plain "Badges" header. GoalsScreen is cited for the _structural_ pattern (header lives in the container, conditional on state) — not for keeping the header present in both states, which doesn't apply here since `BadgesWall` (unlike `GoalsCockpit`) renders its own header when populated.                                                                                                                                                                                                                                                                                                                                                             |
+| D2  | The spotlight's `earnedAt` is the **raw resolved ISO string** — `(row.completedAt ?? row.createdAt) as string \| null` — passed straight into `BadgesWallSpotlight.earnedAt`, not pre-formatted.                                                                                                                                        | Pre-format via `formatDate(..., i18n.language)` in the container, matching the issue body's literal phrasing.                                                       | `BadgesWall.tsx` already calls `formatDate(spotlight.earnedAt, i18n.language)` internally (line 245), and its own doc comment says `earnedAt` is a "Resolved ISO date string (container applies `completedAt ?? createdAt`)" (`BadgesWall.tsx:37-39`). Pre-formatting in the container would double-format (and `formatDate` on an already-formatted string like "Jan 28, 2026" returns it unchanged only by luck of `Date` parsing — not a safe assumption). Code precedent (the actual consumer) overrides the issue's shorthand phrasing.                                                                                                                                                                                                                                                                               |
+| D3  | Gallery items map to `{ id, title, design }` only — no date field, matching `BadgesWallGalleryItem` (`BadgesWall.tsx:41-46`).                                                                                                                                                                                                           | N/A — interface has no date field                                                                                                                                   | The type is prescriptive; gallery cells don't show a date (`BadgeWallCell.tsx`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| D4  | `onSeeGoals` reuses the exact navigation the old empty-state action used: `navigation.getParent<NativeStackNavigationProp<RootTabParamList>>()?.navigate("GoalsTab", { screen: "Goals" })` (current `BadgesScreen.tsx:37-44`).                                                                                                          | Navigate directly on the screen's own `Nav` type (`BadgesStackParamList`), which has no `GoalsTab` route.                                                           | `BadgesWallProps.onSeeGoals` is a required prop (`BadgesWall.tsx:57`) the issue's bullet list doesn't explicitly mention wiring, but the component can't render without it. The old screen already solved "jump to the Goals tab from within the Badges stack" via `getParent()`; reusing it is the direct precedent and the only nav object with a `GoalsTab` route.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| D5  | The old `EmptyState` component and the `badges:empty.*` i18n keys (`title`/`body`/`action`) are left in place, unused by this screen — not deleted.                                                                                                                                                                                     | Delete `EmptyState` import/usage and prune the orphaned `badges:empty.*` keys as cleanup.                                                                           | Out of scope per the issue ("PR is wiring + query + nav only"); `EmptyState` becomes unused _by this screen_ only (the component itself isn't deleted, so no other consumer is affected — grep confirms none exist today, but removing a shared component is a separate, deliberate change). Flagged under Not in Scope below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D6  | No new i18n keys or locale work needed.                                                                                                                                                                                                                                                                                                 | N/A                                                                                                                                                                 | All consumed keys (`badges:header`, `badges:wall.count`, `badges:wall.allVerifiable`, `badges:wall.justEarned`, `badges:wall.empty.*`, `badges:card.untitledFallback`) already exist in `en/`, `de/`, and `pseudo/badges.json` (shipped by #404) — verified present in all three locale files.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D7  | Keep the tab-bar inset: the container calls `useTabScreenContentInset()` and threads it into `BadgesWall` via a new **optional** `contentInset?: { paddingBottom: number }` prop, merged into the gallery `FlatList`'s `contentContainerStyle` (`contentContainerStyle={[styles.galleryContent, contentInset]}`, `BadgesWall.tsx:271`). | Drop `useTabScreenContentInset` from this screen and let `BadgesWall`'s fixed `galleryContent` bottom padding (`theme.space[8]`) stand, with no tab-bar accounting. | Threading the inset is the app-wide convention for every screen under `FocusPillTabBar` — `GoalsScreen.tsx:5,218,228` (the issue's explicit structural template) passes it as a `contentInset` prop into its presentational `GoalsCockpitContainer` (`GoalsScreen.tsx:90-92,186`), and `SettingsScreen.tsx:131`, `EditModeScreen.tsx:85`, `CaptureVideoScreen.tsx:46`, `CaptureTextNote.tsx:39`, `IntlProbeScreen.tsx:53` all do the same. The **current** `BadgesScreen.tsx:26` already calls it, so dropping it is a functional regression that hides the last gallery row behind the floating pill bar. An optional layout prop with a default of `undefined` introduces no new visual element, so it does not violate "no un-storied UI" (which targets unverified _visuals_); existing #404 stories render unchanged. |
+
+## Affected Areas
+
+- `apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx`: rewrite `BadgeList`/`FlatList`/`BadgeCard`/`EmptyState` path into a thin container (`BadgesWallContainer`) that queries, maps, and renders `BadgesWall` (+ conditional `ScreenHeader`), keeping the outer `ErrorBoundary`/`Suspense` shell.
+- `apps/native-rd/src/screens/BadgesScreen/BadgesScreen.styles.ts`: drop now-unused `scrollContent`/`listContent` styles (the `FlatList` they styled is gone); keep `screen`/`loadingIndicator`.
+- `apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx`: rewrite for wall-props mapping, nav wiring, and empty state; drop the old `BadgeCard`-rendering assertions (now covered by `BadgesWall.test.tsx`).
+
+- `apps/native-rd/src/screens/BadgesScreen/BadgesWall.tsx`: add the optional `contentInset?: { paddingBottom: number }` prop and merge it into the gallery `FlatList`'s `contentContainerStyle` (D7). Layout-only — no new visual element, no story changes.
+
+No changes to `BadgeWallCell.tsx`, `db/queries.ts`, or any i18n resource files.
+
+## Implementation Plan
+
+### Step 1: Rewrite `BadgesScreen.tsx` as a thin container
+
+**Files**: `apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx`
+**Commit**: `feat(native-rd): wire BadgesScreen container to wall (#405)`
+**Changes**:
+
+- [ ] Remove `BadgeList`, the `FlatList` import, `BadgeCard`, `EmptyState` imports/usage.
+- [ ] Add a `BadgesWallContainer` function component: `rows = useQuery(badgesWithGoalsQuery)`; `count = rows.length`; `spotlight = rows[0] ?? null`; `gallery = rows.slice(1)`.
+- [ ] Map `spotlight` row → `BadgesWallSpotlight`: `{ id, design: parseBadgeDesign(row.design), goalTitle: row.goalTitle ?? t("badges:card.untitledFallback"), earnedAt: (row.completedAt ?? row.createdAt) as string | null }` (D2).
+- [ ] Map `gallery` rows → `BadgesWallGalleryItem[]`: `{ id, title: row.goalTitle ?? t("badges:card.untitledFallback"), design: parseBadgeDesign(row.design) }` (D3).
+- [ ] `onOpenBadge = (id) => navigation.navigate("BadgeDetail", { badgeId: id })`.
+- [ ] `onSeeGoals` per D4 (`getParent<NativeStackNavigationProp<RootTabParamList>>()?.navigate("GoalsTab", { screen: "Goals" })`).
+- [ ] Render: `count === 0 ? <><ScreenHeader title={t("badges:header")} /><BadgesWall .../></> : <BadgesWall .../>` (D1).
+- [ ] `BadgesScreen` keeps the outer `<View style={styles.screen}><ErrorBoundary><Suspense fallback={...}><BadgesWallContainer /></Suspense></ErrorBoundary></View>` shell, dropping the always-on `ScreenHeader` that used to sit outside `Suspense`.
+- [ ] Keep the `BadgeRow`/`Nav` type aliases; drop unused `RootTabParamList`-adjacent imports that no longer apply (re-verify after edit).
+- [ ] Keep `useTabScreenContentInset()` (currently `BadgesScreen.tsx:26`) and pass it as `contentInset` to `BadgesWall` (D7).
+
+### Step 1b: Add the `contentInset` prop to `BadgesWall`
+
+**Files**: `apps/native-rd/src/screens/BadgesScreen/BadgesWall.tsx`
+**Commit**: same commit as Step 1
+**Changes**:
+
+- [ ] Add `contentInset?: { paddingBottom: number }` to `BadgesWallProps` (after `onSeeGoals`, `BadgesWall.tsx:48-58`), documented as the tab-bar clearance the container threads in.
+- [ ] Destructure it in the component signature (`BadgesWall.tsx:118-124`) and change the gallery `FlatList` to `contentContainerStyle={[styles.galleryContent, contentInset]}` (`BadgesWall.tsx:271`).
+- [ ] No story changes — the prop is optional and `undefined` in existing #404 stories, so they render byte-identically.
+
+### Step 2: Trim `BadgesScreen.styles.ts`
+
+**Files**: `apps/native-rd/src/screens/BadgesScreen/BadgesScreen.styles.ts`
+**Commit**: same commit as Step 1 (single cohesive change)
+**Changes**:
+
+- [ ] Remove `scrollContent` and `listContent` (only consumed by the removed `FlatList`).
+- [ ] Keep `screen` and `loadingIndicator`.
+
+### Step 3: Rewrite `BadgesScreen.test.tsx`
+
+**Files**: `apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx`
+**Commit**: `test(native-rd): cover BadgesScreen wall-container wiring (#405)`
+**Changes**:
+
+- [ ] Keep the `@react-navigation/native` and `@evolu/react` mocks (`mockUseQuery`, `mockNavigate`, `mockGetParent`) from the current file.
+- [ ] Keep `jest.mock("../../../db", ...)` exporting `badgesWithGoalsQuery: { __brand: "badgesWithGoalsQuery" }`; route `mockUseQuery` on that brand (mirrors `GoalsScreen.test.tsx`'s `mockData` helper) so `BadgesWall`'s internal `useAnimationPref` → `useQuery(userSettingsQuery)` call (unbranded, since `userSettingsQuery` isn't exported from the mock) safely falls through to a `[]` default instead of leaking badge rows into the animation-pref hook.
+- [ ] Use `design: null` in all row fixtures so gallery/spotlight art render `BadgeWallCell`'s/`BadgesWall`'s plain fallback tiles — avoids needing to mock `BadgeRenderer`/`react-native-svg` (this is a wiring test, not a visual one; visuals are `BadgesWall.test.tsx`'s job per the issue).
+- [ ] `describe("empty state")`: `count === 0` → assert `badges:header` (ScreenHeader) **and** `badges:wall.empty.title`/`badges:wall.empty.body` render; press `badges:wall.empty.action` → assert `mockNavigate` called with `("GoalsTab", { screen: "Goals" })` via `mockGetParent`.
+- [ ] `describe("populated")`: 3 rows → assert `badges:wall.count` text with `count: 3`; assert `badges-wall-spotlight` testID renders row 0's title; assert `badge-wall-cell-<id>` testIDs render for rows 1 and 2; assert `badges:header` is **not** on screen (no purple header over the wall).
+- [ ] `describe("navigation")`: press `badges-wall-spotlight` → `mockNavigate` called with `("BadgeDetail", { badgeId: <row0.id> })`; press a `badge-wall-cell-<id>` → same for that row's id.
+- [ ] Keep an `untitledFallback` case: a row with `goalTitle: null` renders `badges:card.untitledFallback` as both spotlight title and (if it's the only other row) a gallery cell's accessibility label.
+- [ ] Keep the pseudo-locale `it.each` for `badges:header` and the two `wall.empty.*` keys (drop the old `badges:empty.*` keys, now unreachable from this screen).
+- [ ] Drop assertions tied to the removed `BadgeCard`/date-formatting-in-`BadgeCard` path (formatted-date rendering is `BadgesWall.test.tsx`'s job, per D2/the issue's "don't duplicate" instruction).
+
+## Testing Strategy
+
+- [ ] Unit tests for `BadgesScreen` container (Jest 30, `@testing-library/react-native` v13) per Step 3.
+- [ ] Test file stays at `apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx` (mirrors existing location).
+- [ ] `bun run test --testPathPatterns BadgesScreen` green.
+- [ ] `bun run type-check` and `bun run lint` clean.
+- [ ] Manual/in-app spot check (per issue Acceptance): Full Ride, Night Ride, and one shadow-off theme (Bold Ink or highContrast) — both empty and populated states, and specifically that the last gallery row clears the floating `FocusPillTabBar` (D7).
+
+## Not in Scope
+
+| Item                                                                     | Reason                                                                                                                              | Follow-up                                    |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Deleting the unused `EmptyState` component or `badges:empty.*` i18n keys | Issue scope is wiring/query/nav only; `EmptyState` may still be intentionally kept as a shared primitive                            | none filed                                   |
+| `badge-wall-bg` design token (conditional Step 7 in #381's plan)         | Only needed if the 7-theme Storybook check on `BadgesWall` (already done in #404) surfaces a contrast problem; not this issue's job | #381 Step 7 (conditional, not yet triggered) |
+| Bottom-nav / `FocusPillTabBar` redesign                                  | Separate track (#379)                                                                                                               | #379                                         |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->

--- a/apps/native-rd/src/navigation/TopInsetColor.tsx
+++ b/apps/native-rd/src/navigation/TopInsetColor.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { useIsFocused } from "@react-navigation/native";
+
+type SetTopInsetColor = (color: string | null) => void;
+
+const TopInsetColorContext = createContext<SetTopInsetColor>(() => {});
+
+/**
+ * Lets a screen repaint the device top-inset strip that App.tsx draws above the
+ * navigator.
+ *
+ * App.tsx paints that strip with `chrome.screenHeaderBg` so it reads as a
+ * continuation of the ScreenHeader band below it. The navigator content is
+ * offset by `insets.top`, so a screen can never cover the strip itself — a
+ * full-bleed surface (the badge wall) would otherwise sit under an orphaned
+ * header-colored band it has nothing to do with. This is the opt-out.
+ */
+export function TopInsetColorProvider({
+  children,
+  onChange,
+}: {
+  children: React.ReactNode;
+  onChange: SetTopInsetColor;
+}) {
+  return (
+    <TopInsetColorContext.Provider value={onChange}>
+      {children}
+    </TopInsetColorContext.Provider>
+  );
+}
+
+/**
+ * Paint the top-inset strip `color` while this screen is focused; pass `null`
+ * to leave it at the default header color. Reverts on blur/unmount, so pushing
+ * a detail screen or switching tabs restores the header-colored strip.
+ */
+export function useTopInsetColor(color: string | null) {
+  const setColor = useContext(TopInsetColorContext);
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (!isFocused || color === null) return;
+    setColor(color);
+    return () => setColor(null);
+  }, [color, isFocused, setColor]);
+}
+
+/**
+ * State holder for {@link TopInsetColorProvider} — App.tsx owns the value and
+ * paints with it; screens set it through the context.
+ */
+export function useTopInsetColorState() {
+  const [topInsetColor, setTopInsetColor] = useState<string | null>(null);
+  return { topInsetColor, setTopInsetColor };
+}

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.styles.ts
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.styles.ts
@@ -5,13 +5,6 @@ export const styles = StyleSheet.create((theme) => ({
     flex: 1,
     backgroundColor: theme.colors.background,
   },
-  scrollContent: {
-    padding: theme.space[4],
-    gap: theme.space[4],
-  },
-  listContent: {
-    gap: theme.space[3],
-  },
   loadingIndicator: {
     marginTop: theme.space[8],
   },

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
@@ -13,8 +13,10 @@ import type {
   BadgesStackParamList,
   RootTabParamList,
 } from "../../navigation/types";
+import { useTopInsetColor } from "../../navigation/TopInsetColor";
 import { BadgesWall } from "./BadgesWall";
 import type { BadgesWallGalleryItem, BadgesWallSpotlight } from "./BadgesWall";
+import { WALL_SURFACE } from "./BadgesWall.styles";
 import { styles } from "./BadgesScreen.styles";
 
 type BadgeRow = typeof badgesWithGoalsQuery.Row;
@@ -55,6 +57,12 @@ function BadgesWallContainer({
     title: titleOf(row),
     design: parseBadgeDesign(row.design as string | null),
   }));
+
+  // Populated, the wall is full-bleed with no ScreenHeader — so it also takes
+  // over the device top-inset strip, which App.tsx otherwise paints in the
+  // header color. Without this the dark surface sits under an orphaned purple
+  // band. The empty branch keeps its ScreenHeader, so the strip stays default.
+  useTopInsetColor(count > 0 ? WALL_SURFACE : null);
 
   const wall = (
     <BadgesWall

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesScreen.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { View, FlatList, ActivityIndicator } from "react-native";
+import { View, ActivityIndicator } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { useTabScreenContentInset } from "../../navigation/useTabScreenContentInset";
@@ -7,88 +7,95 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useQuery } from "@evolu/react";
 import { ErrorBoundary } from "../../components/ErrorBoundary";
 import { ScreenHeader } from "../../components/ScreenHeader";
-import { BadgeCard } from "../../components/BadgeCard";
-import { EmptyState } from "../../components/EmptyState";
 import { parseBadgeDesign } from "../../badges/types";
 import { badgesWithGoalsQuery } from "../../db";
-import { formatDate } from "../../utils/format";
 import type {
   BadgesStackParamList,
   RootTabParamList,
 } from "../../navigation/types";
+import { BadgesWall } from "./BadgesWall";
+import type { BadgesWallGalleryItem, BadgesWallSpotlight } from "./BadgesWall";
 import { styles } from "./BadgesScreen.styles";
 
 type BadgeRow = typeof badgesWithGoalsQuery.Row;
 type Nav = NativeStackNavigationProp<BadgesStackParamList>;
 
-function BadgeList() {
+/**
+ * Thin container for the Badges tab (#405): query → props → {@link BadgesWall}.
+ * No layout or visuals of its own beyond the empty-state ScreenHeader — the
+ * populated wall is full-bleed and owns its count header.
+ */
+function BadgesWallContainer({
+  contentInset,
+}: {
+  contentInset: { paddingBottom: number };
+}) {
   const navigation = useNavigation<Nav>();
-  const tabInset = useTabScreenContentInset();
   const rows = useQuery(badgesWithGoalsQuery);
-  const { t, i18n } = useTranslation(["badges"]);
+  const { t } = useTranslation(["badges"]);
 
-  if (rows.length === 0) {
-    return (
-      <EmptyState
-        title={t("badges:empty.title")}
-        body={t("badges:empty.body")}
-        action={{
-          label: t("badges:empty.action"),
-          onPress: () => {
-            const parent =
-              navigation.getParent<
-                NativeStackNavigationProp<RootTabParamList>
-              >();
-            parent?.navigate("GoalsTab", { screen: "Goals" });
-          },
-        }}
-      />
-    );
-  }
+  const titleOf = (row: BadgeRow) =>
+    (row.goalTitle as string | null) ?? t("badges:card.untitledFallback");
 
-  return (
-    <FlatList
-      data={rows}
-      keyExtractor={(item) => item.id}
-      style={{ flex: 1 }}
-      contentContainerStyle={[
-        styles.scrollContent,
-        styles.listContent,
-        tabInset,
-      ]}
-      scrollIndicatorInsets={{ right: 1 }}
-      renderItem={({ item }: { item: BadgeRow }) => (
-        <BadgeCard
-          title={
-            (item.goalTitle as string) ?? t("badges:card.untitledFallback")
-          }
-          description={(item.goalDescription as string | null) ?? undefined}
-          earnedDate={formatDate(
-            (item.completedAt ?? item.createdAt) as string | null,
-            i18n.language,
-          )}
-          design={parseBadgeDesign(item.design as string | null)}
-          onPress={() =>
-            navigation.navigate("BadgeDetail", { badgeId: item.id })
-          }
-        />
-      )}
+  const count = rows.length;
+  const spotlightRow = rows[0] ?? null;
+  const spotlight: BadgesWallSpotlight | null = spotlightRow
+    ? {
+        id: spotlightRow.id,
+        design: parseBadgeDesign(spotlightRow.design as string | null),
+        goalTitle: titleOf(spotlightRow),
+        // Raw ISO string — BadgesWall formats it with the active locale.
+        earnedAt: (spotlightRow.completedAt ?? spotlightRow.createdAt) as
+          | string
+          | null,
+      }
+    : null;
+  const gallery: BadgesWallGalleryItem[] = rows.slice(1).map((row) => ({
+    id: row.id,
+    title: titleOf(row),
+    design: parseBadgeDesign(row.design as string | null),
+  }));
+
+  const wall = (
+    <BadgesWall
+      count={count}
+      spotlight={spotlight}
+      gallery={gallery}
+      contentInset={contentInset}
+      onOpenBadge={(badgeId) => navigation.navigate("BadgeDetail", { badgeId })}
+      onSeeGoals={() => {
+        // Goals lives on a sibling tab, so the jump goes through the tab
+        // navigator — the Badges stack has no "GoalsTab" route.
+        const parent =
+          navigation.getParent<NativeStackNavigationProp<RootTabParamList>>();
+        parent?.navigate("GoalsTab", { screen: "Goals" });
+      }}
     />
+  );
+
+  // Populated: the wall is full-bleed with its own count header — no purple
+  // ScreenHeader above it. Empty: a plain "Badges" header frames the ghost card.
+  if (count > 0) return wall;
+  return (
+    <>
+      <ScreenHeader title={t("badges:header")} />
+      {wall}
+    </>
   );
 }
 
 export function BadgesScreen() {
-  const { t } = useTranslation(["badges"]);
+  const tabInset = useTabScreenContentInset();
+
   return (
     <View style={styles.screen}>
-      <ScreenHeader title={t("badges:header")} />
       <ErrorBoundary>
         <Suspense
           fallback={
             <ActivityIndicator style={styles.loadingIndicator} size="large" />
           }
         >
-          <BadgeList />
+          <BadgesWallContainer contentInset={tabInset} />
         </Suspense>
       </ErrorBoundary>
     </View>

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesWall.styles.ts
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesWall.styles.ts
@@ -32,7 +32,9 @@ export const SPOTLIGHT_ART_COMPACT = 48;
 // the no-raw-colors rule still guards the REST of the file against accidental
 // hardcodes, while this one documented exception stays explicit.
 /* eslint-disable local/no-raw-colors -- fixed dark wall surface, see note above */
-const WALL_SURFACE = "#161616";
+/** The fixed dark wall surface. Exported so the container can extend it into
+ *  the device top-inset strip (App.tsx paints that, above the navigator). */
+export const WALL_SURFACE = "#161616";
 const WALL_INK = palette.white;
 const WALL_INK_MUTED = palette.gray400;
 const WALL_PANEL = palette.gray800;

--- a/apps/native-rd/src/screens/BadgesScreen/BadgesWall.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/BadgesWall.tsx
@@ -55,6 +55,12 @@ export interface BadgesWallProps {
   onOpenBadge: (id: string) => void;
   /** Empty-state CTA target — container wires this to the Goals tab (D12). */
   onSeeGoals: () => void;
+  /**
+   * Extra bottom clearance for the gallery, threaded in by the container so the
+   * last row clears the floating FocusPillTabBar (`useTabScreenContentInset`).
+   * Layout only — omit it and the gallery keeps its own fixed bottom padding.
+   */
+  contentInset?: { paddingBottom: number };
 }
 
 /** Ghost-badge motif for the empty state — a dashed outline coin with the
@@ -121,6 +127,7 @@ export function BadgesWall({
   gallery,
   onOpenBadge,
   onSeeGoals,
+  contentInset,
 }: BadgesWallProps) {
   const { t, i18n } = useTranslation(["badges"]);
   const { animationPref } = useAnimationPref();
@@ -268,7 +275,7 @@ export function BadgesWall({
         keyExtractor={(item) => item.id}
         numColumns={numColumns}
         columnWrapperStyle={styles.galleryRow}
-        contentContainerStyle={styles.galleryContent}
+        contentContainerStyle={[styles.galleryContent, contentInset]}
         ListHeaderComponent={listHeader}
         renderItem={({ item }) => (
           <BadgeWallCell

--- a/apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx
@@ -39,85 +39,136 @@ jest.mock("../../../db", () => ({
   badgesWithGoalsQuery: { __brand: "badgesWithGoalsQuery" },
 }));
 
+// `design: null` throughout — this is a wiring test, so cells and the spotlight
+// render their initial-letter fallback tiles rather than dragging in
+// BadgeRenderer/react-native-svg. Visuals are BadgesWall.test.tsx's job.
 const makeBadgeRow = (overrides: Record<string, unknown> = {}) => ({
   id: "badge-1",
   goalId: "goal-1",
   imageUri: "pending:baked-image",
+  design: null,
   createdAt: "2026-01-28T00:00:00.000Z",
   goalTitle: "Learn TypeScript",
+  goalDescription: null,
   completedAt: "2026-01-28T00:00:00.000Z",
   ...overrides,
 });
 
+/**
+ * Route rows by query brand. BadgesWall's useAnimationPref also calls useQuery
+ * (with `userSettingsQuery`, which the db mock doesn't export) — the unbranded
+ * fall-through keeps badge rows from leaking into the animation pref.
+ */
+const mockBadges = (badges: Record<string, unknown>[]) => {
+  mockUseQuery.mockImplementation((query: { __brand?: string }) =>
+    query?.__brand === "badgesWithGoalsQuery" ? badges : [],
+  );
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
-  mockUseQuery.mockReturnValue([]);
+  mockBadges([]);
   mockGetParent.mockReturnValue({ navigate: mockNavigate });
 });
 
 describe("BadgesScreen", () => {
   describe("empty state", () => {
-    it("renders empty state when no badges exist", () => {
+    it("renders the plain Badges header above the wall's empty state", () => {
       renderWithProviders(<BadgesScreen />);
-      expect(screen.getByText(i18n.t("badges:empty.title"))).toBeOnTheScreen();
-      expect(screen.getByText(i18n.t("badges:empty.body"))).toBeOnTheScreen();
+      expect(screen.getByText(i18n.t("badges:header"))).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("badges:wall.empty.title")),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("badges:wall.empty.body")),
+      ).toBeOnTheScreen();
     });
 
-    it("renders Go to Goals action button", () => {
+    it("navigates to the Goals tab when the empty-state CTA is pressed", () => {
       renderWithProviders(<BadgesScreen />);
-      expect(screen.getByText(i18n.t("badges:empty.action"))).toBeOnTheScreen();
-    });
-
-    it("navigates to Goals tab when Go to Goals is pressed", () => {
-      renderWithProviders(<BadgesScreen />);
-      fireEvent.press(screen.getByText(i18n.t("badges:empty.action")));
+      fireEvent.press(screen.getByTestId("badges-wall-see-goals"));
       expect(mockNavigate).toHaveBeenCalledWith("GoalsTab", {
         screen: "Goals",
       });
     });
   });
 
-  describe("header", () => {
-    it("renders Badges title", () => {
+  describe("populated", () => {
+    const threeBadges = [
+      makeBadgeRow({ id: "badge-1", goalTitle: "Learn TypeScript" }),
+      makeBadgeRow({ id: "badge-2", goalTitle: "Learn Rust" }),
+      makeBadgeRow({ id: "badge-3", goalTitle: "Learn Elixir" }),
+    ];
+
+    it("passes the total badge count to the wall header", () => {
+      mockBadges(threeBadges);
       renderWithProviders(<BadgesScreen />);
-      expect(screen.getByText(i18n.t("badges:header"))).toBeOnTheScreen();
+      expect(
+        screen.getByText(i18n.t("badges:wall.count", { count: 3 })),
+      ).toBeOnTheScreen();
+    });
+
+    it("spotlights the most recent badge and galleries the rest", () => {
+      mockBadges(threeBadges);
+      renderWithProviders(<BadgesScreen />);
+
+      expect(screen.getByTestId("badges-wall-spotlight")).toHaveProp(
+        "accessibilityLabel",
+        "Learn TypeScript",
+      );
+      expect(screen.getByTestId("badge-wall-cell-badge-2")).toBeOnTheScreen();
+      expect(screen.getByTestId("badge-wall-cell-badge-3")).toBeOnTheScreen();
+      // The spotlight badge is not repeated as a gallery cell.
+      expect(screen.queryByTestId("badge-wall-cell-badge-1")).toBeNull();
+    });
+
+    it("renders no purple ScreenHeader over the populated wall", () => {
+      mockBadges(threeBadges);
+      renderWithProviders(<BadgesScreen />);
+      expect(screen.queryByText(i18n.t("badges:header"))).toBeNull();
+    });
+
+    it("falls back to the untitled label when the goal was deleted", () => {
+      mockBadges([
+        makeBadgeRow({ id: "badge-1", goalTitle: null }),
+        makeBadgeRow({ id: "badge-2", goalTitle: null }),
+      ]);
+      renderWithProviders(<BadgesScreen />);
+
+      const fallback = i18n.t("badges:card.untitledFallback");
+      expect(screen.getByTestId("badges-wall-spotlight")).toHaveProp(
+        "accessibilityLabel",
+        fallback,
+      );
+      expect(screen.getByTestId("badge-wall-cell-badge-2")).toHaveProp(
+        "accessibilityLabel",
+        fallback,
+      );
     });
   });
 
-  describe("badge list", () => {
-    it("renders badge cards when badges exist", () => {
-      const badges = [
+  describe("navigation", () => {
+    beforeEach(() => {
+      mockBadges([
         makeBadgeRow({ id: "badge-1", goalTitle: "Learn TypeScript" }),
         makeBadgeRow({ id: "badge-2", goalTitle: "Learn Rust" }),
-      ];
-      mockUseQuery.mockReturnValue(badges);
-
-      renderWithProviders(<BadgesScreen />);
-      expect(screen.getByText("Learn TypeScript")).toBeOnTheScreen();
-      expect(screen.getByText("Learn Rust")).toBeOnTheScreen();
+      ]);
     });
 
-    it("navigates to BadgeDetail when a badge card is pressed", () => {
-      const badges = [
-        makeBadgeRow({ id: "badge-1", goalTitle: "Learn TypeScript" }),
-      ];
-      mockUseQuery.mockReturnValue(badges);
-
+    it("opens BadgeDetail from the spotlight", () => {
       renderWithProviders(<BadgesScreen />);
-      fireEvent.press(screen.getByText("Learn TypeScript"));
+      fireEvent.press(screen.getByTestId("badges-wall-spotlight"));
       expect(mockNavigate).toHaveBeenCalledWith("BadgeDetail", {
         badgeId: "badge-1",
       });
     });
 
-    it("formats earned date correctly", () => {
-      const badges = [
-        makeBadgeRow({ completedAt: "2026-01-28T00:00:00.000Z" }),
-      ];
-      mockUseQuery.mockReturnValue(badges);
-
+    it("opens BadgeDetail from a gallery cell", () => {
       renderWithProviders(<BadgesScreen />);
-      expect(screen.getByText("Jan 28, 2026")).toBeOnTheScreen();
+      fireEvent.press(screen.getByTestId("badge-wall-cell-badge-2"));
+      expect(mockNavigate).toHaveBeenCalledWith("BadgeDetail", {
+        badgeId: "badge-2",
+      });
     });
   });
 
@@ -128,9 +179,8 @@ describe("BadgesScreen", () => {
 
     it.each([
       "badges:header",
-      "badges:empty.title",
-      "badges:empty.body",
-      "badges:empty.action",
+      "badges:wall.empty.title",
+      "badges:wall.empty.body",
     ] as const)(
       "renders %s as bracketed copy under pseudo locale",
       async (key) => {
@@ -144,7 +194,7 @@ describe("BadgesScreen", () => {
 
     it("renders badges:card.untitledFallback as bracketed copy when goalTitle is null", async () => {
       await i18n.changeLanguage("pseudo");
-      mockUseQuery.mockReturnValue([makeBadgeRow({ goalTitle: null })]);
+      mockBadges([makeBadgeRow({ goalTitle: null })]);
       renderWithProviders(<BadgesScreen />);
       const pseudo = i18n.t("badges:card.untitledFallback");
       expect(pseudo.startsWith("[")).toBe(true);

--- a/apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx
+++ b/apps/native-rd/src/screens/BadgesScreen/__tests__/BadgesScreen.test.tsx
@@ -5,6 +5,8 @@ import {
   fireEvent,
 } from "../../../__tests__/test-utils";
 import { i18n } from "../../../i18n";
+import { TopInsetColorProvider } from "../../../navigation/TopInsetColor";
+import { WALL_SURFACE } from "../BadgesWall.styles";
 import { BadgesScreen } from "../BadgesScreen";
 
 const mockNavigate = jest.fn();
@@ -169,6 +171,43 @@ describe("BadgesScreen", () => {
       expect(mockNavigate).toHaveBeenCalledWith("BadgeDetail", {
         badgeId: "badge-2",
       });
+    });
+  });
+
+  // App.tsx paints the device top-inset strip in the header color; the
+  // full-bleed wall has no header to continue, so it claims the strip instead.
+  describe("top-inset strip", () => {
+    const renderWithStrip = () => {
+      const onChange = jest.fn();
+      renderWithProviders(
+        <TopInsetColorProvider onChange={onChange}>
+          <BadgesScreen />
+        </TopInsetColorProvider>,
+      );
+      return onChange;
+    };
+
+    it("extends the wall surface into the strip when populated", () => {
+      mockBadges([makeBadgeRow()]);
+      expect(renderWithStrip()).toHaveBeenCalledWith(WALL_SURFACE);
+    });
+
+    it("leaves the strip at the header color in the empty state", () => {
+      mockBadges([]);
+      expect(renderWithStrip()).not.toHaveBeenCalled();
+    });
+
+    it("releases the strip on unmount", () => {
+      mockBadges([makeBadgeRow()]);
+      const onChange = jest.fn();
+      const view = renderWithProviders(
+        <TopInsetColorProvider onChange={onChange}>
+          <BadgesScreen />
+        </TopInsetColorProvider>,
+      );
+      onChange.mockClear();
+      view.unmount();
+      expect(onChange).toHaveBeenCalledWith(null);
     });
   });
 


### PR DESCRIPTION
Closes #405.

Replaces `BadgesScreen`'s `BadgeList`/`FlatList`/`BadgeCard`/`EmptyState` implementation with a thin container over the already-built `BadgesWall` (#404) — query, map, wire nav. No new visual UI, per the issue's "no un-storied UI" constraint.

## What changed

**`BadgesScreen.tsx`** — now `BadgesWallContainer`: `useQuery(badgesWithGoalsQuery)` → `spotlight = rows[0]` (query is `createdAt DESC`), `gallery = rows.slice(1)`, `count = rows.length`. `earnedAt` is passed as the raw resolved ISO string (`completedAt ?? createdAt`) since `BadgesWall` formats it with the active locale — pre-formatting here would double-format. `onOpenBadge` → `navigate("BadgeDetail", { badgeId })`; `onSeeGoals` → `getParent()?.navigate("GoalsTab", { screen: "Goals" })`, the same hop the old empty state used.

**`ScreenHeader` renders only in the empty branch.** Populated, the wall is full-bleed and owns its own count header.

**`BadgesWall.tsx`** — new optional `contentInset?: { paddingBottom: number }`, merged into the gallery `FlatList`'s `contentContainerStyle`. The current screen already calls `useTabScreenContentInset()`; dropping it would hide the last gallery row behind the floating `FocusPillTabBar`. Optional with an `undefined` default, so the #404 stories render unchanged.

**`BadgesScreen.styles.ts`** — dropped `scrollContent`/`listContent` (the `FlatList` they styled is gone).

## Top-inset strip fix

Caught on a simulator pass. `App.tsx` paints the device top-inset strip with `chrome.screenHeaderBg` so it reads as a continuation of the `ScreenHeader` band below it, and offsets the navigator by `insets.top` — so no screen can cover that strip itself. The full-bleed wall renders no band, which left its dark surface sitting under an orphaned purple strip.

New `src/navigation/TopInsetColor.tsx` gives a focused screen an opt-in way to repaint the strip (reverts on blur/unmount, so pushing BadgeDetail or switching tabs restores the header color). `BadgesScreen` claims it with `WALL_SURFACE` when populated. Status-bar glyph polarity now follows the strip color when overridden, so the clock/wifi/battery stay legible on `#161616`. The empty branch keeps its `ScreenHeader`, so its strip is unchanged.

## Testing

`BadgesScreen.test.tsx` rewritten around wall-props mapping, the spotlight/gallery split (and that the spotlight isn't duplicated as a cell), nav from both surfaces, `untitledFallback` when a goal was deleted, the redesigned empty state, the top-inset strip, and pseudo-locale coverage. `useQuery` is now routed by query brand so `BadgesWall`'s internal `useAnimationPref` lookup no longer receives badge rows. Badge-card and date-formatting assertions drop — those live in `BadgesWall.test.tsx`.

Full suite green: **213 suites / 10060 tests**. `type-check` and `lint` clean.

## Reviewer notes

- **Deviates from the issue's D1** in one place: the issue specced no `ScreenHeader` on the populated wall, which is what's implemented — but see the top-inset section for why that alone wasn't enough to make it look right.
- The wall is a deliberately fixed dark surface across all 14 themes, so on a light theme the dark strip now reads as part of the wall rather than the chrome. Intended, but it's the most visible consequence of this change.
- `EmptyState` and the `badges:empty.*` keys are left in place, unused by this screen — pruning a shared component is a separate, deliberate change (issue scope is wiring/query/nav only).

## Not yet done

Manual multi-theme spot check (Full Ride, Night Ride, one shadow-off variant) beyond the two screenshots that surfaced the strip bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k9en9iEDr9XTAbLJKFzaJ