### PR TITLE
fix(native-rd): four review fixes — hero top inset, rename clear control, designer rail bleed, reveal sparkles

### DIFF
--- a/apps/native-rd/src/badges/BadgeColorsAccordion.styles.ts
+++ b/apps/native-rd/src/badges/BadgeColorsAccordion.styles.ts
@@ -39,9 +39,16 @@ export const styles = StyleSheet.create((theme) => ({
     fontSize: 12,
     fontWeight: "800",
   },
+  // See selectorStyles.rail: the swatch rail bleeds past the section's
+  // horizontal inset so it scrolls to the card border, and re-applies that
+  // inset as content padding so the first swatch stays aligned with the tab
+  // bar above it.
+  paletteRail: {
+    marginHorizontal: -theme.space[4],
+  },
   paletteRow: {
     gap: theme.space[3],
-    paddingHorizontal: theme.space[1],
+    paddingHorizontal: theme.space[4],
     alignItems: "flex-start",
   },
   cell: {

--- a/apps/native-rd/src/badges/CenterModeSelector.tsx
+++ b/apps/native-rd/src/badges/CenterModeSelector.tsx
@@ -49,7 +49,10 @@ export function CenterModeSelector({
       accessibilityRole="radiogroup"
       accessibilityLabel={t("center.a11y")}
     >
-      <View style={[selectorStyles.row, styles.row]}>
+      {/* Static (non-scrolling) rail, but it takes the same bleed + inset pair
+          as the scrolling selectors so its options line up with theirs across
+          sections instead of sitting a second `space[4]` in. */}
+      <View style={[selectorStyles.rail, selectorStyles.row, styles.row]}>
         {MODES.map((mode) => {
           const isSelected = mode === selectedMode;
           const label = t(`center.options.${mode}`);

--- a/apps/native-rd/src/badges/ChannelPalette.tsx
+++ b/apps/native-rd/src/badges/ChannelPalette.tsx
@@ -52,6 +52,7 @@ export function ChannelPalette({
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
+        style={styles.paletteRail}
         contentContainerStyle={styles.paletteRow}
       >
         <Pressable

--- a/apps/native-rd/src/badges/ColorPicker.tsx
+++ b/apps/native-rd/src/badges/ColorPicker.tsx
@@ -90,6 +90,7 @@ export function ColorPicker({
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
+        style={selectorStyles.rail}
         contentContainerStyle={selectorStyles.row}
       >
         {swatches.map(({ id, hex }) => {

--- a/apps/native-rd/src/badges/FrameSelector.tsx
+++ b/apps/native-rd/src/badges/FrameSelector.tsx
@@ -60,6 +60,7 @@ export function FrameSelector({
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
+        style={selectorStyles.rail}
         contentContainerStyle={selectorStyles.row}
       >
         {FRAMES.map((frame) => {

--- a/apps/native-rd/src/badges/ShapeSelector.tsx
+++ b/apps/native-rd/src/badges/ShapeSelector.tsx
@@ -51,6 +51,7 @@ export function ShapeSelector({
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
+        style={selectorStyles.rail}
         contentContainerStyle={selectorStyles.row}
       >
         {SHAPES.map((shape) => {

--- a/apps/native-rd/src/badges/__tests__/selectorRailBleed.test.ts
+++ b/apps/native-rd/src/badges/__tests__/selectorRailBleed.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Rail bleed invariant.
+ *
+ * Every horizontal option rail (shape / frame / color / center mode, plus the
+ * per-channel swatch rail) lives inside a CollapsibleSection, whose content is
+ * inset horizontally. With that inset on the scroll *viewport*, the last option
+ * is clipped against a hard gutter and the rail reads as truncated instead of
+ * scrollable — the review finding this guards.
+ *
+ * The fix is a pair that must stay balanced: a negative margin on the
+ * ScrollView cancelling the section inset, and the same value re-applied as
+ * content padding so cells still line up with the section title. Asserting the
+ * relationship (not the literal number) keeps a spacing-token change from
+ * silently reintroducing the gutter.
+ */
+import { styles as sectionStyles } from "../../components/CollapsibleSection/CollapsibleSection.styles";
+import { styles as colorsAccordionStyles } from "../BadgeColorsAccordion.styles";
+import { selectorStyles } from "../selectorStyles";
+
+describe("selector rail bleed", () => {
+  const sectionInset = sectionStyles.content.paddingHorizontal as number;
+
+  it("cancels exactly the section's horizontal inset", () => {
+    expect(selectorStyles.rail.marginHorizontal).toBe(-sectionInset);
+    expect(colorsAccordionStyles.paletteRail.marginHorizontal).toBe(
+      -sectionInset,
+    );
+  });
+
+  it("re-applies that inset as rail content padding", () => {
+    expect(selectorStyles.row.paddingHorizontal).toBe(sectionInset);
+    expect(colorsAccordionStyles.paletteRow.paddingHorizontal).toBe(
+      sectionInset,
+    );
+  });
+});

--- a/apps/native-rd/src/badges/selectorStyles.ts
+++ b/apps/native-rd/src/badges/selectorStyles.ts
@@ -1,6 +1,18 @@
 import { StyleSheet } from "react-native-unistyles";
 
 export const selectorStyles = StyleSheet.create((theme) => ({
+  // Applied to the horizontal ScrollView itself (never its content container).
+  // Every selector rail lives inside a CollapsibleSection, whose content is
+  // inset by `space[4]`; with that inset on the *scroll viewport* the last
+  // reachable option is clipped against a hard gutter and the rail reads as
+  // truncated rather than scrollable. Cancelling the inset here makes the
+  // viewport span the card, while `row` below restores the same inset as
+  // content padding — so cells still start/end flush with the section title,
+  // but scroll all the way to the border. Keep this in sync with
+  // CollapsibleSection.styles `content.paddingHorizontal`.
+  rail: {
+    marginHorizontal: -theme.space[4],
+  },
   row: {
     gap: theme.space[3],
     paddingHorizontal: theme.space[4],

--- a/apps/native-rd/src/components/CelebrationSparkles/CelebrationSparkles.styles.ts
+++ b/apps/native-rd/src/components/CelebrationSparkles/CelebrationSparkles.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from "react-native-unistyles";
+
+export const styles = StyleSheet.create(() => ({
+  // Fills the parent celebration surface; individual glyphs are positioned
+  // absolutely within it (see the layouts in CelebrationSparkles.tsx).
+  layer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  sparkle: {
+    position: "absolute",
+  },
+}));

--- a/apps/native-rd/src/components/CelebrationSparkles/CelebrationSparkles.tsx
+++ b/apps/native-rd/src/components/CelebrationSparkles/CelebrationSparkles.tsx
@@ -1,0 +1,175 @@
+/**
+ * CelebrationSparkles — the static ✦/◆ decoration layer that sits behind a
+ * celebration surface.
+ *
+ * Extracted from BadgeDetailScreen's CelebrationHeroHeader (#468) so the
+ * finishing flow's full-bleed "Earned" reveal carries the same celebratory
+ * texture instead of a flat yellow field. Purely decorative: absolutely
+ * positioned, non-interactive, hidden from screen readers, and clipped by
+ * whichever surface it fills (the parent owns `overflow: "hidden"`).
+ *
+ * NOT the falling Confetti component — these are motionless glyphs at low
+ * opacity, which is why they are safe to render under reduced-motion settings.
+ * Callers still gate them on their own "should we celebrate visually" flag.
+ *
+ * Two layouts, because the surfaces differ in shape:
+ * - `band` — the six pixel-positioned glyphs transcribed from the Badge Detail
+ *   C prototype's header. Fixed offsets are correct there: the band's height
+ *   is driven by its content and barely varies.
+ * - `screen` — percentage-positioned for a full-height surface, so the scatter
+ *   stays even from an SE to a Max instead of bunching at the top. Kept clear
+ *   of the vertical centre band where the badge and title live.
+ */
+import React from "react";
+import { View, type DimensionValue } from "react-native";
+import { Diamond, Sparkle } from "phosphor-react-native";
+import { styles } from "./CelebrationSparkles.styles";
+
+type SparkleSpec = {
+  kind: "sparkle" | "diamond";
+  size: number;
+  opacity: number;
+  position: {
+    top?: DimensionValue;
+    bottom?: DimensionValue;
+    left?: DimensionValue;
+    right?: DimensionValue;
+  };
+};
+
+/**
+ * Badge Detail C Prototype: 6 ✦/◆ glyphs at the band edges, opacity 0.4–0.55.
+ * Positions are band-relative pixels.
+ */
+const BAND_SPARKLES: readonly SparkleSpec[] = [
+  { kind: "sparkle", size: 16, opacity: 0.5, position: { top: 46, left: 30 } },
+  {
+    kind: "diamond",
+    size: 13,
+    opacity: 0.55,
+    position: { top: 34, right: 48 },
+  },
+  { kind: "diamond", size: 13, opacity: 0.5, position: { top: 150, left: 26 } },
+  {
+    kind: "sparkle",
+    size: 16,
+    opacity: 0.5,
+    position: { top: 168, right: 30 },
+  },
+  { kind: "sparkle", size: 11, opacity: 0.4, position: { top: 120, left: 54 } },
+  {
+    kind: "diamond",
+    size: 10,
+    opacity: 0.45,
+    position: { top: 110, right: 60 },
+  },
+];
+
+/**
+ * Full-surface scatter: the same glyph vocabulary and opacity range as the
+ * band, spread top-to-bottom and biased toward the edges so the centred badge,
+ * title, and CTA stay on clean ground.
+ */
+const SCREEN_SPARKLES: readonly SparkleSpec[] = [
+  {
+    kind: "sparkle",
+    size: 18,
+    opacity: 0.5,
+    position: { top: "8%", left: "10%" },
+  },
+  {
+    kind: "diamond",
+    size: 14,
+    opacity: 0.55,
+    position: { top: "6%", right: "14%" },
+  },
+  {
+    kind: "diamond",
+    size: 11,
+    opacity: 0.4,
+    position: { top: "17%", left: "26%" },
+  },
+  {
+    kind: "sparkle",
+    size: 13,
+    opacity: 0.45,
+    position: { top: "22%", right: "8%" },
+  },
+  {
+    kind: "sparkle",
+    size: 11,
+    opacity: 0.4,
+    position: { top: "38%", left: "6%" },
+  },
+  {
+    kind: "diamond",
+    size: 12,
+    opacity: 0.45,
+    position: { top: "44%", right: "9%" },
+  },
+  {
+    kind: "diamond",
+    size: 15,
+    opacity: 0.5,
+    position: { top: "63%", left: "12%" },
+  },
+  {
+    kind: "sparkle",
+    size: 16,
+    opacity: 0.5,
+    position: { top: "68%", right: "13%" },
+  },
+  {
+    kind: "sparkle",
+    size: 12,
+    opacity: 0.4,
+    position: { bottom: "12%", left: "22%" },
+  },
+  {
+    kind: "diamond",
+    size: 10,
+    opacity: 0.45,
+    position: { bottom: "9%", right: "26%" },
+  },
+];
+
+const LAYOUTS = {
+  band: BAND_SPARKLES,
+  screen: SCREEN_SPARKLES,
+} as const;
+
+export interface CelebrationSparklesProps {
+  /** Glyph color — pass the surface's celebration ink (`chrome.celebrationFg`). */
+  color: string;
+  /** Scatter to use. `band` for a header strip, `screen` for a full-bleed surface. */
+  layout?: keyof typeof LAYOUTS;
+  testID?: string;
+}
+
+export function CelebrationSparkles({
+  color,
+  layout = "band",
+  testID = "celebration-sparkles",
+}: CelebrationSparklesProps) {
+  return (
+    <View
+      style={styles.layer}
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      testID={testID}
+    >
+      {LAYOUTS[layout].map((s, i) => {
+        const Glyph = s.kind === "sparkle" ? Sparkle : Diamond;
+        return (
+          <View
+            key={i}
+            style={[styles.sparkle, s.position, { opacity: s.opacity }]}
+          >
+            <Glyph size={s.size} weight="fill" color={color} />
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/CelebrationSparkles/__tests__/CelebrationSparkles.test.tsx
+++ b/apps/native-rd/src/components/CelebrationSparkles/__tests__/CelebrationSparkles.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+import { renderWithProviders, screen } from "../../../__tests__/test-utils";
+import { CelebrationSparkles } from "../CelebrationSparkles";
+
+/** The layer is a11y-hidden by design, so every query opts into hidden nodes. */
+const hidden = { includeHiddenElements: true } as const;
+
+describe("CelebrationSparkles", () => {
+  it("hides the whole layer from screen readers and from touch", () => {
+    renderWithProviders(<CelebrationSparkles color="#111111" />);
+    const layer = screen.getByTestId("celebration-sparkles", hidden);
+    expect(layer.props.accessibilityElementsHidden).toBe(true);
+    expect(layer.props.importantForAccessibility).toBe("no-hide-descendants");
+    expect(layer.props.pointerEvents).toBe("none");
+  });
+
+  // The band layout is the Badge Detail prototype's six fixed-pixel glyphs;
+  // the screen layout spreads more of them by percentage so a full-height
+  // surface doesn't bunch its decoration at the top.
+  it.each([
+    ["band", 6],
+    ["screen", 10],
+  ] as const)("renders the %s layout's glyph count", (layout, count) => {
+    renderWithProviders(
+      <CelebrationSparkles color="#111111" layout={layout} />,
+    );
+    const layer = screen.getByTestId("celebration-sparkles", hidden);
+    expect(layer.children).toHaveLength(count);
+  });
+
+  it("positions the screen layout in percentages so it scales with height", () => {
+    renderWithProviders(
+      <CelebrationSparkles color="#111111" layout="screen" />,
+    );
+    const layer = screen.getByTestId("celebration-sparkles", hidden);
+    const offsets = (layer.children as unknown[])
+      .flatMap((child) => {
+        const style = (child as { props?: { style?: unknown } }).props?.style;
+        return Array.isArray(style) ? style : [style];
+      })
+      .flatMap((entry) => {
+        const s = entry as Record<string, unknown>;
+        return [s?.top, s?.bottom, s?.left, s?.right];
+      })
+      .filter((v) => v !== undefined);
+    expect(offsets.length).toBeGreaterThan(0);
+    offsets.forEach((v) => expect(String(v)).toMatch(/%$/));
+  });
+
+  it("accepts a caller testID so two layers can coexist in one tree", () => {
+    renderWithProviders(
+      <CelebrationSparkles color="#111111" testID="finish-reveal-sparkles" />,
+    );
+    expect(
+      screen.getByTestId("finish-reveal-sparkles", hidden),
+    ).toBeOnTheScreen();
+  });
+});

--- a/apps/native-rd/src/components/CelebrationSparkles/index.ts
+++ b/apps/native-rd/src/components/CelebrationSparkles/index.ts
@@ -1,0 +1,4 @@
+export {
+  CelebrationSparkles,
+  type CelebrationSparklesProps,
+} from "./CelebrationSparkles";

--- a/apps/native-rd/src/components/EditGoalView/EditGoalStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalStepRow.tsx
@@ -26,6 +26,7 @@ import {
   type GestureResponderEvent,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { XCircle } from "phosphor-react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useUnistyles } from "react-native-unistyles";
 import Animated, {
@@ -111,6 +112,8 @@ export interface EditGoalStepRowProps {
   moveDownLabel?: (stepTitle: string) => string;
   /** a11y label for the × delete affordance. */
   deleteStepLabel?: (stepTitle: string) => string;
+  /** a11y label for the clear control that empties the rename field. */
+  clearStepTitleLabel?: string;
   /** a11y label for the “Nest under…” trigger (R8). */
   nestUnderTriggerA11yLabel?: string;
   /** Title of the nest-under picker modal. */
@@ -158,6 +161,7 @@ export function EditGoalStepRow({
   moveUpLabel = (stepTitle) => `Move "${stepTitle}" up`,
   moveDownLabel = (stepTitle) => `Move "${stepTitle}" down`,
   deleteStepLabel = (stepTitle) => `Delete step: ${stepTitle}`,
+  clearStepTitleLabel = "Clear step title",
   nestUnderTriggerA11yLabel = "Nest this step under another step",
   nestUnderPickerTitle = "Choose a step to nest under",
   nestUnderRowLabel = (targetTitle) => `Nest under "${targetTitle}"`,
@@ -250,6 +254,22 @@ export function EditGoalStepRow({
         testID={`edit-goal-step-edit-${step.id}`}
         accessibilityLabel={editStepA11yLabel(step.title)}
       />
+      {/* Clearing wipes the field only — it never commits. `onBlur` commits
+          this row, so the host ScrollViews use keyboardShouldPersistTaps
+          ="handled": without it the first tap is swallowed to dismiss the
+          keyboard, blurring the input and closing the editor instead. */}
+      {editText.length > 0 && (
+        <Pressable
+          style={styles.editClear}
+          onPress={() => onEditTextChange("")}
+          accessibilityRole="button"
+          accessibilityLabel={clearStepTitleLabel}
+          hitSlop={8}
+          testID={`edit-goal-step-clear-${step.id}`}
+        >
+          <XCircle size={20} weight="bold" color={theme.colors.textSecondary} />
+        </Pressable>
+      )}
     </View>
   ) : (
     <>

--- a/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalSubStepRow.tsx
@@ -12,6 +12,7 @@ import {
   type GestureResponderEvent,
 } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { XCircle } from "phosphor-react-native";
 import { useUnistyles } from "react-native-unistyles";
 import Animated, {
   type SharedValue,
@@ -73,6 +74,8 @@ export interface EditGoalSubStepRowProps {
   editEvidenceLabel?: string;
   /** a11y label for the × delete affordance. */
   deleteSubStepLabel?: (subStepTitle: string) => string;
+  /** a11y label for the clear control that empties the rename field. */
+  clearSubStepTitleLabel?: string;
   /** a11y label for the ↑ reorder-up fallback button. */
   moveSubStepUpLabel?: (subStepTitle: string) => string;
   /** a11y label for the ↓ reorder-down fallback button. */
@@ -110,6 +113,7 @@ export function EditGoalSubStepRow({
   tapToEditHint = "Tap to edit sub-step title",
   editEvidenceLabel = "Edit planned evidence",
   deleteSubStepLabel = (subStepTitle) => `Delete sub-step: ${subStepTitle}`,
+  clearSubStepTitleLabel = "Clear sub-step title",
   moveSubStepUpLabel = (subStepTitle) => `Move "${subStepTitle}" up`,
   moveSubStepDownLabel = (subStepTitle) => `Move "${subStepTitle}" down`,
   unNestA11yLabel = "Promote this step to top level",
@@ -201,6 +205,24 @@ export function EditGoalSubStepRow({
           testID={`edit-goal-substep-edit-${subStep.id}`}
           accessibilityLabel={editSubStepA11yLabel(subStep.title)}
         />
+        {/* Mirrors EditGoalStepRow's clear control — wipes the field without
+            committing or deleting the sub-step. */}
+        {editText.length > 0 && (
+          <Pressable
+            style={styles.editClear}
+            onPress={() => onEditTextChange("")}
+            accessibilityRole="button"
+            accessibilityLabel={clearSubStepTitleLabel}
+            hitSlop={8}
+            testID={`edit-goal-substep-clear-${subStep.id}`}
+          >
+            <XCircle
+              size={20}
+              weight="bold"
+              color={theme.colors.textSecondary}
+            />
+          </Pressable>
+        )}
       </View>
     );
   }

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.styles.ts
@@ -169,6 +169,16 @@ export const styles = StyleSheet.create((theme) => ({
     color: theme.colors.text,
     padding: 0,
   },
+  // Clear-all-text control on an inline rename row (steps and sub-steps).
+  // Carries a Phosphor XCircle rather than the row's bare × delete glyph, so
+  // "empty the field" never reads as "delete the step". Full 44pt target per
+  // the a11y baseline; only mounted while the field has text.
+  editClear: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+  },
   evidenceChip: {
     minHeight: 32,
     justifyContent: "center" as const,

--- a/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
+++ b/apps/native-rd/src/components/EditGoalView/EditGoalView.tsx
@@ -435,6 +435,11 @@ export function EditGoalView({
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          // Rename rows commit on blur, and the default ("never") swallows the
+          // first tap to dismiss the keyboard — which blurs the field and
+          // closes the editor. "handled" delivers taps to the row's own
+          // controls (the clear button, evidence chip) while an edit is in flight.
+          keyboardShouldPersistTaps="handled"
         >
           {/* Optional description (D3) — rendered only when the prop is supplied;
             no "add a description" affordance when absent. */}

--- a/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
@@ -650,6 +650,62 @@ describe("EditGoalView", () => {
     });
   });
 
+  // Clearing the field is distinct from deleting the row: it only empties
+  // the rename input, so a long title can be replaced without backspacing.
+  describe("clear title while renaming", () => {
+    it("empties the step field without committing or deleting", () => {
+      const onStepTitleChange = jest.fn();
+      const onDeleteStep = jest.fn();
+      renderWithProviders(
+        <EditGoalView {...makeProps({ onStepTitleChange, onDeleteStep })} />,
+      );
+      fireEvent.press(screen.getByTestId("edit-goal-step-title-s1"));
+      fireEvent.press(screen.getByTestId("edit-goal-step-clear-s1"));
+      expect(screen.getByTestId("edit-goal-step-edit-s1").props.value).toBe("");
+      expect(onStepTitleChange).not.toHaveBeenCalled();
+      expect(onDeleteStep).not.toHaveBeenCalled();
+    });
+
+    it("hides the clear control once the step field is empty", () => {
+      renderWithProviders(<EditGoalView {...makeProps()} />);
+      fireEvent.press(screen.getByTestId("edit-goal-step-title-s1"));
+      fireEvent.press(screen.getByTestId("edit-goal-step-clear-s1"));
+      expect(screen.queryByTestId("edit-goal-step-clear-s1")).toBeNull();
+    });
+
+    it("does not render the clear control outside inline-edit mode", () => {
+      renderWithProviders(<EditGoalView {...makeProps()} />);
+      expect(screen.queryByTestId("edit-goal-step-clear-s1")).toBeNull();
+    });
+
+    it("empties the sub-step field without committing", () => {
+      const onSubStepTitleChange = jest.fn();
+      renderWithProviders(
+        <EditGoalView
+          {...makeProps({ steps: withSub, onSubStepTitleChange })}
+        />,
+      );
+      fireEvent.press(screen.getByTestId("edit-goal-substep-title-sub1"));
+      fireEvent.press(screen.getByTestId("edit-goal-substep-clear-sub1"));
+      expect(
+        screen.getByTestId("edit-goal-substep-edit-sub1").props.value,
+      ).toBe("");
+      expect(onSubStepTitleChange).not.toHaveBeenCalled();
+    });
+
+    it("exposes both clears as labelled buttons", () => {
+      renderWithProviders(<EditGoalView {...makeProps({ steps: withSub })} />);
+      fireEvent.press(screen.getByTestId("edit-goal-step-title-s1"));
+      const stepClear = screen.getByTestId("edit-goal-step-clear-s1");
+      expect(stepClear.props.accessibilityRole).toBe("button");
+      expect(stepClear.props.accessibilityLabel).toBe("Clear step title");
+
+      fireEvent.press(screen.getByTestId("edit-goal-substep-title-sub1"));
+      const subClear = screen.getByTestId("edit-goal-substep-clear-sub1");
+      expect(subClear.props.accessibilityLabel).toBe("Clear sub-step title");
+    });
+  });
+
   describe("sub-step reorder (#459)", () => {
     it("renders the ≡ handle (not ↳) on sub-step rows, hidden from screen readers", () => {
       renderWithProviders(<EditGoalView {...makeProps({ steps: withSub })} />);

--- a/apps/native-rd/src/components/FinishRevealStage/FinishRevealStage.styles.ts
+++ b/apps/native-rd/src/components/FinishRevealStage/FinishRevealStage.styles.ts
@@ -7,6 +7,9 @@ export const styles = StyleSheet.create((theme) => ({
     // Full-bleed celebration band — reuses the existing #419 celebration tokens
     // that already back Badge Detail's hero header (D5).
     backgroundColor: theme.chrome.celebrationBg,
+    // Clips the decorative sparkle layer at the surface edge, as the hero band
+    // does — a glyph near a percentage edge would otherwise overhang.
+    overflow: "hidden",
   },
   center: {
     flex: 1,

--- a/apps/native-rd/src/components/FinishRevealStage/FinishRevealStage.tsx
+++ b/apps/native-rd/src/components/FinishRevealStage/FinishRevealStage.tsx
@@ -5,6 +5,7 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from "react-native-reanimated";
+import { useUnistyles } from "react-native-unistyles";
 
 import { BadgeRenderer } from "../../badges/BadgeRenderer";
 import { type BadgeDesign } from "../../badges/types";
@@ -12,6 +13,7 @@ import type { AnimationPref } from "../../hooks/useAnimationPref";
 import { getSpringConfig } from "../../utils/animation";
 import { Text } from "../Text";
 import { Button } from "../Button";
+import { CelebrationSparkles } from "../CelebrationSparkles";
 import { styles } from "./FinishRevealStage.styles";
 
 const DEFAULT_BADGE_SIZE = 200;
@@ -42,7 +44,8 @@ export interface FinishRevealStageProps {
 
 /**
  * Reveal stage of the finishing flow — the earned-badge moment. A full-bleed
- * celebration band (D5 tokens) frames an "Earned" eyebrow, the large badge with
+ * celebration band (D5 tokens), textured with the same static sparkle layer as
+ * Badge Detail's hero, frames an "Earned" eyebrow, the large badge with
  * a one-shot pop-in scale animation (gated by `animationPref`, D6), the goal
  * title, an earned-date label, a primary "View badge" CTA, and a quiet
  * underlined "Back to goals" link (D7, not a boxed Button variant).
@@ -61,6 +64,7 @@ export function FinishRevealStage({
   animationPref,
   badgeSize = DEFAULT_BADGE_SIZE,
 }: FinishRevealStageProps) {
+  const { theme } = useUnistyles();
   const shouldAnimate = animationPref !== "none";
   // Start at resting scale when motion is off so there is no undersized frame;
   // otherwise start small and spring to full size once mounted.
@@ -80,6 +84,19 @@ export function FinishRevealStage({
 
   return (
     <View style={styles.band} testID="finish-reveal-stage">
+      {/* Painted first so it sits behind the badge/title/CTA, clipped by the
+          band. Same decoration as Badge Detail's hero, scattered for a
+          full-height surface — it gives the flat yellow field texture without
+          competing with the badge. Suppressed with motion off, matching how
+          the hero gates it. */}
+      {shouldAnimate ? (
+        <CelebrationSparkles
+          color={theme.chrome.celebrationFg}
+          layout="screen"
+          testID="finish-reveal-sparkles"
+        />
+      ) : null}
+
       <View style={styles.center}>
         <Text variant="mono" style={styles.eyebrow}>
           {eyebrow}

--- a/apps/native-rd/src/components/FinishRevealStage/__tests__/FinishRevealStage.test.tsx
+++ b/apps/native-rd/src/components/FinishRevealStage/__tests__/FinishRevealStage.test.tsx
@@ -86,4 +86,29 @@ describe("FinishRevealStage", () => {
       expect(scaleFromStyle(badge.props.style)).toBe(expectedScale);
     },
   );
+
+  // The same decoration Badge Detail's hero carries, so the reveal surface
+  // isn't a flat yellow field. Static, but suppressed with motion off — the
+  // hero gates it the same way.
+  it.each([
+    ["full", true],
+    ["reduced", true],
+    ["none", false],
+  ] as const)(
+    "renders the sparkle layer for animationPref=%s: %s",
+    (animationPref, present) => {
+      renderWithProviders(
+        <FinishRevealStage {...makeProps({ animationPref })} />,
+      );
+      // Decorative layer is a11y-hidden, so opt into hidden elements.
+      const sparkles = screen.queryByTestId("finish-reveal-sparkles", {
+        includeHiddenElements: true,
+      });
+      if (present) {
+        expect(sparkles).toBeOnTheScreen();
+      } else {
+        expect(sparkles).toBeNull();
+      }
+    },
+  );
 });

--- a/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.tsx
+++ b/apps/native-rd/src/components/NewGoalWizard/NewGoalWizard.tsx
@@ -620,6 +620,10 @@ export function NewGoalWizard({
               <ScrollView
                 contentContainerStyle={styles.buildScrollContent}
                 showsVerticalScrollIndicator={false}
+                // See EditGoalView's scroll: inline rename commits on blur, so
+                // taps must reach the row controls (clear button) instead of being
+                // consumed by the keyboard dismissal.
+                keyboardShouldPersistTaps="handled"
               >
                 {/* The build step reuses EditGoalStepList (#489/#490) — same "Your
                   steps" header + count, drag-reorderable rows, evidence chips,

--- a/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
@@ -10,6 +10,7 @@ import {
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useUnistyles } from "react-native-unistyles";
 import { useQuery } from "@evolu/react";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "phosphor-react-native";
@@ -19,6 +20,7 @@ import { Card } from "../../components/Card";
 import { ErrorBoundary } from "../../components/ErrorBoundary";
 import { IconButton } from "../../components/IconButton";
 import { HeaderBand } from "../../components/ScreenHeader";
+import { useTopInsetColor } from "../../navigation/TopInsetColor";
 import { ConfirmDeleteModal } from "../../components/ConfirmDeleteModal";
 import { badgeWithGoalQuery, deleteBadge } from "../../db";
 import type { BadgeId } from "../../db";
@@ -182,6 +184,13 @@ function BadgeDetailContent({ badgeId }: { badgeId: string }) {
   const [showOverflowMenu, setShowOverflowMenu] = useState(false);
   const { shouldAnimate } = useAnimationPref();
   const insets = useSafeAreaInsets();
+  const { theme } = useUnistyles();
+  // The celebration band is the first thing under the status bar, so the
+  // device top-inset strip App.tsx paints has to be the band's surface — not
+  // the purple header chrome, which belongs to screens that actually have a
+  // ScreenHeader. Null while the badge is missing: that path renders
+  // DetailFallbackHeader, which *is* a header band.
+  useTopInsetColor(badge ? theme.chrome.celebrationBg : null);
   const {
     exportVerifiableBadge,
     exportImage,

--- a/apps/native-rd/src/screens/BadgeDetailScreen/CelebrationHeroHeader.styles.ts
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/CelebrationHeroHeader.styles.ts
@@ -20,18 +20,6 @@ export const styles = StyleSheet.create((theme) => ({
     borderBottomColor: theme.chrome.celebrationFg,
     borderBottomWidth: theme.borderWidth.medium,
   },
-  // Decorative sparkle layer fills the band; individual glyphs are positioned
-  // absolutely within it (see SPARKLES in the component). Non-interactive.
-  sparkleLayer: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
-  sparkle: {
-    position: "absolute",
-  },
   // Back arrow (left) and ⋯ overflow (right) on the same row as the band's
   // chrome. `alignSelf: "stretch"` lets space-between push them to the edges
   // even though the band centers the badge/chip below.

--- a/apps/native-rd/src/screens/BadgeDetailScreen/CelebrationHeroHeader.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/CelebrationHeroHeader.tsx
@@ -13,19 +13,16 @@
  * sparkle layer sits behind the content, scattered and clipped to the band —
  * this is the prototype's `showConfetti` decoration (small ✦/◆ glyphs at low
  * opacity), NOT the full-screen falling Confetti component used on completion.
+ * That layer now lives in the shared CelebrationSparkles component, which the
+ * finishing flow's reveal stage renders with its full-surface layout.
  */
 import React from "react";
 import { View } from "react-native";
-import {
-  ArrowLeft,
-  Check,
-  Diamond,
-  DotsThree,
-  Sparkle,
-} from "phosphor-react-native";
+import { ArrowLeft, Check, DotsThree } from "phosphor-react-native";
 import { useUnistyles } from "react-native-unistyles";
 import { Text } from "../../components/Text";
 import { IconButton } from "../../components/IconButton";
+import { CelebrationSparkles } from "../../components/CelebrationSparkles";
 import { BadgeRenderer } from "../../badges/BadgeRenderer";
 import { createDefaultBadgeDesign, type BadgeDesign } from "../../badges/types";
 import { palette } from "../../themes/adapter";
@@ -33,64 +30,6 @@ import { styles } from "./CelebrationHeroHeader.styles";
 
 /** Logical-pixel size of the hero badge. Matches the HTML prototype (D2). */
 const BADGE_SIZE = 146;
-
-/**
- * Scattered decorative sparkles, transcribed from the prototype's celebration
- * header (Badge Detail C Prototype: 6 ✦/◆ glyphs at the band edges, opacity
- * 0.4–0.55). Positions are band-relative pixels; the band's overflow:hidden
- * clips any that fall outside.
- */
-const SPARKLES = [
-  { kind: "sparkle", size: 16, opacity: 0.5, position: { top: 46, left: 30 } },
-  {
-    kind: "diamond",
-    size: 13,
-    opacity: 0.55,
-    position: { top: 34, right: 48 },
-  },
-  { kind: "diamond", size: 13, opacity: 0.5, position: { top: 150, left: 26 } },
-  {
-    kind: "sparkle",
-    size: 16,
-    opacity: 0.5,
-    position: { top: 168, right: 30 },
-  },
-  { kind: "sparkle", size: 11, opacity: 0.4, position: { top: 120, left: 54 } },
-  {
-    kind: "diamond",
-    size: 10,
-    opacity: 0.45,
-    position: { top: 110, right: 60 },
-  },
-] as const;
-
-/**
- * Static decorative sparkle layer. Painted behind the badge/chip, non-
- * interactive, and hidden from screen readers — purely celebratory chrome.
- */
-function Sparkles({ color }: { color: string }) {
-  return (
-    <View
-      style={styles.sparkleLayer}
-      pointerEvents="none"
-      accessibilityElementsHidden
-      importantForAccessibility="no-hide-descendants"
-      testID="celebration-sparkles"
-    >
-      {SPARKLES.map((s, i) => {
-        const Glyph = s.kind === "sparkle" ? Sparkle : Diamond;
-        return (
-          <View
-            key={i}
-            style={[styles.sparkle, s.position, { opacity: s.opacity }]}
-          >
-            <Glyph size={s.size} weight="fill" color={color} />
-          </View>
-        );
-      })}
-    </View>
-  );
-}
 
 export interface CelebrationHeroHeaderProps {
   /** Stored badge design, or null to fall back to the monogram default (D4). */
@@ -158,7 +97,9 @@ export function CelebrationHeroHeader({
   return (
     <View style={styles.band}>
       {/* Behind the content (painted first), clipped by the band. */}
-      {showConfetti ? <Sparkles color={theme.chrome.celebrationFg} /> : null}
+      {showConfetti ? (
+        <CelebrationSparkles color={theme.chrome.celebrationFg} layout="band" />
+      ) : null}
 
       {/* a11y labels default to English so the component stays i18n-free and
           Storybook-renderable in isolation. Callers pass localised strings via

--- a/apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx
@@ -8,6 +8,8 @@ import {
 import { BadgeDetailScreen } from "../BadgeDetailScreen";
 import type { BadgeDetailScreenProps } from "../../../navigation/types";
 import { createDefaultBadgeDesign } from "../../../badges/types";
+import { TopInsetColorProvider } from "../../../navigation/TopInsetColor";
+import { mockTheme } from "../../../__tests__/mocks/unistyles";
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -820,6 +822,43 @@ describe("BadgeDetailScreen", () => {
         fireEvent.press(screen.getByLabelText("View timeline")),
       ).not.toThrow();
       expect(mockParentNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  // The celebration band runs to the top of the screen, so App.tsx's top-inset
+  // strip has to be the band's surface — not the purple header chrome, which
+  // belongs to screens that render a ScreenHeader.
+  describe("top-inset strip", () => {
+    const renderWithStrip = () => {
+      const onChange = jest.fn();
+      const view = renderWithProviders(
+        <TopInsetColorProvider onChange={onChange}>
+          <BadgeDetailScreen route={mockRoute} navigation={{} as never} />
+        </TopInsetColorProvider>,
+      );
+      return { onChange, view };
+    };
+
+    it("extends the celebration surface into the strip", () => {
+      mockUseQuery.mockReturnValue([makeRow()]);
+      expect(renderWithStrip().onChange).toHaveBeenCalledWith(
+        mockTheme.chrome.celebrationBg,
+      );
+    });
+
+    it("leaves the strip at the header color when the badge is missing", () => {
+      // The not-found path renders DetailFallbackHeader — a real header band,
+      // which the default strip color already continues.
+      mockUseQuery.mockReturnValue([]);
+      expect(renderWithStrip().onChange).not.toHaveBeenCalled();
+    });
+
+    it("releases the strip on unmount", () => {
+      mockUseQuery.mockReturnValue([makeRow()]);
+      const { onChange, view } = renderWithStrip();
+      onChange.mockClear();
+      view.unmount();
+      expect(onChange).toHaveBeenCalledWith(null);
     });
   });
 });


### PR DESCRIPTION
Four items from a design review pass on the simulator.

## 1. Badge detail hero stopped at the safe area
The celebration band is the first thing under the status bar, but `App.tsx` paints the device top-inset strip with `chrome.screenHeaderBg` — leaving a purple stripe above the yellow hero. The screen now claims the strip via `useTopInsetColor` (the same opt-out the full-bleed badge wall uses). Status-bar glyph polarity follows automatically; the not-found path keeps the default because it renders a real header band.

## 2. No way to clear a step/sub-step title while renaming
Renaming meant backspacing the old title character by character. Inline-edit rows (steps and sub-steps) now carry a Phosphor `XCircle` that empties the field without committing or deleting the row — mounted only while there is text, and visually distinct from the row's delete ×.

Host `ScrollView`s (`EditGoalView`, the wizard's build step) needed `keyboardShouldPersistTaps="handled"`: rename rows commit on blur, and the default swallows the first tap to dismiss the keyboard — which would blur the field and close the editor instead of clearing it.

## 3. Badge designer option rails clipped against the section inset
Every horizontal rail sits inside a `CollapsibleSection` whose content is inset by `space[4]`. With that inset on the scroll *viewport*, the last option is clipped against a hard gutter and the rail reads as truncated rather than scrollable. The inset now moves off the viewport — a matching negative margin on the ScrollView, re-applied as content padding — so cells still line up with the section title but scroll to the card border. Covers shape / frame / color / center-mode plus the per-channel swatch rail.

## 4. Earned-badge reveal was a flat yellow field
The sparkle texture from Badge Detail's hero is now shared: extracted out of `CelebrationHeroHeader` into a `CelebrationSparkles` component with two layouts. `band` keeps the six fixed-pixel positions from the prototype (right for a header strip); `screen` scatters ten glyphs by percentage so a full-height surface stays even across device sizes, edge-biased to leave the badge, title, and CTA on clean ground. Still decoration, not the falling Confetti — motionless, a11y-hidden, and gated on the animation preference exactly as the hero gates it.

## Verification
- `bun run type-check`, `bun run lint` clean
- `bun run test` — 213 suites / 10087 tests green, including new coverage: top-inset claim + release, clear-control behavior and labels, a styles test asserting the rail bleed and content padding stay balanced, and both sparkle layouts plus the reveal's gating
- Not yet run on a simulator build — visual confirmation of the four fixes still pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WwYphrbuHPu5nkCegjtyY