### PR TITLE
feat(native-rd): StepDayGrid + StepTimingEditor — in-row B/C authoring (#574, #573)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-574-573-step-timing-editor.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-574-573-step-timing-editor.md
@@ -409,7 +409,7 @@ sub-line's quoted `“late.”`), `deadline` (outside the sub-line's `not a dead
       `accessibilityState={{ selected: isSelected }}`, `minHeight: 44`,
       `fontVariant: ["tabular-nums"]`. **Never** `disabled`.
 - [ ] `accessibilityLabel` = full date via `Intl.DateTimeFormat(locale, { weekday:
-  "long", day: "numeric", month: "long", year: "numeric" })`, plus
+"long", day: "numeric", month: "long", year: "numeric" })`, plus
       `marksA11ySuffix(count)` when marks exist.
 - [ ] `onPress` → `onChange(key === value ? null : key)`.
 - [ ] Marks: first two labels as badges, third+ collapses to one overflow badge (`+`).
@@ -482,7 +482,7 @@ sub-line's quoted `“late.”`), `deadline` (outside the sub-line's `not a dead
       `minHeight: 44`, `accessibilityRole="button"`.
 - [ ] Empty `candidates` → `noCandidatesLabel` instead of an empty box.
 - [ ] `OrderingNote` part: renders **only** when `draft.dueDate && draft.afterStepId &&
-  target.dueDate && draft.dueDate < target.dueDate`. Plain `Text`, body weight,
+target.dueDate && draft.dueDate < target.dueDate`. Plain `Text`, body weight,
       `colors.textSecondary`, a quiet left rule. **No** icon, **no** `error`/`danger`
       token, **no** `accessibilityRole="alert"`, **no** `disabled` anywhere.
 - [ ] Footer: `Clear` (quiet, fixed width) + `Done` (primary, `flex: 1`), both
@@ -588,6 +588,22 @@ sub-line's quoted `“late.”`), `deadline` (outside the sub-line's `not a dead
 | i18n resource keys                                                | D7 — copy is caller-supplied with English defaults                  | #576                                                                        |
 | Expand/collapse animation                                         | D9 — needs `animationPref` threaded as a prop                       | Follow-up issue; note in the component doc comment                          |
 | Rebasing onto PR #582 (`AnimatedSheet` lift)                      | No sheet in this design                                             | none                                                                        |
+
+## Follow-ups from review
+
+Raised by the reuse / simplification / efficiency / altitude review pass on this
+branch, deliberately **not** fixed here. Recorded so they are not chat-only.
+
+| #   | Finding                                                                                                                                                                                                                                                                                                                              | Why deferred                                                                                                                                                                                               |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F-1 | **One shared `MetadataBand`** across `TimelineStep`, `FocusCurrentTaskCard` and this editor. There are now three renderings of `↩ after …` / `▦ due …` and four copy sources (two i18n namespaces with duplicate keys, plus this component's defaults). Sharing it would make parity structural and retire `readOutParity.test.tsx`. | Pre-existing debt this PR extends rather than creates. Touching Focus and Timeline is out of scope for a Storybook-only PR, and `readOutParity` + the new resource-pinning tests hold the line until then. |
+| F-2 | **Move the forbidden-copy check to `src/__tests__/structure/`**, covering every component and screen rather than these two directories plus three namespaces.                                                                                                                                                                        | The repo already has that shape of test there. Widening it will surface hits in surfaces this PR does not own.                                                                                             |
+| F-3 | **`useParkRowAtTop(scrollRef, contentRef)` hook** so #575 inherits the `measureLayout` → `scrollTo` wiring instead of retyping it from `InsideAScrollingList`.                                                                                                                                                                       | The story proves the contract today; the hook is worth extracting when #575 actually consumes it.                                                                                                          |
+| F-4 | **Move `monthGrid.ts` → `src/utils/localDay.ts`.** `toDayKey` / `dayKey` are exactly what #576 needs for the `YYYY-MM-DD` → local-midnight `DateIso` conversion, and a screen should not import date maths from a component directory.                                                                                               | A file move belongs with the issue that consumes it (#576).                                                                                                                                                |
+| F-5 | **One shared 44pt touch-target constant.** ~25 style files hardcode a bare `minHeight: 44`; this PR added two names for it (now file-local, unexported).                                                                                                                                                                             | Repo-wide sweep, not this PR.                                                                                                                                                                              |
+| F-6 | **Shared Storybook theme-matrix scaffolding.** `MOOD_NAMES` is copy-pasted in 13 story files, `AllThemesMatrix` in 17, `PhoneWidth` in 5 — this PR follows the house style and adds two more. A shared helper would delete several hundred lines repo-wide.                                                                          | Established convention; diverging in two files would be inconsistent, not cleaner.                                                                                                                         |
+| F-7 | **`local/no-shared-component-reimplementation` only fires under `/screens/`** (`src/eslint-rules/no-shared-component-reimplementation.js:24`), which is why it stayed silent while this PR hand-rolled a footer and month-nav buttons. Widening it to `src/components/` would have caught both.                                      | A lint-rule change needs its own PR and a pass over the hits it surfaces.                                                                                                                                  |
+| F-8 | **Expand/collapse animation** (D9) — needs `animationPref` threaded as a prop, since `useAnimationPref` reads Evolu.                                                                                                                                                                                                                 | Un-animated is the accessible default; the prototype gates its unfold behind `prefers-reduced-motion` anyway.                                                                                              |
 
 ## Open Questions
 

--- a/apps/native-rd/docs/plans/dev-plans/issue-574-573-step-timing-editor.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-574-573-step-timing-editor.md
@@ -1,0 +1,660 @@
+# Development Plan: Issues #574 + #573 (combined)
+
+**Branch**: `feat/issue-574-573-step-timing-editor`
+**One PR, both issues.** #573 embeds #574's `StepDayGrid`; the user has decided
+to ship them together. Do not propose splitting.
+
+## Issue Summary
+
+|                     |                                                                  |
+| ------------------- | ---------------------------------------------------------------- |
+| **#574**            | `[Storybook] StepDayGrid — themed month grid, any day reachable` |
+| **#573**            | `[Storybook] StepTimingEditor — in-row date + \`depends on\``    |
+| **Type**            | feature (Storybook-only; no screen wiring — that is #576)        |
+| **Milestone**       | native-rd: Set B & C authoring (#6), Epic #570                   |
+| **Complexity**      | **LARGE** (~700–850 lines incl. stories + tests)                 |
+| **Estimated Lines** | #574 ~250–350 · #573 ~400–500 · combined ~700–850                |
+| **Commits**         | 7                                                                |
+
+Both issues were **rescoped 2026-08-13**. The rescoped bodies are the authoritative
+spec. The design of record is
+`apps/native-rd/prototypes/screen-redesign/Set BC D Prototype.html`
+(801 lines, added in commit `3e76787`, PR #583) — **not** `Set BC B Prototype.dc.html`,
+whose `DUE` / `EXP` / `WHO` arrays are demo fixtures.
+
+> **Scope reality check.** ~750 lines is over the ~500-line single-PR guideline. It is
+> accepted here because (a) the two components are one interaction that cannot be
+> reviewed apart, (b) roughly half the volume is stories and tests, and (c) the
+> component boundary between them is clean, so the diff reads as two files plus a
+> shared barrel. The commit sequence below keeps each commit independently
+> type-checking so a reviewer can walk it.
+
+## Intent Verification
+
+Observable criteria a reviewer can check by running Storybook or reading the tests.
+
+**#574 — `StepDayGrid`**
+
+- [ ] From the `Unset` story, tapping `‹` twelve times reaches the same month one year
+      earlier, and tapping a day there fires `onChange` with that day's `YYYY-MM-DD` —
+      i.e. no month is unreachable and no day is off-limits.
+- [ ] A day strictly before `now` renders in the quiet treatment **and still fires
+      `onChange`** when tapped; nothing on the grid is ever `disabled` or
+      `accessibilityState={{ disabled: true }}` (grep the component for `disabled` →
+      zero hits).
+- [ ] Tapping the currently selected day fires `onChange(null)`.
+- [ ] A month whose 1st falls on a Sunday renders exactly 6 leading blanks
+      (Monday-first); a month whose 1st is a Monday renders 0.
+- [ ] A day carrying three `marks` renders two ordinal badges plus one overflow badge,
+      and its `accessibilityLabel` names that other steps sit there.
+- [ ] Passing `locale="de"` renders German month and weekday names (via `Intl`, not a
+      hand-written month array).
+- [ ] `now` is a required prop; the component body contains no `new Date()` /
+      `Date.now()` reading the wall clock (same discipline as
+      `resolveStepDependencyBand`).
+
+**#573 — `StepTimingEditor`**
+
+- [ ] A step with `afterStepTitle: "Inspection & labels"` and `dueAt` set renders **two**
+      timing lines whose text is byte-identical to what `TimelineStep`'s `MetadataBand`
+      renders for the same data (asserted directly in a test, not by eye).
+- [ ] An unset, non-completed step renders exactly **one** affordance reading `＋ when?`
+      — not two chips.
+- [ ] A **completed** unset step renders **no** `＋ when?` at all; a completed step that
+      already has timing still shows its lines.
+- [ ] Tapping the timing line expands the editor and flips its
+      `accessibilityState.expanded` to `true`; the editor's first control receives
+      accessibility focus; collapsing returns focus to the timing line.
+- [ ] Picking a day, then collapsing **without** `Done`, leaves `onCommit` uncalled — the
+      draft is discarded.
+- [ ] `Done` fires `onCommit({ dueDate, afterStepId })` exactly once with the draft
+      values; `Clear` fires `onClear()` and collapses.
+- [ ] With a draft day strictly before the dependency's own day, the ordering note
+      renders as plain body text — and the rendered subtree contains no
+      `accessibilityRole="alert"`, no icon glyph, no `disabled` prop, and no theme
+      `error`/`danger` colour token.
+- [ ] The candidate list excludes the editing step itself, includes sub-steps, marks the
+      current selection, marks completed candidates as completed, and offers `nothing`.
+- [ ] A step whose goal has no other steps shows the empty-state copy instead of an empty
+      scroll box.
+- [ ] The strings `blocked`, `overdue`, `late`, `deadline`, `missing`, `needed` appear
+      nowhere in either component's source or its i18n-free copy defaults (grep test).
+
+## Dependencies
+
+| Issue / PR | Title                                           | Status                | Type                                                                                                                                                                                                      |
+| ---------- | ----------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #574       | `StepDayGrid`                                   | 🟢 In this PR         | Blocker for #573 — satisfied by shipping together                                                                                                                                                         |
+| #454       | Schema: step dependency + due-date fields       | ✅ Merged             | Prior art — `afterStepId` / `dueAt` columns, `resolveStepDependencyBand`                                                                                                                                  |
+| #571       | Neutral past-tense expected date                | ✅ Merged (`742f6bb`) | Prior art — `waitingOnExpectedIsPast`, strict `<`, injected `now`                                                                                                                                         |
+| #583       | Direction D prototype                           | ✅ Merged (`3e76787`) | Design of record                                                                                                                                                                                          |
+| PR #582    | `refactor/animated-sheet-lift`                  | 🟡 Open               | **Not a dependency.** No sheet in this design — confirmed: neither component imports `AnimatedSheet`, `Modal`, or any scrim. #582 lands on its own merits. **Do not rebase onto it, do not wait for it.** |
+| #575       | Edit Goal step rows — one pressable timing line | 🟡 Open               | Runs alongside; owns the _row_, this issue owns the _timing line + editor_                                                                                                                                |
+| #576       | Wire to `updateStep`                            | 🟡 Open               | Downstream — owns `YYYY-MM-DD` → local-midnight `DateIso` conversion                                                                                                                                      |
+
+**Status**: ✅ All dependencies met. `has_blockers: false` — #573's only blocker (#574)
+ships in the same PR.
+
+## Objective
+
+Ship two presentational Storybook components that together replace the retired
+`StepDueDateSheet` / `StepDependencySheet` pair:
+
+1. `StepDayGrid` — a themed, unbounded, Monday-first month grid where **every** day is
+   reachable and other steps' days are marked on it.
+2. `StepTimingEditor` — the in-row timing line plus the editor it expands into: the
+   grid, a `Depends on` picker, the neutral ordering note, and a `Clear` / `Done`
+   footer.
+
+No screen wiring, no DB writes, no i18n resource keys (copy is caller-supplied with
+English defaults — the D7 / D9 convention). No `AnimatedSheet`, no `Modal`, no scrim.
+
+## The prototype, transcribed
+
+Read from `Set BC D Prototype.html`. Pinned instant: **Wed 24 June 2026**
+(`TODAY_ISO = "2026-06-24"`). Use the same instant in stories and tests so a reviewer
+can hold the prototype and Storybook side by side.
+
+**Grid** (`calendarHtml`, `.day` / `.mark` CSS):
+
+| Prototype                                            | RN translation                                                                          |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `lead = (first.getDay() + 6) % 7`                    | Monday-first leading blanks — port verbatim                                             |
+| `.day` 40px tall, 7-col grid, `gap: 2px`             | `minHeight: 44` (a11y floor beats the prototype's 40)                                   |
+| `.day.is-today { border-color: ink }`                | today ring: `borderWidth.thick` + `colors.border`                                       |
+| `.day.is-past { color: faint }`                      | `colors.textMuted` — quieter, **never disabled**                                        |
+| `.day.is-sel` blue fill + ink border + hard shadow   | `colors.primary` bg, `colors.border` border, `shadowStyle(theme, "cardElevationSmall")` |
+| `.mark` 13px pill, mint bg, ink border, ≤2 then `+`  | ordinal badges under the number; 3rd+ collapses to one overflow badge                   |
+| `.day.is-sel .mark { background: #fff }`             | badge gets its own ground on the filled day                                             |
+| `font-variant-numeric: tabular-nums`                 | `fontVariant: ["tabular-nums"]` on the day number                                       |
+| `.legend` "badges mark days your other steps sit on" | caller-supplied `legendLabel`, same default                                             |
+
+**Editor** (`editorHtml`, `afterHtml`, `noteHtml`):
+
+- Question `When do you want this done?` — headline font, `size.sm`-ish.
+- Sub-line `Your intent, not a deadline. A passed date never reads as "late."`
+- `Depends on` field label (mono, uppercase, letter-spaced, `journey`/green ink).
+- Collapsed picker button shows the current candidate's ordinal badge + title, or the
+  `nothing` placeholder, with a caret.
+- Expanded: a `nothing` option first, then every step and sub-step except this one;
+  sub-steps indented (`.after-opt.is-child { margin-left: 14px }`); completed candidates
+  render `✓` in the ordinal slot; the selection carries a `●` tick.
+- Note (`noteHtml`) renders **only** when `draft.due && draft.after && target.due &&
+draft.due < target.due` — a left-rule quiet panel, body weight, no icon.
+- Footer: `.btn-clear` (fixed width, quiet) + `.btn-done` (flex 1, primary).
+
+**Row behaviour** (`rowHtml`, `parkOpenRow`):
+
+- `showTiming = lines.length > 0 || !step.done` — a completed step with no timing shows
+  nothing.
+- `aria-expanded` on the timing button.
+- `parkOpenRow()` scrolls the opened row to the top of the list. The prototype comments
+  that `scrollTo({behavior:"smooth"})` silently no-ops on that container — the RN
+  equivalent lives host-side (see D6).
+
+## Decisions
+
+| ID      | Decision                                                                                                                                                                                                                                                                                                                                           | Alternatives Considered                                                            | Rationale                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1**  | Two sibling component directories, `src/components/StepDayGrid/` and `src/components/StepTimingEditor/`, each with `index.ts` + `.tsx` + `.styles.ts` + `.stories.tsx` + `__tests__/`. `StepTimingEditor` imports the grid via its barrel.                                                                                                         | One directory with the grid as a `.parts.tsx`; grid nested under the editor.       | The grid is independently specified (#574), independently story'd, and #576/#575 may reuse it. Sibling dirs match `TimelineStep` / `TimelineNode`.                                                                                                                                                                                                                                                |
+| **D2**  | `StepDayGrid` emits plain `YYYY-MM-DD` strings and never touches `DateIso`. All internal date maths is on **local** `Date(y, m, d)` triples + lexicographic string compare, exactly as the prototype does.                                                                                                                                         | Emit `DateIso`; use `Date.parse` on ISO strings.                                   | #574 is explicit: the branded-`DateIso`-at-local-midnight conversion is #576's job. Lexicographic compare on zero-padded `YYYY-MM-DD` is total-order-correct and dodges every timezone trap.                                                                                                                                                                                                      |
+| **D3**  | Past/future classification uses **string compare against a `YYYY-MM-DD` derived from `now` in local time**, strict `<` — mirroring `waitingOnExpectedIsPast`'s strict `<` (queries.ts D4) and the prototype's `key < TODAY_ISO`. A day equal to today's key is **not** past.                                                                       | `Date.parse(key) < now.getTime()`.                                                 | `Date.parse("2026-06-24")` is UTC-midnight; `now` is local — that comparison flips sign for anyone east of UTC on the boundary day. The whole grid is day-granular, so day-granular compare is the correct instrument. Strictness matches #571.                                                                                                                                                   |
+| **D4**  | Month/weekday names via `new Intl.DateTimeFormat(locale, …)`, memoised per `(locale, month)`. Weekday headers generated from a known Monday (`Date(2026, 5, 22)`) + `weekday: "narrow"`.                                                                                                                                                           | Hand-written `MONTHS` array (as the prototype has); `toLocaleDateString` per cell. | #574 forbids hand-assembly. Hermes ships `Intl` locale data on-device (verified in the #66 spike; `formatDate` carries the note). `formatDate` itself is wrong for headers — it always emits day+year.                                                                                                                                                                                            |
+| **D5**  | `StepTimingEditor` owns its expanded state internally (uncontrolled), and additionally accepts optional `expanded` + `onExpandedChange` for a host that must enforce "only one editor open at a time".                                                                                                                                             | Fully controlled only; fully uncontrolled only.                                    | #573 says the component owns expanded state, _and_ that only one editor may be open at a time. A host with N rows cannot enforce that without a controlled escape hatch. Uncontrolled default keeps the stories and #575 simple.                                                                                                                                                                  |
+| **D6**  | Scroll-to-top on expand is **requested, not performed**: `onExpand?: (rowRef: RefObject<View \| null>) => void` hands the host the row's own root ref so it can `measureLayout` against its `ScrollView` and set the offset. A dedicated story (`InsideAScrollingList`) implements the host side and demonstrates the behaviour.                   | Component owns a `ScrollView` ref prop; component calls `scrollIntoView` itself.   | The component is presentational and does not own the list. Precedent: `EditModeScreen`'s `dragScrollController` / `scrollInstrumentation` split, and `EditGoalStepRow`'s `registerRowLayout`. The requirement ("set the scroll offset explicitly on expand") is still demonstrably met, in the story and in #575.                                                                                 |
+| **D7**  | All copy is caller-supplied props with English defaults; **no** new keys in `src/i18n/resources/en/*.json` in this PR.                                                                                                                                                                                                                             | Add an `editGoal:timing.*` namespace now.                                          | The D7/D9 convention every Storybook-first component in this epic follows (`AnimatedSheet`, `EditGoalStepRow`). #576 is the `[Integrate]` issue and owns `t()` wiring; adding keys now would ship dead strings and churn `pseudo/`.                                                                                                                                                               |
+| **D8**  | The row's truth lines are rendered from **pre-formatted, pre-resolved props** (`afterStepTitle`, `afterStepIsCompleted`, `dueDateLabel`) and composed with the same interpolation shapes as `timelineJourney:step.metadata.*`. Parity is asserted by a test that renders `TimelineStep`'s band and this component's line and compares the strings. | Call `resolveStepDependencyBand` inside the editor; re-derive the copy.            | The resolver reads a DB row shape the Storybook component must not depend on. Parity is a _test_ obligation, not a coupling obligation — and a test catches drift that a shared import would only hide.                                                                                                                                                                                           |
+| **D9**  | **No animation.** The editor appears/disappears without the prototype's 160ms `unfold`.                                                                                                                                                                                                                                                            | `useAnimationPref()` + reanimated `withTiming`, as `AnimatedSheet` does.           | `useAnimationPref` reads Evolu (`useQuery(userSettingsQuery)`), which a presentational Storybook component must not require. Threading `animationPref` as a prop is doable but is pure addition on an already-oversized PR. Noted as a follow-up; the prototype already gates the unfold behind `prefers-reduced-motion`, so shipping it un-animated is the accessible default, not a regression. |
+| **D10** | `marks` labels are **caller-supplied strings** (`"1"`, `"a"`, `"b"`), not derived.                                                                                                                                                                                                                                                                 | Take step objects and derive ordinals with `toLetterOrdinal`.                      | Ordinal assignment is the list's business (`TimelineStep` already does `toLetterOrdinal(index)`), and the grid must stay a pure presentational input.                                                                                                                                                                                                                                             |
+| **D11** | The candidate list is a plain in-editor `ScrollView` with `maxHeight`, not a `FlatList`, not a sheet.                                                                                                                                                                                                                                              | `FlatList`; a modal picker (as `EditGoalStepRow`'s nest-under picker uses).        | A goal has tens of steps at most; virtualising inside an already-scrolling parent is the classic nested-VirtualizedList warning. A modal is explicitly forbidden by #573.                                                                                                                                                                                                                         |
+
+## Affected Areas
+
+**New files**
+
+- `src/components/StepDayGrid/StepDayGrid.tsx` — component (~180 lines)
+- `src/components/StepDayGrid/StepDayGrid.styles.ts` — themed styles (~90)
+- `src/components/StepDayGrid/monthGrid.ts` — pure date helpers (~70)
+- `src/components/StepDayGrid/index.ts` — barrel
+- `src/components/StepDayGrid/StepDayGrid.stories.tsx` — 6 stories + matrix (~150)
+- `src/components/StepDayGrid/__tests__/StepDayGrid.test.tsx` (~140)
+- `src/components/StepDayGrid/__tests__/monthGrid.test.ts` (~80)
+- `src/components/StepTimingEditor/StepTimingEditor.tsx` — timing line + editor (~230)
+- `src/components/StepTimingEditor/StepTimingEditor.parts.tsx` — truth lines, candidate picker, ordering note (~170)
+- `src/components/StepTimingEditor/StepTimingEditor.styles.ts` (~140)
+- `src/components/StepTimingEditor/index.ts` — barrel
+- `src/components/StepTimingEditor/StepTimingEditor.stories.tsx` — 10 stories + matrix (~230)
+- `src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx` (~200)
+- `src/components/StepTimingEditor/__tests__/readOutParity.test.tsx` (~70)
+
+**Existing files touched**
+
+- None required. `src/db/queries.ts`, `src/utils/format.ts`, and the i18n resources are
+  **read-only references** for this PR. If a barrel at `src/components/index.ts` exists
+  and lists components, add both there; otherwise leave it.
+
+## Exact prop signatures
+
+### `StepDayGrid`
+
+```ts
+/** A day another step already sits on, with its list ordinal ("1", "2", "a", "b"). */
+export interface StepDayMark {
+  /** `YYYY-MM-DD`. */
+  date: string;
+  /** The other step's ordinal badge text. Caller-assigned (D10). */
+  label: string;
+}
+
+export interface StepDayGridProps {
+  /** Selected day as `YYYY-MM-DD`, or null for no day. */
+  value: string | null;
+  /**
+   * Required. Never read the clock inside this component — the same convention
+   * `resolveStepDependencyBand` follows (`src/db/queries.ts`), so stories and tests
+   * pin a fixed instant. Used only to derive today's ring and past/future quieting.
+   */
+  now: Date;
+  /** Days other steps sit on. At most two badges render per day, then an overflow badge. */
+  marks?: readonly StepDayMark[];
+  /** Fires with the tapped day, or `null` when the selected day is tapped again. */
+  onChange: (next: string | null) => void;
+  /** BCP-47 tag for month + weekday names — pass `i18n.language` from the caller. */
+  locale?: string;
+
+  // --- Copy (caller-supplied, English defaults — D7). ---
+  /** a11y label for the previous-month control. Default: "Previous month". */
+  previousMonthLabel?: string;
+  /** a11y label for the next-month control. Default: "Next month". */
+  nextMonthLabel?: string;
+  /** Quiet caption under the grid. Default: "badges mark days your other steps sit on". */
+  legendLabel?: string;
+  /**
+   * Appended to a day's a11y label when other steps sit there.
+   * Default: (n) => n === 1 ? "1 other step here" : `${n} other steps here`.
+   */
+  marksA11ySuffix?: (count: number) => string;
+  /** testID root; day cells get `${testID}-day-${iso}`. */
+  testID?: string;
+}
+```
+
+### `StepTimingEditor`
+
+```ts
+/** A step (or sub-step) this one may depend on. */
+export interface StepTimingCandidate {
+  id: string;
+  title: string;
+  /** Ordinal badge text — "1", "2", "a" (D10). */
+  label: string;
+  /** True for a sub-step: indents the row, matching the prototype's `.is-child`. */
+  isSubStep?: boolean;
+  /** Renders the ordinal slot as a check and the title in the completed treatment. */
+  isCompleted?: boolean;
+  /** This candidate's own day, `YYYY-MM-DD` or null — feeds the ordering note. */
+  dueDate: string | null;
+  /** This candidate's day, pre-formatted for the active locale (`formatDate`). */
+  dueDateLabel?: string;
+}
+
+/** Draft values handed back on commit. */
+export interface StepTimingValue {
+  /** `YYYY-MM-DD` or null. Conversion to a branded `DateIso` is #576's job. */
+  dueDate: string | null;
+  /** Candidate id, or null for `nothing`. Unvalidated by design. */
+  afterStepId: string | null;
+}
+
+export interface StepTimingEditorProps {
+  /** Current committed timing for this step. */
+  value: StepTimingValue;
+  /** Required, injected — never read the clock inside (same rule as StepDayGrid). */
+  now: Date;
+  /**
+   * Every step and sub-step in the goal **except this one** — the caller filters.
+   * Empty array is a supported state (a goal's first step) and renders the empty copy.
+   */
+  candidates: readonly StepTimingCandidate[];
+  /**
+   * Whether this step is completed. A completed step with no timing renders **no**
+   * `＋ when?` — nothing is left to plan on it — but still shows timing it has.
+   */
+  isCompleted?: boolean;
+  /**
+   * The current dependency's title, pre-resolved by the caller the way
+   * `resolveStepDependencyBand` resolves it (unresolvable → null → no `after` line).
+   */
+  afterStepTitle?: string | null;
+  /** Whether that dependency is completed — drives the `· done ✓` suffix. See OQ-1. */
+  afterStepIsCompleted?: boolean;
+  /** `value.dueDate` pre-formatted for the active locale via `formatDate` (D8). */
+  dueDateLabel?: string | null;
+  /** Days other steps sit on, forwarded to the grid. */
+  marks?: readonly StepDayMark[];
+  /** BCP-47 tag, forwarded to the grid and used for nothing else. */
+  locale?: string;
+
+  /** Fires on `Done` with the draft. Never fires on collapse-without-Done. */
+  onCommit: (next: StepTimingValue) => void;
+  /** Fires on `Clear` — removes both the date and the dependency. */
+  onClear: () => void;
+
+  /** Controlled expansion (D5). Omit for uncontrolled. */
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  /**
+   * Fired when the row expands, with this row's root `View` ref, so the host can
+   * `measureLayout` against its ScrollView and park the row at the top of the list
+   * (D6). Without it the editor can unfold below the fold and the tap reads as
+   * having done nothing.
+   */
+  onExpand?: (rowRef: React.RefObject<View | null>) => void;
+
+  // --- Copy (caller-supplied, English defaults — D7). ---
+  /** Unset affordance. Default: "＋ when?" */
+  whenPromptLabel?: string;
+  /** Editor question. Default: "When do you want this done?" */
+  questionLabel?: string;
+  /** Sub-line. Default: `Your intent, not a deadline. A passed date never reads as "late."` */
+  intentSubLabel?: string;
+  /** Field label above the dependency control. Default: "Depends on" */
+  dependsOnLabel?: string;
+  /** Placeholder + clear option. Default: "nothing" */
+  nothingLabel?: string;
+  /** Copy when `candidates` is empty. Default: "No other steps in this goal yet." */
+  noCandidatesLabel?: string;
+  /** Footer buttons. Defaults: "Clear" / "Done". */
+  clearLabel?: string;
+  doneLabel?: string;
+  /**
+   * The neutral ordering note. Default:
+   * (title, date) => `${title} needs to be done first, and it sits on ${date}. ` +
+   *   `This one lands before it — that's allowed, it just won't read in order.`
+   */
+  orderingNote?: (dependencyTitle: string, dependencyDate: string) => string;
+  /** a11y label on the timing line. Default: "Timing for this step". */
+  timingLineA11yLabel?: string;
+  /** Forwarded to the grid. */
+  gridCopy?: Pick<
+    StepDayGridProps,
+    "previousMonthLabel" | "nextMonthLabel" | "legendLabel" | "marksA11ySuffix"
+  >;
+  testID?: string;
+}
+```
+
+## Copy strings, verbatim
+
+Transcribed from the issue bodies and the prototype. **Curly quotes and the fullwidth
+plus are intentional — copy them exactly.**
+
+| Where                                 | String                                                                                                                                                                           |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unset affordance                      | `＋ when?` (U+FF0B FULLWIDTH PLUS SIGN)                                                                                                                                          |
+| Editor question                       | `When do you want this done?`                                                                                                                                                    |
+| Editor sub-line                       | `Your intent, not a deadline. A passed date never reads as “late.”` (U+201C / U+201D)                                                                                            |
+| Dependency field label                | `Depends on`                                                                                                                                                                     |
+| Dependency empty value / clear option | `nothing`                                                                                                                                                                        |
+| Footer                                | `Clear` · `Done`                                                                                                                                                                 |
+| Grid legend                           | `badges mark days your other steps sit on`                                                                                                                                       |
+| Month nav a11y                        | `Previous month` · `Next month`                                                                                                                                                  |
+| Ordering note (example from #573)     | `Inspection & labels needs to be done first, and it sits on Jun 30. This one lands before it — that's allowed, it just won't read in order.` (em dash U+2014, apostrophe U+2019) |
+| Ordering note (template)              | `{title} needs to be done first, and it sits on {date}. This one lands before it — that's allowed, it just won't read in order.`                                                 |
+| Truth line — after                    | `↩ after {title}` (glyph U+21A9)                                                                                                                                                 |
+| Truth line — after, completed dep     | `↩ after {title} · done ✓` (U+00B7, U+2713) — **see OQ-1**                                                                                                                       |
+| Truth line — due                      | `▦ due {date}` (glyph U+25A6)                                                                                                                                                    |
+| Candidate empty state                 | `No other steps in this goal yet.` (new copy — see OQ-4)                                                                                                                         |
+
+**Forbidden strings** (grep test in commit 7): `blocked`, `overdue`, `late` (outside the
+sub-line's quoted `“late.”`), `deadline` (outside the sub-line's `not a deadline`),
+`missing`, `needed`, `required`, `remaining`.
+
+## Implementation Plan
+
+### Step 1: pure month-grid helpers
+
+**Files**: `src/components/StepDayGrid/monthGrid.ts`,
+`src/components/StepDayGrid/__tests__/monthGrid.test.ts`
+**Commit**: `feat(native-rd): add pure month-grid date helpers for StepDayGrid (#574)`
+
+- [ ] `toDayKey(date: Date): string` — local `YYYY-MM-DD`, zero-padded. No UTC.
+- [ ] `dayKey(y: number, m: number, d: number): string` — the prototype's `iso()`.
+- [ ] `leadingBlanks(y, m): number` — `(new Date(y, m, 1).getDay() + 6) % 7`, Monday-first.
+- [ ] `daysInMonth(y, m): number` — `new Date(y, m + 1, 0).getDate()`.
+- [ ] `shiftMonth({ year, month }, delta): { year, month }` — unbounded, wraps the year.
+- [ ] `isPastDay(key: string, nowKey: string): boolean` — strict `key < nowKey` (D3).
+- [ ] `groupMarksByDay(marks): Record<string, string[]>` — preserves input order.
+- [ ] Tests: `test.each` over a table of months → expected leading blanks, incl. a
+      Sunday-1st month (6 blanks) and a Monday-1st month (0); leap-year February;
+      December→January and January→December wrap; `isPastDay` at the exact `now`
+      boundary (equal → `false`).
+
+### Step 2: `StepDayGrid` component + styles
+
+**Files**: `StepDayGrid.tsx`, `StepDayGrid.styles.ts`, `index.ts`
+**Commit**: `feat(native-rd): add StepDayGrid themed month grid (#574)`
+
+- [ ] Month state initialised from `value ?? now`; `useEffect` re-anchors when `value`
+      changes to a different month.
+- [ ] Header: `‹` / month-year label / `›`. Both nav controls `Pressable`,
+      `accessibilityRole="button"`, labelled, `minWidth/minHeight: 44`.
+- [ ] Month label from `Intl.DateTimeFormat(locale, { month: "long", year: "numeric" })`,
+      memoised on `[locale, year, month]`.
+- [ ] Weekday header row from a known Monday + `{ weekday: "narrow" }`, memoised on
+      `[locale]`.
+- [ ] 7-column layout. Leading blanks are non-interactive `View`s with
+      `importantForAccessibility="no-hide-descendants"`.
+- [ ] Day cell: `Pressable`, `accessibilityRole="button"`,
+      `accessibilityState={{ selected: isSelected }}`, `minHeight: 44`,
+      `fontVariant: ["tabular-nums"]`. **Never** `disabled`.
+- [ ] `accessibilityLabel` = full date via `Intl.DateTimeFormat(locale, { weekday:
+    "long", day: "numeric", month: "long", year: "numeric" })`, plus
+      `marksA11ySuffix(count)` when marks exist.
+- [ ] `onPress` → `onChange(key === value ? null : key)`.
+- [ ] Marks: first two labels as badges, third+ collapses to one overflow badge (`+`).
+      Selected day swaps the badge ground (prototype `.day.is-sel .mark`).
+- [ ] Legend caption below the grid.
+- [ ] Styles: all tokens (`theme.colors.*`, `space`, `radius`, `borderWidth`,
+      `fontFamily`, `shadowStyle(theme, "cardElevationSmall")`). Zero hardcoded hex.
+- [ ] Doc comment records where a recurrence control would attach (next to the month
+      header) and that nothing is built for it.
+- [ ] Doc comment records why not `@react-native-community/datetimepicker` (the four
+      reasons from #574), so the question is answered in the code, not in review.
+
+### Step 3: `StepDayGrid` stories
+
+**Files**: `StepDayGrid.stories.tsx`
+**Commit**: `feat(native-rd): add StepDayGrid stories under Set B & C (#574)`
+
+- [ ] `title: "Set B & C/StepDayGrid"` — establishes the new Storybook section.
+- [ ] Pinned `const NOW = new Date(2026, 5, 24)` (the prototype's instant).
+- [ ] Stories: `Unset` · `DaySelected` · `PastDaySelected` · `WithMarks` (incl. a
+      three-mark day exercising the overflow badge) · `MonthStartingSunday`
+      (November 2026) · `AcrossAYearBoundary` (opens on December 2026, with a
+      note to tap `›`).
+- [ ] `AllThemesMatrix` over `themeNames` with `ScopedTheme` + `MOOD_NAMES`, copying the
+      `FocusParkedState.stories.tsx` scaffolding.
+- [ ] A `LargeTextDensity` story wrapping the grid in
+      `composeTheme("light", "largeText")` — see OQ-2; this is how the issue's
+      "confirm at `largeText` density" gets a review surface, since `largeText` is not
+      one of the seven registered product themes.
+- [ ] `PhoneWidth` wrapper at 344px, matching the sibling stories.
+
+### Step 4: `StepDayGrid` tests
+
+**Files**: `__tests__/StepDayGrid.test.tsx`
+**Commit**: `test(native-rd): cover StepDayGrid selection, marks and a11y (#574)`
+
+- [ ] Pinned `now`; assert leading-blank count via testIDs for a Sunday-1st month.
+- [ ] `test.each` over boundary days: `now - 1d` past, `now` not past, `now + 1d` not
+      past — asserted through the past style flag exposed as a testID suffix or an
+      `accessibilityState`, not a colour probe.
+- [ ] Tapping an unselected day → `onChange("YYYY-MM-DD")`.
+- [ ] Tapping the selected day → `onChange(null)`.
+- [ ] Tapping a **past** day still fires `onChange` (the "never refused" contract).
+- [ ] No day cell has `accessibilityState.disabled === true`.
+- [ ] Month nav: `›` twelve times from June 2026 lands on June 2027 (label assertion).
+- [ ] Three marks on one day → two ordinal badges + one overflow badge.
+- [ ] a11y label of a marked day includes the marks suffix.
+- [ ] `locale="de"` renders a German month name (guards the `Intl` path against a
+      regression to a hand-written array).
+
+### Step 5: `StepTimingEditor` component + parts + styles
+
+**Files**: `StepTimingEditor.tsx`, `StepTimingEditor.parts.tsx`,
+`StepTimingEditor.styles.ts`, `index.ts`
+**Commit**: `feat(native-rd): add StepTimingEditor in-row date + depends-on editor (#573)`
+
+- [ ] Root `View` with a ref, so `onExpand` can hand it to the host (D6).
+- [ ] `TimingLine` part: renders the truth lines (`↩ after …`, `▦ due …`), or the single
+      `＋ when?`, or nothing when `isCompleted && !hasTiming`. `Pressable`,
+      `accessibilityRole="button"`, `accessibilityState={{ expanded }}`,
+      `minHeight: 44`.
+- [ ] Draft state `{ dueDate, afterStepId }` seeded from `value` on **expand**; reset on
+      every expand so a discarded draft never leaks into the next open.
+- [ ] `StepDayGrid` embedded, `value={draft.dueDate}`, `onChange` → draft only.
+- [ ] `DependencyPicker` part: collapsed button (ordinal badge + title, or the `nothing`
+      placeholder, plus a caret), expanding to a `maxHeight` `ScrollView` of options
+      (D11). `nothing` first, then candidates; sub-steps indented; completed candidates
+      show `✓` in the ordinal slot and the completed title treatment; the current
+      selection carries a tick and `accessibilityState={{ selected: true }}`. Every row
+      `minHeight: 44`, `accessibilityRole="button"`.
+- [ ] Empty `candidates` → `noCandidatesLabel` instead of an empty box.
+- [ ] `OrderingNote` part: renders **only** when `draft.dueDate && draft.afterStepId &&
+    target.dueDate && draft.dueDate < target.dueDate`. Plain `Text`, body weight,
+      `colors.textSecondary`, a quiet left rule. **No** icon, **no** `error`/`danger`
+      token, **no** `accessibilityRole="alert"`, **no** `disabled` anywhere.
+- [ ] Footer: `Clear` (quiet, fixed width) + `Done` (primary, `flex: 1`), both
+      `minHeight: 44`, both labelled.
+- [ ] `Done` → `onCommit(draft)` then collapse. `Clear` → `onClear()` then collapse.
+      Collapse by tapping the timing line → discard, `onCommit` **not** called.
+- [ ] Focus: on expand, `focusAccessibilityRef` onto the editor question `Text`; on
+      collapse, `focusAccessibilityRef` back onto the timing line. Store both refs;
+      cancel a pending focus on unmount (the util returns a cancel fn).
+- [ ] Controlled/uncontrolled expansion per D5.
+- [ ] Doc comment records: `afterStepId` stays unvalidated — no cycle detection, no
+      same-goal check, no disabled candidates — citing `updateStep`
+      (`src/db/queries.ts:893-897`) and the read side's graceful degradation
+      (`resolveStepDependencyBand`, `src/db/queries.ts:547-568`). Guards inform; they
+      never refuse.
+- [ ] Doc comment records that `waiting on` is deliberately absent from this surface and
+      moves to Focus (#573), so a future reader does not "restore" it.
+
+### Step 6: `StepTimingEditor` stories
+
+**Files**: `StepTimingEditor.stories.tsx`
+**Commit**: `feat(native-rd): add StepTimingEditor stories under Set B & C (#573)`
+
+- [ ] `title: "Set B & C/StepTimingEditor"`, pinned `NOW = new Date(2026, 5, 24)`,
+      fixtures transcribed from the prototype's `initialSteps()` (Rewire the workshop:
+      "Plan layout & buy materials", "Wire the circuits", "Inspection & labels" +
+      3 sub-steps, "Mount the panels", "Final walkthrough").
+- [ ] Stories, one per acceptance bullet: `Unset` · `DateOnly` · `DependencyOnly` ·
+      `Both` · `PastDate` · `EditingAnExistingPair` (opens expanded) ·
+      `OrderingNoteVisible` (the prototype's `conflict` demo: step 4 depends on
+      "Inspection & labels" (Jun 30) with its own day set to Jun 26) ·
+      `NoCandidates` · `CompletedStep` (no `＋ when?`) · `SubStep`.
+- [ ] `InsideAScrollingList` — several rows in a `ScrollView`, wiring `onExpand` to
+      `measureLayout` + `scrollTo`, and enforcing one-open-at-a-time via the controlled
+      `expanded` prop. This is the story that demonstrates the prototype's
+      `parkOpenRow()` requirement.
+- [ ] `AllThemesMatrix` over all 7 themes, rendering the `Both` + expanded fixture (the
+      richest chrome per theme).
+
+### Step 7: `StepTimingEditor` tests, incl. read-out parity
+
+**Files**: `__tests__/StepTimingEditor.test.tsx`, `__tests__/readOutParity.test.tsx`
+**Commit**: `test(native-rd): cover StepTimingEditor draft, note and read-out parity (#573)`
+
+- [ ] Timing line: unset non-completed → exactly one `＋ when?`; unset completed → no
+      affordance at all; completed with timing → lines shown.
+- [ ] Expand flips `accessibilityState.expanded`; collapse flips it back.
+- [ ] Draft discard: expand → pick a day → collapse via the timing line → `onCommit` not
+      called; re-expand shows the original `value`, not the discarded draft.
+- [ ] `Done` → `onCommit` called once with the draft; `Clear` → `onClear` called, editor
+      collapses.
+- [ ] Per-field clearing: tapping the selected day again clears the draft date; choosing
+      `nothing` clears the draft dependency — both without `Clear`.
+- [ ] Candidate list: excludes the editing step; includes sub-steps; marks the selection;
+      renders a completed candidate as completed; empty list → `noCandidatesLabel`.
+- [ ] Ordering note: `test.each` over (draft date, dependency date) pairs — before →
+      shown, same day → hidden, after → hidden, dependency dateless → hidden, no
+      dependency → hidden.
+- [ ] Ordering-note neutrality: the rendered note subtree contains no
+      `accessibilityRole="alert"` and no element with `disabled`/`accessibilityState.disabled`.
+- [ ] Forbidden-copy grep test over the rendered tree **and** the source files:
+      `/blocked|overdue|missing|needed/i` → zero matches (with the two documented
+      exceptions for `late`/`deadline` inside the sub-line).
+- [ ] a11y: every day cell, candidate row, nav control and footer button reports
+      `accessibilityRole` + a non-empty `accessibilityLabel` (or accessible text) and a
+      style with `minHeight >= 44`.
+- [ ] **Read-out parity** (`readOutParity.test.tsx`): render `TimelineStep` with
+      `afterStep` / `dueDate` and render `StepTimingEditor` with the equivalent props;
+      assert the `after` line and the `due` line strings are identical. Drive both from
+      the same `formatDate(iso, "en-US")` output so a formatter change breaks the test
+      rather than the app.
+
+## Testing Strategy
+
+- [ ] Jest 30 + `@testing-library/react-native` v13, `renderWithProviders` from
+      `src/__tests__/test-utils`.
+- [ ] Tests co-located at `src/components/<Name>/__tests__/<Name>.test.tsx` — the
+      dominant convention for components in this repo (`TimelineStep`,
+      `FocusCurrentTaskCard`, `EvidenceTypePicker`), notwithstanding CLAUDE.md's
+      `src/__tests__/` mirroring line, which the shared/util tests follow.
+- [ ] `test.each` for the leading-blank table, the past/future boundary table, and the
+      ordering-note truth table.
+- [ ] Every test pins `now` to `new Date(2026, 5, 24)` — never `new Date()`.
+- [ ] Run with `bun run test --testPathPatterns "StepDayGrid|StepTimingEditor|monthGrid"`.
+- [ ] Manual: `bun run storybook:web`, walk both story sets, then
+      `AllThemesMatrix` in all 7 themes and the `LargeTextDensity` story; confirm no day
+      cell or candidate row collapses below 44pt and the digit columns do not jitter.
+- [ ] Manual: on device/sim, VoiceOver through one expand→pick→Done cycle, confirming
+      focus lands in the editor on expand and returns to the timing line on collapse.
+
+## Not in Scope
+
+| Item                                                              | Reason                                                              | Follow-up                                                                   |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Screen wiring, `updateStep` writes                                | #573/#574 are Storybook-only                                        | #576                                                                        |
+| `YYYY-MM-DD` → local-midnight `DateIso` conversion                | #574 leaves it to the caller deliberately                           | #576                                                                        |
+| The row itself (drag, title, evidence chip)                       | #573 owns the timing line, not the row                              | #575 (needs rescoping — it still says "two chips")                          |
+| `waiting on` authoring (`waitingOnLabel` / `waitingOnExpectedAt`) | An external wait is recorded mid-ride, in Focus, not while planning | Needs its own issue under #570 before #576 can claim the band is authorable |
+| `listRecentWaitingOnLabels()` / waiting-on suggestion chips       | Nothing queries distinct labels; the old chips were a demo fixture  | Owned by whichever issue picks up the wait                                  |
+| Recurrence UI                                                     | #574 explicitly: note where it attaches, build nothing              | none                                                                        |
+| OS picker as a "jump to a far-off month" affordance               | #574: "Build nothing for that now"                                  | none                                                                        |
+| Cycle detection / same-goal validation on `afterStepId`           | Guards inform, never refuse (ADR-0010/0012)                         | none — this is a permanent decision                                         |
+| i18n resource keys                                                | D7 — copy is caller-supplied with English defaults                  | #576                                                                        |
+| Expand/collapse animation                                         | D9 — needs `animationPref` threaded as a prop                       | Follow-up issue; note in the component doc comment                          |
+| Rebasing onto PR #582 (`AnimatedSheet` lift)                      | No sheet in this design                                             | none                                                                        |
+
+## Open Questions
+
+**OQ-1 — `· done ✓` has no shipped precedent, and its data is unsourced. (Blocking-ish.)**
+#573 says the row's set state shows "the truth-lines **exactly as Focus and Timeline
+render them** — `↩ after <title> · done ✓`". Focus and Timeline render **no such
+suffix**. `focusMode:currentTask.metadata.after` and
+`timelineJourney:step.metadata.after` are both plain `"after {{title}}"`, and
+`FocusCurrentTaskCard.parts.tsx:118-121` carries an explicit comment:
+
+> _"No completion suffix: `afterStep` carries only the prerequisite's title, not its
+> done-state, so a hard-coded '✓ done' would assert a fact the props can't back. Real
+> dependency-completion data is still unsourced."_
+
+`resolveStepDependencyBand` returns `afterStepTitle` only — no completion flag. So
+"read-out parity" and "`· done ✓`" are mutually exclusive as written.
+
+**Assumption taken** (state it in the PR body): the editor accepts an
+`afterStepIsCompleted` prop and renders the suffix when it is `true`, defaulting to
+`false` so the default render is byte-identical to Focus/Timeline. The parity test
+asserts the **suffix-free** form. If the reviewer wants the suffix shipped as the
+canonical read-out, that is a change to Focus, Timeline and the resolver — a separate
+issue, not this PR.
+
+**OQ-2 — `largeText` is not one of the seven product themes.**
+#574 lists the variants as `highContrast, dyslexia, largeText, lowVision,
+autismFriendly, lowInfo` and asks to "confirm at `largeText` density". But
+`productThemeEntries` (`src/themes/compose.ts:303-311`) registers
+`light-default, dark-default, light-highContrast, light-dyslexia,
+light-autismFriendly, light-lowVision, light-lowInfo` — `largeText` is a composable
+`Variant`, not a registered `ThemeName`. `AllThemesMatrix` therefore cannot include it.
+**Assumption**: `AllThemesMatrix` covers the seven registered themes (matching every
+existing matrix story), and a separate `LargeTextDensity` story uses
+`composeTheme("light", "largeText")` — the `TestScreen.tsx:352` precedent — to satisfy
+the "confirm at `largeText` density" clause. `light-lowVision` already carries
+`size: sizeL`, so the 1.25× scale is covered inside the matrix too.
+
+**OQ-3 — the prototype's date format omits the year; parity requires it.**
+The prototype's `fmtDay()` emits `Jun 30`. The shipped read-out uses `formatDate`
+(`src/utils/format.ts:15`), which emits `Jun 30, 2026` and has no year-less mode.
+**Assumption**: parity wins — the timing line and the ordering note both use
+caller-supplied `formatDate(…, i18n.language)` output, so the editor reads
+`▦ due Jun 30, 2026` where the prototype reads `▦ due Jun 30`. Flagged because a
+reviewer holding the prototype will notice.
+
+**OQ-4 — the candidate empty-state copy is unspecified.**
+#573 requires an empty state ("a goal's first step has no candidates") but supplies no
+string. **Assumption**: `No other steps in this goal yet.` — declarative, no
+`missing`/`needed` framing. Easy to change; it is a prop default.
+
+**OQ-5 — the issue's line references have drifted.**
+Both issues cite `src/db/queries.ts:533-544` and `:871-875`. On `main` at `3e76787`,
+`resolveStepDependencyBand` is at **`:547-568`** and the `afterStepId` pass-through is
+at **`:893-897`**. Cosmetic, but the plan and the code comments use the current numbers.
+
+**OQ-6 — "only one editor open at a time" cannot be enforced by a self-contained
+component.** Resolved by D5 (optional controlled `expanded`), but worth calling out: in
+the uncontrolled default, N sibling editors can all be open. The `InsideAScrollingList`
+story shows the controlled wiring, and #575 must adopt it.
+
+## Discovery Log
+
+<!-- Entries added by the implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+
+- [2026-08-13] Research pass. Confirmed: no `AnimatedSheet` / `Modal` / scrim dependency;
+  PR #582 is genuinely independent. Confirmed `Set B & C/` is a **new** Storybook
+  section — existing titles are `Iteration B/<Area>/<Component>`, `Design System/…`,
+  `Badges/…`, `Screens/…`.

--- a/apps/native-rd/docs/plans/dev-plans/issue-574-573-step-timing-editor.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-574-573-step-timing-editor.md
@@ -409,7 +409,7 @@ sub-line's quoted `“late.”`), `deadline` (outside the sub-line's `not a dead
       `accessibilityState={{ selected: isSelected }}`, `minHeight: 44`,
       `fontVariant: ["tabular-nums"]`. **Never** `disabled`.
 - [ ] `accessibilityLabel` = full date via `Intl.DateTimeFormat(locale, { weekday:
-    "long", day: "numeric", month: "long", year: "numeric" })`, plus
+  "long", day: "numeric", month: "long", year: "numeric" })`, plus
       `marksA11ySuffix(count)` when marks exist.
 - [ ] `onPress` → `onChange(key === value ? null : key)`.
 - [ ] Marks: first two labels as badges, third+ collapses to one overflow badge (`+`).
@@ -482,7 +482,7 @@ sub-line's quoted `“late.”`), `deadline` (outside the sub-line's `not a dead
       `minHeight: 44`, `accessibilityRole="button"`.
 - [ ] Empty `candidates` → `noCandidatesLabel` instead of an empty box.
 - [ ] `OrderingNote` part: renders **only** when `draft.dueDate && draft.afterStepId &&
-    target.dueDate && draft.dueDate < target.dueDate`. Plain `Text`, body weight,
+  target.dueDate && draft.dueDate < target.dueDate`. Plain `Text`, body weight,
       `colors.textSecondary`, a quiet left rule. **No** icon, **no** `error`/`danger`
       token, **no** `accessibilityRole="alert"`, **no** `disabled` anywhere.
 - [ ] Footer: `Clear` (quiet, fixed width) + `Done` (primary, `flex: 1`), both
@@ -658,3 +658,46 @@ story shows the controlled wiring, and #575 must adopt it.
   PR #582 is genuinely independent. Confirmed `Set B & C/` is a **new** Storybook
   section — existing titles are `Iteration B/<Area>/<Component>`, `Design System/…`,
   `Badges/…`, `Screens/…`.
+
+### Implementation deviations
+
+- **OQ-1 resolved as planned, and now verified.** `readOutParity.test.tsx` renders
+  `TimelineStep`'s band and the editor's timing line from the same `formatDate`
+  output and asserts the strings are identical. They are. `afterStepIsCompleted`
+  defaults to `false`, so the default render carries no `· done ✓`. Making the
+  suffix canonical remains a change to Focus, Timeline and the resolver together.
+- **OQ-2 resolved differently.** The planned `composeTheme("light", "largeText")`
+  story is not buildable: `ScopedTheme` accepts only _registered_ theme names
+  (`keyof UnistylesThemes`), and `largeText` is a composable variant. The
+  `LargeTextDensity` story therefore renders under `light-lowVision`, which carries
+  the identical `size: sizeL` scale (`src/themes/variants.ts:128` vs `:96`). The
+  first draft of this story passed a `largeText` background colour to a
+  `light-default` subtree — it would have _looked_ like a density check while
+  rendering at normal scale. Replaced before commit.
+- **Draft seeding moved off the press handler.** Seeding on `handleTimingLinePress`
+  meant a controlled host that opens a row programmatically (no tap reaches the
+  component) would edit a stale draft. Seeding now keys on the expand transition
+  itself, via React's render-time state-adjustment pattern rather than an effect —
+  an effect would paint one frame of the wrong state and trips
+  `react-hooks/set-state-in-effect`. The same pattern re-anchors `StepDayGrid`'s
+  displayed month on a `value` change.
+- **Focus target is the heading `View`, not the question `Text`.** The shared `Text`
+  component does not forward refs. The block is the better target anyway: it
+  announces the question and the intent sub-line together.
+- **Two files split beyond the plan.** `StepDayGrid.parts.tsx` (the day cell) keeps
+  `StepDayGrid.tsx` inside the repo's 300-line lint budget; `types.ts` holds the
+  editor's exported types so the component file stays under it too.
+- **`theme.lineHeight.relaxed` does not exist** — the scale is size-keyed
+  (`xs…3xl`). Used `md`.
+- **`forbiddenCopy.test.ts` is its own file** rather than a block inside the editor
+  test. It greps string literals in _both_ components, with comments stripped first
+  (comments are where the ban is explained). Verified to fail on a planted
+  `"this step is blocked"` before being restored.
+- **Barrel required before the first commit.** `local/require-barrel-export` fires on
+  any file in a component directory without an `index.ts`, so commit 1 ships the
+  barrel exporting the helpers, widened in commit 2. Note: `expo lint` caches
+  results under `.expo/cache/eslint`, so adding a barrel does not clear the error
+  for unchanged files until that cache is dropped.
+- **Scope.** 18 new files, **zero existing files modified** — `queries.ts`,
+  `format.ts` and the i18n resources stayed read-only references as planned. ~1.5k
+  lines of component code, ~1.6k of stories and tests.

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.parts.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.parts.tsx
@@ -63,6 +63,7 @@ export function DayCell({
               key={`${key}-mark-${index}`}
               label={label}
               onSelectedDay={isSelected}
+              testID={`${testID}-mark-${index}`}
             />
           ))}
           {/* Third and beyond collapse into one badge — the cell is 44pt wide,

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.parts.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.parts.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "../Text";
+import { styles } from "./StepDayGrid.styles";
+
+/**
+ * One day cell. Split out of `StepDayGrid` to keep both files inside the
+ * 300-line budget; it holds no state of its own.
+ */
+export function DayCell({
+  day,
+  dayKey: key,
+  a11yLabel,
+  isSelected,
+  isToday,
+  isPast,
+  marks,
+  onPress,
+  testID,
+}: {
+  day: number;
+  dayKey: string;
+  a11yLabel: string;
+  isSelected: boolean;
+  isToday: boolean;
+  isPast: boolean;
+  /** Ordinals of other steps sitting on this day, in list order. */
+  marks: readonly string[];
+  onPress: () => void;
+  testID: string;
+}) {
+  const visibleMarks = marks.slice(0, 2);
+  const hasOverflow = marks.length > 2;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: isSelected }}
+      accessibilityLabel={a11yLabel}
+      testID={testID}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.day,
+        isToday && styles.dayToday,
+        isSelected && styles.daySelected,
+        pressed && !isSelected && styles.dayPressed,
+      ]}
+    >
+      <Text
+        style={[
+          styles.dayNumber,
+          isPast && styles.dayNumberPast,
+          isSelected && styles.dayNumberSelected,
+        ]}
+      >
+        {day}
+      </Text>
+
+      {marks.length > 0 && (
+        <View style={styles.marksRow}>
+          {visibleMarks.map((label, index) => (
+            <MarkBadge
+              key={`${key}-mark-${index}`}
+              label={label}
+              onSelectedDay={isSelected}
+            />
+          ))}
+          {/* Third and beyond collapse into one badge — the cell is 44pt wide,
+              not a list. */}
+          {hasOverflow && (
+            <MarkBadge
+              label="+"
+              onSelectedDay={isSelected}
+              testID={`${testID}-overflow`}
+            />
+          )}
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+function MarkBadge({
+  label,
+  onSelectedDay,
+  testID,
+}: {
+  label: string;
+  /** The selected day is filled, so the badge needs its own ground on top. */
+  onSelectedDay: boolean;
+  testID?: string;
+}) {
+  return (
+    <View
+      testID={testID}
+      style={[styles.mark, onSelectedDay && styles.markOnSelected]}
+    >
+      <Text
+        style={[styles.markLabel, onSelectedDay && styles.markLabelOnSelected]}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.parts.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.parts.tsx
@@ -9,7 +9,6 @@ import { styles } from "./StepDayGrid.styles";
  */
 export function DayCell({
   day,
-  dayKey: key,
   a11yLabel,
   isSelected,
   isToday,
@@ -19,7 +18,6 @@ export function DayCell({
   testID,
 }: {
   day: number;
-  dayKey: string;
   a11yLabel: string;
   isSelected: boolean;
   isToday: boolean;
@@ -60,7 +58,7 @@ export function DayCell({
         <View style={styles.marksRow}>
           {visibleMarks.map((label, index) => (
             <MarkBadge
-              key={`${key}-mark-${index}`}
+              key={index}
               label={label}
               onSelectedDay={isSelected}
               testID={`${testID}-mark-${index}`}

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.stories.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.stories.tsx
@@ -1,0 +1,264 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { ScrollView, View } from "react-native";
+import { ScopedTheme, StyleSheet } from "react-native-unistyles";
+import { Text } from "../Text";
+import { StepDayGrid, type StepDayMark } from "./StepDayGrid";
+import { themes, themeNames, type ThemeName } from "../../themes/compose";
+
+const meta: Meta<typeof StepDayGrid> = {
+  title: "Set B & C/StepDayGrid",
+  component: StepDayGrid,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StepDayGrid>;
+
+/**
+ * The Direction D prototype's pinned instant — Wed 24 June 2026. Every story
+ * and test uses it so a reviewer can hold the prototype and Storybook side by
+ * side, and so "today" never drifts under the snapshots.
+ */
+const NOW = new Date(2026, 5, 24);
+
+/** Days the rest of the "Rewire the workshop" plan sits on. */
+const MARKS: StepDayMark[] = [
+  { date: "2026-06-26", label: "2" },
+  { date: "2026-06-30", label: "3" },
+  { date: "2026-06-30", label: "a" },
+  { date: "2026-06-30", label: "b" },
+  { date: "2026-07-02", label: "4" },
+];
+
+/**
+ * The grid is a controlled input, so every story owns the selection — that is
+ * also what makes tap-again-to-clear visible by hand.
+ */
+function LiveGrid({
+  initial = null,
+  marks,
+  locale,
+}: {
+  initial?: string | null;
+  marks?: StepDayMark[];
+  locale?: string;
+}) {
+  const [value, setValue] = useState<string | null>(initial);
+  return (
+    <View style={storyStyles.stack}>
+      <StepDayGrid
+        value={value}
+        now={NOW}
+        marks={marks}
+        locale={locale}
+        onChange={setValue}
+      />
+      <Text style={storyStyles.readout}>value: {value ?? "null"}</Text>
+    </View>
+  );
+}
+
+// R8 — the prototype's 344px phone width, matching the sibling stories.
+function PhoneWidth({ children }: { children: React.ReactNode }) {
+  return (
+    <View style={storyStyles.stage}>
+      <View style={storyStyles.frame}>{children}</View>
+    </View>
+  );
+}
+
+/** No day chosen. Today (Jun 24) carries the ring; nothing is filled. */
+export const Unset: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid />
+    </PhoneWidth>
+  ),
+};
+
+/** A future day selected. Tap it again to clear it. */
+export const DaySelected: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid initial="2026-06-30" />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * A past day selected — quieter, never refused. Jun 18 is six days before the
+ * pinned now; it selects, reads back, and clears exactly like any other day.
+ */
+export const PastDaySelected: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid initial="2026-06-18" />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * Marks from the rest of the plan. Jun 30 carries three, so it shows two
+ * ordinals plus the overflow badge.
+ */
+export const WithMarks: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid marks={MARKS} initial="2026-06-30" />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * November 2026 starts on a Sunday — the maximum six leading blanks in a
+ * Monday-first week.
+ */
+export const MonthStartingSunday: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid initial="2026-11-15" />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * Opens on December 2026. Tap `›` once to cross into January 2027 — month
+ * navigation is unbounded, so no day is ever out of reach.
+ */
+export const AcrossAYearBoundary: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid initial="2026-12-28" />
+    </PhoneWidth>
+  ),
+};
+
+/** German month and weekday names, proving the Intl path rather than an array. */
+export const GermanLocale: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveGrid initial="2026-06-30" marks={MARKS} locale="de" />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * #574's "confirm at `largeText` density" check, at the 344px phone width.
+ *
+ * `largeText` is a composable *variant*, not one of the seven registered
+ * product themes, and `ScopedTheme` only accepts registered names — so it
+ * cannot be rendered directly here. `light-lowVision` is the stand-in and it is
+ * an exact one for this purpose: it carries `size: sizeL`
+ * (`src/themes/variants.ts:128`), the same 1.25x scale `largeText` applies
+ * (`:96`). At that scale, confirm every day cell still clears 44pt and the
+ * digit columns do not jitter.
+ */
+export const LargeTextDensity: Story = {
+  render: () => (
+    <ScopedTheme name="light-lowVision">
+      <View
+        style={[
+          storyStyles.stage,
+          { backgroundColor: themes["light-lowVision"].colors.background },
+        ]}
+      >
+        <View style={storyStyles.frame}>
+          <LiveGrid initial="2026-06-30" marks={MARKS} />
+        </View>
+      </View>
+    </ScopedTheme>
+  ),
+};
+
+const MOOD_NAMES: Record<ThemeName, string> = {
+  "light-default": "Full Ride",
+  "dark-default": "Night Ride",
+  "light-highContrast": "Bold Ink",
+  "light-dyslexia": "Warm Studio",
+  "light-autismFriendly": "Still Water",
+  "light-lowVision": "Loud & Clear",
+  "light-lowInfo": "Clean Signal",
+};
+
+/**
+ * All 7 product themes, rendering the richest fixture (marks + a selected day)
+ * so each theme's fill, ring, badge ground and shadow are all visible.
+ */
+export const AllThemesMatrix: Story = {
+  render: () => (
+    <ScrollView contentContainerStyle={storyStyles.matrixContainer}>
+      {themeNames.map((name) => (
+        <View key={name} style={storyStyles.matrixThemeBlock}>
+          <View style={storyStyles.matrixThemeLabel}>
+            <Text style={storyStyles.matrixThemeName}>{MOOD_NAMES[name]}</Text>
+            <Text style={storyStyles.matrixThemeKey}>{name}</Text>
+          </View>
+          <ScopedTheme name={name}>
+            <View
+              style={[
+                storyStyles.matrixCard,
+                { backgroundColor: themes[name].colors.background },
+              ]}
+            >
+              <StepDayGrid
+                value="2026-06-30"
+                now={NOW}
+                marks={MARKS}
+                onChange={() => {}}
+              />
+            </View>
+          </ScopedTheme>
+        </View>
+      ))}
+    </ScrollView>
+  ),
+};
+
+const storyStyles = StyleSheet.create((theme) => ({
+  stage: {
+    alignItems: "center",
+    padding: theme.space[6],
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  frame: {
+    width: 344,
+    padding: theme.space[5],
+    backgroundColor: theme.colors.background,
+  },
+  stack: {
+    gap: theme.space[3],
+  },
+  readout: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+  },
+  matrixContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "flex-start",
+    padding: theme.space[4],
+    gap: theme.space[6],
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  matrixThemeBlock: {
+    gap: theme.space[2],
+  },
+  matrixThemeLabel: {
+    gap: theme.space[1],
+  },
+  matrixThemeName: {
+    fontWeight: theme.fontWeight.semibold,
+    color: theme.colors.text,
+  },
+  matrixThemeKey: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+  },
+  matrixCard: {
+    width: 344,
+    padding: theme.space[5],
+  },
+}));

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.styles.ts
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.styles.ts
@@ -26,23 +26,6 @@ export const styles = StyleSheet.create((theme) => ({
     fontSize: theme.size.sm,
     color: theme.colors.text,
   },
-  navButton: {
-    minWidth: DAY_CELL_MIN_SIZE,
-    minHeight: DAY_CELL_MIN_SIZE,
-    alignItems: "center",
-    justifyContent: "center",
-    borderWidth: theme.borderWidth.thick,
-    borderColor: theme.colors.border,
-    borderRadius: theme.radius.sm,
-    backgroundColor: theme.colors.backgroundSecondary,
-  },
-  navButtonPressed: {
-    backgroundColor: theme.colors.accentMint,
-  },
-  navGlyph: {
-    fontSize: theme.size.md,
-    color: theme.colors.text,
-  },
   // Seven equal columns, shared by the weekday header and the day grid.
   week: {
     flexDirection: "row",
@@ -89,6 +72,11 @@ export const styles = StyleSheet.create((theme) => ({
     color: theme.colors.text,
     // Keeps the digit columns from jittering between 1 and 11 (#574).
     fontVariant: ["tabular-nums"],
+    // The inherited body lineHeight (26) would eat most of the 44pt cell and
+    // shove the mark badges down. Tighten it to the digits.
+    lineHeight: theme.size.md,
+    textAlign: "center",
+    includeFontPadding: false,
   },
   // A past day reads *quieter*. It is never disabled and never refused (#574).
   dayNumberPast: {
@@ -122,6 +110,11 @@ export const styles = StyleSheet.create((theme) => ({
     fontSize: theme.size.xs,
     fontWeight: theme.fontWeight.bold,
     color: theme.colors.accentMintFg,
+    // See StepTimingEditor's ordinalLabel: the inherited body lineHeight (26)
+    // overflows a badge this small and pushes the glyph off centre.
+    lineHeight: theme.size.xs,
+    textAlign: "center",
+    includeFontPadding: false,
   },
   markLabelOnSelected: {
     color: theme.colors.text,

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.styles.ts
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.styles.ts
@@ -1,0 +1,134 @@
+import { StyleSheet } from "react-native-unistyles";
+import { shadowStyle } from "../../styles/shadows";
+
+/**
+ * a11y floor for every touch target on the grid. The prototype's day cell is
+ * 40px; 44 is the project minimum and wins. Seven columns on a 360dp screen
+ * leaves ~48dp per column, so the width fits without horizontal scroll (#574).
+ */
+export const DAY_CELL_MIN_SIZE = 44;
+
+export const styles = StyleSheet.create((theme) => ({
+  container: {
+    gap: theme.space[2],
+  },
+  // Month header: ‹ | June 2026 | ›
+  monthRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.space[2],
+  },
+  monthLabel: {
+    flex: 1,
+    textAlign: "center",
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.sm,
+    color: theme.colors.text,
+  },
+  navButton: {
+    minWidth: DAY_CELL_MIN_SIZE,
+    minHeight: DAY_CELL_MIN_SIZE,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  navButtonPressed: {
+    backgroundColor: theme.colors.accentMint,
+  },
+  navGlyph: {
+    fontSize: theme.size.md,
+    color: theme.colors.text,
+  },
+  // Seven equal columns, shared by the weekday header and the day grid.
+  week: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  cell: {
+    // 1/7th of the row. `flexBasis` percentage keeps the columns equal without
+    // measuring, so the grid reflows with the container at any text scale.
+    flexBasis: `${100 / 7}%`,
+  },
+  weekdayLabel: {
+    textAlign: "center",
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+    letterSpacing: theme.letterSpacing.wide,
+    paddingVertical: theme.space[1],
+  },
+  day: {
+    minHeight: DAY_CELL_MIN_SIZE,
+    alignItems: "center",
+    justifyContent: "flex-start",
+    paddingTop: theme.space[1],
+    paddingBottom: theme.space[1],
+    borderWidth: theme.borderWidth.thick,
+    // Reserved ring: today swaps this for a visible border, so a day cell never
+    // changes size when it becomes today.
+    borderColor: theme.colors.transparent,
+    borderRadius: theme.radius.sm,
+  },
+  dayToday: {
+    borderColor: theme.colors.border,
+  },
+  daySelected: {
+    backgroundColor: theme.colors.accentPrimary,
+    borderColor: theme.colors.border,
+    ...shadowStyle(theme, "cardElevationSmall"),
+  },
+  dayPressed: {
+    backgroundColor: theme.colors.backgroundTertiary,
+  },
+  dayNumber: {
+    fontSize: theme.size.sm,
+    color: theme.colors.text,
+    // Keeps the digit columns from jittering between 1 and 11 (#574).
+    fontVariant: ["tabular-nums"],
+  },
+  // A past day reads *quieter*. It is never disabled and never refused (#574).
+  dayNumberPast: {
+    color: theme.colors.textMuted,
+  },
+  dayNumberSelected: {
+    color: theme.colors.background,
+    fontWeight: theme.fontWeight.bold,
+  },
+  marksRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: theme.space[1],
+    marginTop: theme.space[1],
+  },
+  mark: {
+    minWidth: theme.space[4],
+    paddingHorizontal: theme.space[1],
+    borderWidth: theme.borderWidth.thin,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.accentMint,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // The badge sits on the selected day's filled ground, so it needs its own.
+  markOnSelected: {
+    backgroundColor: theme.colors.background,
+  },
+  markLabel: {
+    fontSize: theme.size.xs,
+    fontWeight: theme.fontWeight.bold,
+    color: theme.colors.accentMintFg,
+  },
+  markLabelOnSelected: {
+    color: theme.colors.text,
+  },
+  legend: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+  },
+}));

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.styles.ts
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.styles.ts
@@ -92,9 +92,11 @@ export const styles = StyleSheet.create((theme) => ({
     gap: theme.space[1],
     marginTop: theme.space[1],
   },
+  // Same circle rule as the editor's ordinal badge: minWidth === height, no
+  // horizontal padding, so a single ordinal is round rather than oval.
   mark: {
     minWidth: theme.space[4],
-    paddingHorizontal: theme.space[1],
+    height: theme.space[4],
     borderWidth: theme.borderWidth.thin,
     borderColor: theme.colors.border,
     borderRadius: theme.radius.full,

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.tsx
@@ -11,6 +11,7 @@ import {
   groupMarksByDay,
   isPastDay,
   leadingBlanks,
+  localDate,
   shiftMonth,
   toDayKey,
   type GridMonth,
@@ -134,7 +135,7 @@ function StepDayGridComponent({
       new Intl.DateTimeFormat(locale, {
         month: "long",
         year: "numeric",
-      }).format(new Date(view.year, view.month, 1)),
+      }).format(localDate(view.year, view.month, 1)),
     [locale, view.year, view.month],
   );
 
@@ -142,9 +143,9 @@ function StepDayGridComponent({
   // grid in every locale — never a hand-written weekday array (#574).
   const weekdayLabels = useMemo(() => {
     const format = new Intl.DateTimeFormat(locale, { weekday: "narrow" });
-    // 22 June 2026 is a Monday; Date rolls the month over past the 30th.
+    // 22 June 2026 is a Monday; the day rolls the month over past the 30th.
     return Array.from({ length: 7 }, (_, i) =>
-      format.format(new Date(2026, 5, 22 + i)),
+      format.format(localDate(2026, 5, 22 + i)),
     );
   }, [locale]);
 
@@ -226,7 +227,7 @@ function StepDayGridComponent({
               <DayCell
                 day={day}
                 a11yLabel={
-                  dayA11yFormat.format(new Date(view.year, view.month, day)) +
+                  dayA11yFormat.format(localDate(view.year, view.month, day)) +
                   a11ySuffix
                 }
                 isSelected={isSelected}

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
+import { CaretLeft, CaretRight } from "phosphor-react-native";
 import { Text } from "../Text";
+import { IconButton } from "../IconButton";
 import { DayCell } from "./StepDayGrid.parts";
 import { styles } from "./StepDayGrid.styles";
 import {
@@ -52,9 +54,6 @@ export interface StepDayGridProps {
   testID?: string;
 }
 
-/** A Monday, used to generate localised weekday headers in the right order. */
-const A_KNOWN_MONDAY = new Date(2026, 5, 22);
-
 const defaultMarksA11ySuffix = (count: number) =>
   count === 1 ? "1 other step here" : `${count} other steps here`;
 
@@ -91,8 +90,13 @@ function sameMonth(a: GridMonth, b: GridMonth): boolean {
  * of the plan on the calendar you pick from — the reason in-list dating beats a
  * sheet — is impossible; (4) Storybook web is one of our review surfaces and its
  * web support is untested here.
+ *
+ * Exported memoised: inside `StepTimingEditor` this re-renders whenever the
+ * dependency picker moves, which changes nothing the grid reads. Callers must
+ * keep `onChange` stable (`useCallback`) and must not pass `now={new Date()}`
+ * inline, or the memo misses every time.
  */
-export function StepDayGrid({
+function StepDayGridComponent({
   value,
   now,
   marks,
@@ -138,14 +142,9 @@ export function StepDayGrid({
   // grid in every locale — never a hand-written weekday array (#574).
   const weekdayLabels = useMemo(() => {
     const format = new Intl.DateTimeFormat(locale, { weekday: "narrow" });
+    // 22 June 2026 is a Monday; Date rolls the month over past the 30th.
     return Array.from({ length: 7 }, (_, i) =>
-      format.format(
-        new Date(
-          A_KNOWN_MONDAY.getFullYear(),
-          A_KNOWN_MONDAY.getMonth(),
-          A_KNOWN_MONDAY.getDate() + i,
-        ),
-      ),
+      format.format(new Date(2026, 5, 22 + i)),
     );
   }, [locale]);
 
@@ -166,35 +165,27 @@ export function StepDayGrid({
   return (
     <View style={styles.container} testID={testID}>
       <View style={styles.monthRow}>
-        <Pressable
-          accessibilityRole="button"
+        {/* IconButton, not bespoke Pressables: it is already 44pt at `md` and
+            tones the Phosphor icon per theme via resolveIconColor. */}
+        <IconButton
+          icon={<CaretLeft weight="bold" />}
+          tone="surface"
           accessibilityLabel={previousMonthLabel}
           testID={`${testID}-prev`}
           onPress={() => setView((current) => shiftMonth(current, -1))}
-          style={({ pressed }) => [
-            styles.navButton,
-            pressed && styles.navButtonPressed,
-          ]}
-        >
-          <Text style={styles.navGlyph}>‹</Text>
-        </Pressable>
+        />
 
         <Text style={styles.monthLabel} testID={`${testID}-month-label`}>
           {monthLabel}
         </Text>
 
-        <Pressable
-          accessibilityRole="button"
+        <IconButton
+          icon={<CaretRight weight="bold" />}
+          tone="surface"
           accessibilityLabel={nextMonthLabel}
           testID={`${testID}-next`}
           onPress={() => setView((current) => shiftMonth(current, 1))}
-          style={({ pressed }) => [
-            styles.navButton,
-            pressed && styles.navButtonPressed,
-          ]}
-        >
-          <Text style={styles.navGlyph}>›</Text>
-        </Pressable>
+        />
       </View>
 
       <View style={styles.week}>
@@ -234,7 +225,6 @@ export function StepDayGrid({
             <View key={key} style={styles.cell}>
               <DayCell
                 day={day}
-                dayKey={key}
                 a11yLabel={
                   dayA11yFormat.format(new Date(view.year, view.month, day)) +
                   a11ySuffix
@@ -257,3 +247,5 @@ export function StepDayGrid({
     </View>
   );
 }
+
+export const StepDayGrid = React.memo(StepDayGridComponent);

--- a/apps/native-rd/src/components/StepDayGrid/StepDayGrid.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/StepDayGrid.tsx
@@ -1,0 +1,259 @@
+import React, { useMemo, useState } from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "../Text";
+import { DayCell } from "./StepDayGrid.parts";
+import { styles } from "./StepDayGrid.styles";
+import {
+  dayKey,
+  daysInMonth,
+  groupMarksByDay,
+  isPastDay,
+  leadingBlanks,
+  shiftMonth,
+  toDayKey,
+  type GridMonth,
+} from "./monthGrid";
+
+/** A day another step already sits on, with its list ordinal ("1", "2", "a"). */
+export interface StepDayMark {
+  /** `YYYY-MM-DD`. */
+  date: string;
+  /** The other step's ordinal badge text. Caller-assigned. */
+  label: string;
+}
+
+export interface StepDayGridProps {
+  /** Selected day as `YYYY-MM-DD`, or null for no day. */
+  value: string | null;
+  /**
+   * Required. Never read the clock inside this component — the same convention
+   * `resolveStepDependencyBand` follows (`src/db/queries.ts`), so stories and
+   * tests pin a fixed instant. Drives today's ring and the past-day quieting,
+   * and nothing else.
+   */
+  now: Date;
+  /** Days other steps sit on. Two badges render per day, then an overflow badge. */
+  marks?: readonly StepDayMark[];
+  /** Fires with the tapped day, or `null` when the selected day is tapped again. */
+  onChange: (next: string | null) => void;
+  /** BCP-47 tag for month + weekday names — pass `i18n.language` from the caller. */
+  locale?: string;
+
+  // --- Copy: caller-supplied with English defaults (the D7 convention). ---
+  /** a11y label for the previous-month control. */
+  previousMonthLabel?: string;
+  /** a11y label for the next-month control. */
+  nextMonthLabel?: string;
+  /** Quiet caption under the grid. */
+  legendLabel?: string;
+  /** Appended to a day's a11y label when other steps sit there. */
+  marksA11ySuffix?: (count: number) => string;
+  /** testID root; day cells get `${testID}-day-${iso}`. */
+  testID?: string;
+}
+
+/** A Monday, used to generate localised weekday headers in the right order. */
+const A_KNOWN_MONDAY = new Date(2026, 5, 22);
+
+const defaultMarksA11ySuffix = (count: number) =>
+  count === 1 ? "1 other step here" : `${count} other steps here`;
+
+/** The month a `YYYY-MM-DD` key falls in. */
+function monthOfKey(key: string): GridMonth {
+  return { year: Number(key.slice(0, 4)), month: Number(key.slice(5, 7)) - 1 };
+}
+
+function sameMonth(a: GridMonth, b: GridMonth): boolean {
+  return a.year === b.year && a.month === b.month;
+}
+
+/**
+ * A themed month grid — the only way a day gets named in this app, so **every**
+ * day has to be reachable (#574).
+ *
+ * Month navigation is unbounded in both directions, weeks start Monday, and no
+ * day is ever disabled: past days read quieter but stay selectable, because
+ * both the `was expected` reading (#571) and an ordinary "I meant last Tuesday"
+ * depend on it. Guards inform; they never refuse (ADR-0010/0012).
+ *
+ * Emits plain `YYYY-MM-DD`. Converting to a branded `DateIso` at local midnight
+ * is the **caller's** job (#576) — a due date is a *day*, `DateIso` is a
+ * timestamp.
+ *
+ * **Recurrence** would attach next to the month header. Nothing is built for it
+ * (#574 is explicit: note where it goes, build nothing).
+ *
+ * **Why not `@react-native-community/datetimepicker`**, which is installed and
+ * unused: (1) it is an OS component and cannot honour the seven theme variants,
+ * so the `AllThemesMatrix` acceptance would be unsatisfiable; (2) on Android it
+ * is a modal dialog, and the whole point of #573's redesign is that authoring
+ * stops happening in a modal; (3) it has no `marks` concept, so seeing the rest
+ * of the plan on the calendar you pick from — the reason in-list dating beats a
+ * sheet — is impossible; (4) Storybook web is one of our review surfaces and its
+ * web support is untested here.
+ */
+export function StepDayGrid({
+  value,
+  now,
+  marks,
+  onChange,
+  locale,
+  previousMonthLabel = "Previous month",
+  nextMonthLabel = "Next month",
+  legendLabel = "badges mark days your other steps sit on",
+  marksA11ySuffix = defaultMarksA11ySuffix,
+  testID = "step-day-grid",
+}: StepDayGridProps) {
+  const [view, setView] = useState<GridMonth>(() =>
+    monthOfKey(value ?? toDayKey(now)),
+  );
+
+  // Re-anchor on a caller-driven value change, during render rather than in an
+  // effect (React's "adjusting state when a prop changes" pattern) — an effect
+  // here would paint the wrong month for one frame. Tracking the last `value`
+  // we reacted to keeps manual month navigation sticky: navigating away from
+  // the selected day's month must not snap back on the next render.
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    if (value) {
+      const target = monthOfKey(value);
+      if (!sameMonth(target, view)) setView(target);
+    }
+  }
+
+  const nowKey = toDayKey(now);
+  const marksByDay = useMemo(() => groupMarksByDay(marks ?? []), [marks]);
+
+  const monthLabel = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: "long",
+        year: "numeric",
+      }).format(new Date(view.year, view.month, 1)),
+    [locale, view.year, view.month],
+  );
+
+  // Generated from a known Monday so the header order matches the Monday-first
+  // grid in every locale — never a hand-written weekday array (#574).
+  const weekdayLabels = useMemo(() => {
+    const format = new Intl.DateTimeFormat(locale, { weekday: "narrow" });
+    return Array.from({ length: 7 }, (_, i) =>
+      format.format(
+        new Date(
+          A_KNOWN_MONDAY.getFullYear(),
+          A_KNOWN_MONDAY.getMonth(),
+          A_KNOWN_MONDAY.getDate() + i,
+        ),
+      ),
+    );
+  }, [locale]);
+
+  const dayA11yFormat = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      }),
+    [locale],
+  );
+
+  const blanks = leadingBlanks(view.year, view.month);
+  const dayCount = daysInMonth(view.year, view.month);
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <View style={styles.monthRow}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={previousMonthLabel}
+          testID={`${testID}-prev`}
+          onPress={() => setView((current) => shiftMonth(current, -1))}
+          style={({ pressed }) => [
+            styles.navButton,
+            pressed && styles.navButtonPressed,
+          ]}
+        >
+          <Text style={styles.navGlyph}>‹</Text>
+        </Pressable>
+
+        <Text style={styles.monthLabel} testID={`${testID}-month-label`}>
+          {monthLabel}
+        </Text>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={nextMonthLabel}
+          testID={`${testID}-next`}
+          onPress={() => setView((current) => shiftMonth(current, 1))}
+          style={({ pressed }) => [
+            styles.navButton,
+            pressed && styles.navButtonPressed,
+          ]}
+        >
+          <Text style={styles.navGlyph}>›</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.week}>
+        {weekdayLabels.map((label, index) => (
+          <View
+            // Weekday initials repeat within a week (T/T, S/S), so the index is
+            // the only stable key here.
+            key={`weekday-${index}`}
+            style={styles.cell}
+            importantForAccessibility="no-hide-descendants"
+          >
+            <Text style={styles.weekdayLabel}>{label}</Text>
+          </View>
+        ))}
+      </View>
+
+      <View style={styles.week} testID={`${testID}-days`}>
+        {Array.from({ length: blanks }, (_, index) => (
+          <View
+            key={`blank-${index}`}
+            testID={`${testID}-blank-${index}`}
+            style={styles.cell}
+            importantForAccessibility="no-hide-descendants"
+          />
+        ))}
+
+        {Array.from({ length: dayCount }, (_, index) => {
+          const day = index + 1;
+          const key = dayKey(view.year, view.month, day);
+          const isSelected = key === value;
+          const dayMarks = marksByDay[key] ?? [];
+          const a11ySuffix = dayMarks.length
+            ? `, ${marksA11ySuffix(dayMarks.length)}`
+            : "";
+
+          return (
+            <View key={key} style={styles.cell}>
+              <DayCell
+                day={day}
+                dayKey={key}
+                a11yLabel={
+                  dayA11yFormat.format(new Date(view.year, view.month, day)) +
+                  a11ySuffix
+                }
+                isSelected={isSelected}
+                isToday={key === nowKey}
+                isPast={isPastDay(key, nowKey)}
+                marks={dayMarks}
+                // Tapping the selected day again clears it — the same
+                // tap-again-to-clear the prototype's `pickExp` had.
+                onPress={() => onChange(isSelected ? null : key)}
+                testID={`${testID}-day-${key}`}
+              />
+            </View>
+          );
+        })}
+      </View>
+
+      <Text style={styles.legend}>{legendLabel}</Text>
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/StepDayGrid/__tests__/StepDayGrid.test.tsx
+++ b/apps/native-rd/src/components/StepDayGrid/__tests__/StepDayGrid.test.tsx
@@ -1,0 +1,201 @@
+import React from "react";
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from "../../../__tests__/test-utils";
+import { StepDayGrid, type StepDayMark } from "../StepDayGrid";
+
+// The prototype's pinned instant — Wed 24 June 2026. Never `new Date()`: the
+// grid's today-ring and past-day quieting are both derived from `now`.
+const NOW = new Date(2026, 5, 24);
+
+const baseProps = {
+  value: null,
+  now: NOW,
+  onChange: jest.fn(),
+};
+
+const day = (iso: string) => screen.getByTestId(`step-day-grid-day-${iso}`);
+
+describe("StepDayGrid selection", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("fires onChange with the tapped day", () => {
+    const onChange = jest.fn();
+    renderWithProviders(<StepDayGrid {...baseProps} onChange={onChange} />);
+
+    fireEvent.press(day("2026-06-30"));
+    expect(onChange).toHaveBeenCalledWith("2026-06-30");
+  });
+
+  it("clears when the selected day is tapped again", () => {
+    const onChange = jest.fn();
+    renderWithProviders(
+      <StepDayGrid {...baseProps} value="2026-06-30" onChange={onChange} />,
+    );
+
+    fireEvent.press(day("2026-06-30"));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("marks the selected day as selected, and only that day", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} value="2026-06-30" />);
+
+    expect(day("2026-06-30").props.accessibilityState.selected).toBe(true);
+    expect(day("2026-06-29").props.accessibilityState.selected).toBe(false);
+  });
+
+  // The "never refused" contract: past days are the whole reason `was expected`
+  // (#571) and "I meant last Tuesday" work at all.
+  it("still fires onChange for a past day", () => {
+    const onChange = jest.fn();
+    renderWithProviders(<StepDayGrid {...baseProps} onChange={onChange} />);
+
+    fireEvent.press(day("2026-06-01"));
+    expect(onChange).toHaveBeenCalledWith("2026-06-01");
+  });
+
+  it("never disables a day cell", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} />);
+
+    for (let d = 1; d <= 30; d += 1) {
+      const iso = `2026-06-${String(d).padStart(2, "0")}`;
+      const cell = day(iso);
+      expect(cell.props.accessibilityState?.disabled).toBeFalsy();
+      expect(cell.props.disabled).toBeFalsy();
+    }
+  });
+});
+
+describe("StepDayGrid month navigation", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("opens on the selected day's month, not on now's", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} value="2026-11-15" />);
+    expect(screen.getByTestId("step-day-grid-month-label")).toHaveTextContent(
+      "November 2026",
+    );
+  });
+
+  it("reaches the same month a year on after twelve forward taps", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} />);
+    const next = screen.getByTestId("step-day-grid-next");
+
+    for (let i = 0; i < 12; i += 1) fireEvent.press(next);
+
+    expect(screen.getByTestId("step-day-grid-month-label")).toHaveTextContent(
+      "June 2027",
+    );
+  });
+
+  it("navigates backwards across the year boundary", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} value="2026-01-10" />);
+    fireEvent.press(screen.getByTestId("step-day-grid-prev"));
+
+    expect(screen.getByTestId("step-day-grid-month-label")).toHaveTextContent(
+      "December 2025",
+    );
+  });
+
+  it("keeps a day reachable in a month far from now", () => {
+    const onChange = jest.fn();
+    renderWithProviders(<StepDayGrid {...baseProps} onChange={onChange} />);
+
+    for (let i = 0; i < 12; i += 1)
+      fireEvent.press(screen.getByTestId("step-day-grid-next"));
+    fireEvent.press(day("2027-06-15"));
+
+    expect(onChange).toHaveBeenCalledWith("2027-06-15");
+  });
+});
+
+describe("StepDayGrid leading blanks (Monday-first)", () => {
+  test.each([
+    ["2026-11-15", "November 2026 starts on a Sunday", 6],
+    ["2026-06-15", "June 2026 starts on a Monday", 0],
+    ["2026-08-15", "August 2026 starts on a Saturday", 5],
+  ])("%s (%s) renders %i blanks", (value, _why, expected) => {
+    renderWithProviders(<StepDayGrid {...baseProps} value={value} />);
+    // Blanks are hidden from the a11y tree, so they need the hidden-element
+    // query — that they are hidden is itself part of the contract.
+    expect(
+      screen.queryAllByTestId(/^step-day-grid-blank-/, {
+        includeHiddenElements: true,
+      }),
+    ).toHaveLength(expected);
+  });
+});
+
+describe("StepDayGrid marks", () => {
+  const marks: StepDayMark[] = [
+    { date: "2026-06-30", label: "3" },
+    { date: "2026-06-30", label: "a" },
+    { date: "2026-06-30", label: "b" },
+    { date: "2026-06-26", label: "2" },
+  ];
+
+  it("renders two ordinal badges plus one overflow badge for three marks", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} marks={marks} />);
+    const badge = (suffix: string) =>
+      screen.getByTestId(`step-day-grid-day-2026-06-30-${suffix}`);
+
+    // First two ordinals shown in order; the third collapses into the overflow
+    // badge rather than adding a third — the cell is 44pt wide, not a list.
+    expect(badge("mark-0")).toHaveTextContent("3");
+    expect(badge("mark-1")).toHaveTextContent("a");
+    expect(
+      screen.queryByTestId("step-day-grid-day-2026-06-30-mark-2"),
+    ).toBeNull();
+    expect(badge("overflow")).toHaveTextContent("+");
+  });
+
+  it("omits the overflow badge when a day carries one mark", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} marks={marks} />);
+    expect(
+      screen.queryByTestId("step-day-grid-day-2026-06-26-overflow"),
+    ).toBeNull();
+  });
+
+  test.each([
+    ["2026-06-26", "1 other step here"],
+    ["2026-06-30", "3 other steps here"],
+  ])("names the other steps on %s in its a11y label", (iso, suffix) => {
+    renderWithProviders(<StepDayGrid {...baseProps} marks={marks} />);
+    expect(day(iso).props.accessibilityLabel).toContain(suffix);
+  });
+
+  it("leaves an unmarked day's a11y label free of the suffix", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} marks={marks} />);
+    expect(day("2026-06-27").props.accessibilityLabel).not.toContain(
+      "other step",
+    );
+  });
+});
+
+describe("StepDayGrid a11y and localisation", () => {
+  it("gives every day a button role and a full-date label", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} />);
+    const cell = day("2026-06-24");
+
+    expect(cell.props.accessibilityRole).toBe("button");
+    expect(cell.props.accessibilityLabel).toContain("June");
+    expect(cell.props.accessibilityLabel).toContain("2026");
+    expect(cell.props.accessibilityLabel).toContain("24");
+  });
+
+  it("labels both month nav controls", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} />);
+
+    expect(screen.getByLabelText("Previous month")).toBeOnTheScreen();
+    expect(screen.getByLabelText("Next month")).toBeOnTheScreen();
+  });
+
+  // Guards the Intl path against a regression to a hand-written month array.
+  it("renders month names in the passed locale", () => {
+    renderWithProviders(<StepDayGrid {...baseProps} locale="de" />);
+    expect(screen.getByTestId("step-day-grid-month-label")).toHaveTextContent(
+      "Juni 2026",
+    );
+  });
+});

--- a/apps/native-rd/src/components/StepDayGrid/__tests__/monthGrid.test.ts
+++ b/apps/native-rd/src/components/StepDayGrid/__tests__/monthGrid.test.ts
@@ -4,6 +4,7 @@ import {
   groupMarksByDay,
   isPastDay,
   leadingBlanks,
+  localDate,
   shiftMonth,
   toDayKey,
 } from "../monthGrid";
@@ -23,6 +24,29 @@ describe("dayKey / toDayKey", () => {
     expect(toDayKey(new Date(2026, 5, 24))).toBe("2026-06-24");
     // Late-evening local time must still report the same day.
     expect(toDayKey(new Date(2026, 5, 24, 23, 30))).toBe("2026-06-24");
+  });
+});
+
+describe("localDate", () => {
+  it("takes a year literally — 0–99 is not 1900–1999", () => {
+    // `new Date(50, 0, 1)` is 1950. Month navigation is unbounded, so a
+    // two-digit year is reachable and must stay itself.
+    expect(localDate(50, 0, 1).getFullYear()).toBe(50);
+    expect(localDate(99, 11, 31).getFullYear()).toBe(99);
+  });
+
+  it("is local midnight, not UTC", () => {
+    const date = localDate(2026, 5, 24);
+    expect(toDayKey(date)).toBe("2026-06-24");
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+  });
+
+  it("rolls an out-of-range month or day over, as Date does", () => {
+    expect(toDayKey(localDate(2026, 12, 1))).toBe("2027-01-01");
+    expect(toDayKey(localDate(2026, -1, 1))).toBe("2025-12-01");
+    // Day 0 is the last day of the previous month — what daysInMonth relies on.
+    expect(toDayKey(localDate(2026, 6, 0))).toBe("2026-06-30");
   });
 });
 
@@ -63,6 +87,13 @@ describe("shiftMonth", () => {
   it("wraps January → December, carrying the year back", () => {
     expect(shiftMonth({ year: 2026, month: 0 }, -1)).toEqual({
       year: 2025,
+      month: 11,
+    });
+  });
+
+  it("keeps a two-digit year in its own century", () => {
+    expect(shiftMonth({ year: 99, month: 0 }, -1)).toEqual({
+      year: 98,
       month: 11,
     });
   });

--- a/apps/native-rd/src/components/StepDayGrid/__tests__/monthGrid.test.ts
+++ b/apps/native-rd/src/components/StepDayGrid/__tests__/monthGrid.test.ts
@@ -1,0 +1,107 @@
+import {
+  dayKey,
+  daysInMonth,
+  groupMarksByDay,
+  isPastDay,
+  leadingBlanks,
+  shiftMonth,
+  toDayKey,
+} from "../monthGrid";
+
+// The prototype's pinned instant — Wed 24 June 2026.
+const NOW_KEY = "2026-06-24";
+
+describe("dayKey / toDayKey", () => {
+  it("zero-pads month and day and 1-indexes the month", () => {
+    expect(dayKey(2026, 0, 5)).toBe("2026-01-05");
+    expect(dayKey(2026, 11, 31)).toBe("2026-12-31");
+  });
+
+  it("reads the local calendar day off a Date, not the UTC one", () => {
+    // Constructed local-midnight; a UTC-based reading would shift the day for
+    // anyone west of UTC.
+    expect(toDayKey(new Date(2026, 5, 24))).toBe("2026-06-24");
+    // Late-evening local time must still report the same day.
+    expect(toDayKey(new Date(2026, 5, 24, 23, 30))).toBe("2026-06-24");
+  });
+});
+
+describe("leadingBlanks (Monday-first)", () => {
+  test.each([
+    // [year, month (0-indexed), weekday of the 1st, expected blanks]
+    [2026, 10, "Sunday", 6], // Nov 2026 starts on a Sunday — the max
+    [2026, 5, "Monday", 0], // Jun 2026 starts on a Monday — the min
+    [2026, 8, "Tuesday", 1], // Sep 2026
+    [2026, 6, "Wednesday", 2], // Jul 2026
+    [2027, 3, "Thursday", 3], // Apr 2027
+    [2026, 4, "Friday", 4], // May 2026
+    [2026, 7, "Saturday", 5], // Aug 2026
+  ])("%i-%i (1st is a %s) → %i blanks", (year, month, _weekday, expected) => {
+    expect(leadingBlanks(year, month)).toBe(expected);
+  });
+});
+
+describe("daysInMonth", () => {
+  test.each([
+    [2026, 1, 28], // Feb 2026 — common year
+    [2028, 1, 29], // Feb 2028 — leap year
+    [2026, 3, 30], // Apr
+    [2026, 6, 31], // Jul
+  ])("%i-%i → %i days", (year, month, expected) => {
+    expect(daysInMonth(year, month)).toBe(expected);
+  });
+});
+
+describe("shiftMonth", () => {
+  it("wraps December → January, carrying the year", () => {
+    expect(shiftMonth({ year: 2026, month: 11 }, 1)).toEqual({
+      year: 2027,
+      month: 0,
+    });
+  });
+
+  it("wraps January → December, carrying the year back", () => {
+    expect(shiftMonth({ year: 2026, month: 0 }, -1)).toEqual({
+      year: 2025,
+      month: 11,
+    });
+  });
+
+  it("is unbounded — twelve steps forward is the same month a year on", () => {
+    let month = { year: 2026, month: 5 };
+    for (let i = 0; i < 12; i += 1) month = shiftMonth(month, 1);
+    expect(month).toEqual({ year: 2027, month: 5 });
+  });
+});
+
+describe("isPastDay", () => {
+  test.each([
+    ["2026-06-23", true, "the day before now"],
+    ["2026-06-24", false, "now itself — strict <, so today is not past"],
+    ["2026-06-25", false, "the day after now"],
+    ["2025-12-31", true, "a previous year"],
+    ["2027-01-01", false, "a later year"],
+  ])("%s → %s (%s)", (key, expected) => {
+    expect(isPastDay(key, NOW_KEY)).toBe(expected);
+  });
+});
+
+describe("groupMarksByDay", () => {
+  it("groups labels by day, preserving input order", () => {
+    expect(
+      groupMarksByDay([
+        { date: "2026-06-30", label: "3" },
+        { date: "2026-06-26", label: "2" },
+        { date: "2026-06-30", label: "a" },
+        { date: "2026-06-30", label: "b" },
+      ]),
+    ).toEqual({
+      "2026-06-30": ["3", "a", "b"],
+      "2026-06-26": ["2"],
+    });
+  });
+
+  it("returns an empty map for no marks", () => {
+    expect(groupMarksByDay([])).toEqual({});
+  });
+});

--- a/apps/native-rd/src/components/StepDayGrid/index.ts
+++ b/apps/native-rd/src/components/StepDayGrid/index.ts
@@ -1,4 +1,10 @@
 export {
+  StepDayGrid,
+  type StepDayGridProps,
+  type StepDayMark,
+} from "./StepDayGrid";
+export { DAY_CELL_MIN_SIZE } from "./StepDayGrid.styles";
+export {
   dayKey,
   daysInMonth,
   groupMarksByDay,

--- a/apps/native-rd/src/components/StepDayGrid/index.ts
+++ b/apps/native-rd/src/components/StepDayGrid/index.ts
@@ -1,0 +1,10 @@
+export {
+  dayKey,
+  daysInMonth,
+  groupMarksByDay,
+  isPastDay,
+  leadingBlanks,
+  shiftMonth,
+  toDayKey,
+  type GridMonth,
+} from "./monthGrid";

--- a/apps/native-rd/src/components/StepDayGrid/index.ts
+++ b/apps/native-rd/src/components/StepDayGrid/index.ts
@@ -3,14 +3,3 @@ export {
   type StepDayGridProps,
   type StepDayMark,
 } from "./StepDayGrid";
-export { DAY_CELL_MIN_SIZE } from "./StepDayGrid.styles";
-export {
-  dayKey,
-  daysInMonth,
-  groupMarksByDay,
-  isPastDay,
-  leadingBlanks,
-  shiftMonth,
-  toDayKey,
-  type GridMonth,
-} from "./monthGrid";

--- a/apps/native-rd/src/components/StepDayGrid/monthGrid.ts
+++ b/apps/native-rd/src/components/StepDayGrid/monthGrid.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure date helpers behind `StepDayGrid` (#574).
+ *
+ * Every function here works on **local** calendar days and plain
+ * `YYYY-MM-DD` strings. Nothing parses an ISO string with `new Date(str)` and
+ * nothing touches UTC: `Date.parse("2026-06-24")` is UTC midnight, so comparing
+ * it against a local `now` flips sign for anyone east of UTC on the boundary
+ * day. The grid is day-granular, so the comparison is day-granular too —
+ * zero-padded `YYYY-MM-DD` sorts lexicographically in true chronological order.
+ *
+ * The month-shape maths is ported verbatim from the Direction D prototype
+ * (`prototypes/screen-redesign/Set BC D Prototype.html`).
+ */
+
+/** A month the grid can display. `month` is 0-indexed, as `Date` has it. */
+export interface GridMonth {
+  year: number;
+  month: number;
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** Build a `YYYY-MM-DD` key from local calendar parts (`month` 0-indexed). */
+export function dayKey(year: number, month: number, day: number): string {
+  return `${year}-${pad2(month + 1)}-${pad2(day)}`;
+}
+
+/** The local calendar day a `Date` falls on, as `YYYY-MM-DD`. */
+export function toDayKey(date: Date): string {
+  return dayKey(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
+ * Blank cells before the 1st in a **Monday-first** week.
+ * `getDay()` is Sunday-0, so `(d + 6) % 7` rotates Monday to 0 — a month whose
+ * 1st is a Sunday yields 6, a Monday-1st month yields 0.
+ */
+export function leadingBlanks(year: number, month: number): number {
+  return (new Date(year, month, 1).getDay() + 6) % 7;
+}
+
+/** Day count in a month. Day 0 of the next month is the last of this one. */
+export function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/** Step the displayed month by `delta`. Unbounded — wraps the year both ways. */
+export function shiftMonth(current: GridMonth, delta: number): GridMonth {
+  const next = new Date(current.year, current.month + delta, 1);
+  return { year: next.getFullYear(), month: next.getMonth() };
+}
+
+/**
+ * Strictly before today. Equal to today is **not** past — the same strict `<`
+ * `waitingOnExpectedIsPast` uses (#571), and the prototype's `key < TODAY_ISO`.
+ *
+ * A past day only ever reads *quieter*. It is never disabled and never refused:
+ * the `was expected` reading from #571 and an ordinary "I meant last Tuesday"
+ * both depend on past days staying selectable (#574).
+ */
+export function isPastDay(key: string, nowKey: string): boolean {
+  return key < nowKey;
+}
+
+/** Group mark labels by day, preserving input order within each day. */
+export function groupMarksByDay(
+  marks: readonly { date: string; label: string }[],
+): Record<string, string[]> {
+  const byDay: Record<string, string[]> = {};
+  for (const mark of marks) {
+    (byDay[mark.date] ??= []).push(mark.label);
+  }
+  return byDay;
+}

--- a/apps/native-rd/src/components/StepDayGrid/monthGrid.ts
+++ b/apps/native-rd/src/components/StepDayGrid/monthGrid.ts
@@ -33,22 +33,38 @@ export function toDayKey(date: Date): string {
 }
 
 /**
+ * Local midnight on a calendar day (`month` 0-indexed, both `month` and `day`
+ * may be out of range and roll over as `Date` does).
+ *
+ * Never `new Date(year, month, day)`: that constructor maps years 0–99 to
+ * 1900–1999, so navigation into a two-digit year would silently jump nineteen
+ * centuries — and month navigation here is unbounded, so that year is
+ * reachable. `setFullYear` takes the year literally.
+ */
+export function localDate(year: number, month: number, day = 1): Date {
+  const date = new Date(0);
+  date.setFullYear(year, month, day);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+/**
  * Blank cells before the 1st in a **Monday-first** week.
  * `getDay()` is Sunday-0, so `(d + 6) % 7` rotates Monday to 0 — a month whose
  * 1st is a Sunday yields 6, a Monday-1st month yields 0.
  */
 export function leadingBlanks(year: number, month: number): number {
-  return (new Date(year, month, 1).getDay() + 6) % 7;
+  return (localDate(year, month, 1).getDay() + 6) % 7;
 }
 
 /** Day count in a month. Day 0 of the next month is the last of this one. */
 export function daysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate();
+  return localDate(year, month + 1, 0).getDate();
 }
 
 /** Step the displayed month by `delta`. Unbounded — wraps the year both ways. */
 export function shiftMonth(current: GridMonth, delta: number): GridMonth {
-  const next = new Date(current.year, current.month + delta, 1);
+  const next = localDate(current.year, current.month + delta, 1);
   return { year: next.getFullYear(), month: next.getMonth() };
 }
 

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.parts.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.parts.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { Pressable, ScrollView, View } from "react-native";
+import { View } from "react-native";
+import { Check } from "phosphor-react-native";
+import { useUnistyles } from "react-native-unistyles";
 import { Text } from "../Text";
+import { Button } from "../Button";
 import { styles } from "./StepTimingEditor.styles";
-import type { StepTimingCandidate } from "./types";
 
 /** The ordinal badge — "1", "a", or a check for a completed step. */
 export function OrdinalBadge({
@@ -12,9 +14,15 @@ export function OrdinalBadge({
   label: string;
   isCompleted?: boolean;
 }) {
+  const { theme } = useUnistyles();
   return (
     <View style={[styles.ordinal, isCompleted && styles.ordinalCompleted]}>
-      <Text style={styles.ordinalLabel}>{isCompleted ? "✓" : label}</Text>
+      {isCompleted ? (
+        // Phosphor, not a "✓" text run — design system Rule 8 for state marks.
+        <Check size={theme.size.xs} weight="bold" color={theme.colors.text} />
+      ) : (
+        <Text style={styles.ordinalLabel}>{label}</Text>
+      )}
     </View>
   );
 }
@@ -27,39 +35,38 @@ export function OrdinalBadge({
  * band; the *text* is what parity is asserted on.
  */
 export function TruthLines({
-  afterStepTitle,
-  afterStepIsCompleted,
-  dueDateLabel,
   afterLineText,
   dueLineText,
   doneSuffix,
   testID,
 }: {
-  afterStepTitle?: string | null;
-  afterStepIsCompleted?: boolean;
-  dueDateLabel?: string | null;
-  afterLineText: string;
-  dueLineText: string;
-  doneSuffix: string;
+  /** Pre-composed `after …` line, or null when there is no dependency. */
+  afterLineText: string | null;
+  /** Pre-composed `due …` line, or null when there is no date. */
+  dueLineText: string | null;
+  /** Opt-in completion suffix, or null — the default read-out carries none. */
+  doneSuffix: string | null;
   testID: string;
 }) {
   return (
     <>
-      {afterStepTitle ? (
+      {afterLineText ? (
         <View style={styles.truthLine}>
+          {/* `↩` and `▦` are text runs on purpose: FocusCurrentTaskCard's
+              metadata band ships them exactly this way, and read-out parity
+              beats the Phosphor-only rule for a mark the other surface
+              already renders as a glyph. */}
           <Text style={[styles.truthGlyph, styles.truthGlyphAfter]}>↩</Text>
           <Text style={styles.truthText} testID={`${testID}-after-line`}>
             {afterLineText}
-            {/* Opt-in only: the shipped read-out carries no completion suffix,
-                because the resolver supplies no done-state to back it. */}
-            {afterStepIsCompleted ? (
+            {doneSuffix ? (
               <Text style={styles.doneTag}>{doneSuffix}</Text>
             ) : null}
           </Text>
         </View>
       ) : null}
 
-      {dueDateLabel ? (
+      {dueLineText ? (
         <View style={styles.truthLine}>
           <Text style={[styles.truthGlyph, styles.truthGlyphDue]}>▦</Text>
           <Text style={styles.truthText} testID={`${testID}-due-line`}>
@@ -70,150 +77,6 @@ export function TruthLines({
     </>
   );
 }
-
-/**
- * `Depends on` — the C line. Not "comes after": step 4 comes after step 3 by
- * being step 4, and it stops short of "blocked by", which is forbidden here
- * (ADR-0010/0012, #384). Nothing is gated — the complete action stays live on a
- * step whose dependency is still open — so borrowing a gate word would lie.
- */
-export function DependencyPicker({
-  candidates,
-  selectedId,
-  isOpen,
-  onToggle,
-  onPick,
-  nothingLabel,
-  noCandidatesLabel,
-  dependsOnLabel,
-  testID,
-}: {
-  candidates: readonly StepTimingCandidate[];
-  selectedId: string | null;
-  isOpen: boolean;
-  onToggle: () => void;
-  onPick: (id: string | null) => void;
-  nothingLabel: string;
-  noCandidatesLabel: string;
-  dependsOnLabel: string;
-  testID: string;
-}) {
-  const selected = candidates.find((c) => c.id === selectedId) ?? null;
-
-  return (
-    <View>
-      <Text style={styles.fieldLabel}>{dependsOnLabel}</Text>
-
-      <Pressable
-        accessibilityRole="button"
-        accessibilityState={{ expanded: isOpen }}
-        accessibilityLabel={`${dependsOnLabel}: ${selected ? selected.title : nothingLabel}`}
-        testID={`${testID}-toggle`}
-        onPress={onToggle}
-        style={({ pressed }) => [
-          styles.pickerButton,
-          pressed && styles.pickerButtonPressed,
-        ]}
-      >
-        {selected ? (
-          <>
-            <OrdinalBadge
-              label={selected.label}
-              isCompleted={selected.isCompleted}
-            />
-            <Text style={styles.pickerValue}>{selected.title}</Text>
-          </>
-        ) : (
-          <Text style={styles.pickerPlaceholder}>{nothingLabel}</Text>
-        )}
-        <Text style={styles.caret}>{isOpen ? "▲" : "▼"}</Text>
-      </Pressable>
-
-      {isOpen ? (
-        candidates.length === 0 ? (
-          // A goal's first step has nothing to depend on. Say so plainly —
-          // no "missing", no "needed".
-          <Text style={styles.emptyCandidates} testID={`${testID}-empty`}>
-            {noCandidatesLabel}
-          </Text>
-        ) : (
-          <ScrollView
-            style={styles.candidateList}
-            contentContainerStyle={styles.candidateListContent}
-            testID={`${testID}-list`}
-          >
-            <CandidateRow
-              title={nothingLabel}
-              isSelected={selectedId === null}
-              onPress={() => onPick(null)}
-              testID={`${testID}-option-nothing`}
-            />
-            {candidates.map((candidate) => (
-              <CandidateRow
-                key={candidate.id}
-                title={candidate.title}
-                ordinal={candidate.label}
-                isCompleted={candidate.isCompleted}
-                isSubStep={candidate.isSubStep}
-                isSelected={candidate.id === selectedId}
-                onPress={() => onPick(candidate.id)}
-                testID={`${testID}-option-${candidate.id}`}
-              />
-            ))}
-          </ScrollView>
-        )
-      ) : null}
-    </View>
-  );
-}
-
-function CandidateRow({
-  title,
-  ordinal,
-  isCompleted,
-  isSubStep,
-  isSelected,
-  onPress,
-  testID,
-}: {
-  title: string;
-  ordinal?: string;
-  isCompleted?: boolean;
-  isSubStep?: boolean;
-  isSelected: boolean;
-  onPress: () => void;
-  testID: string;
-}) {
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={{ selected: isSelected }}
-      accessibilityLabel={title}
-      testID={testID}
-      onPress={onPress}
-      style={[
-        styles.candidateRow,
-        isSubStep && styles.candidateRowChild,
-        isSelected && styles.candidateRowSelected,
-      ]}
-    >
-      {ordinal !== undefined ? (
-        <OrdinalBadge label={ordinal} isCompleted={isCompleted} />
-      ) : null}
-      <Text
-        style={[
-          styles.candidateTitle,
-          isCompleted && styles.candidateTitleCompleted,
-          isSelected && styles.candidateTitleSelected,
-        ]}
-      >
-        {title}
-      </Text>
-      {isSelected ? <Text style={styles.tick}>●</Text> : null}
-    </Pressable>
-  );
-}
-
 /**
  * The neutral ordering note — what "inform, never enforce" looks like when
  * there is finally something to inform about.
@@ -248,35 +111,27 @@ export function EditorFooter({
   onDone: () => void;
   testID: string;
 }) {
+  // The shared Button, not bespoke Pressables: it carries the neo-brutalist
+  // pressed-translate every other button in the app uses, plus the Android
+  // glyph-run fix. `Done` takes the flex so the prototype's proportions hold.
   return (
     <View style={styles.footer}>
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={clearLabel}
-        testID={`${testID}-clear`}
-        onPress={onClear}
-        style={({ pressed }) => [
-          styles.footerButton,
-          styles.clearButton,
-          pressed && styles.buttonPressed,
-        ]}
-      >
-        <Text style={styles.clearLabel}>{clearLabel}</Text>
-      </Pressable>
-
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={doneLabel}
-        testID={`${testID}-done`}
-        onPress={onDone}
-        style={({ pressed }) => [
-          styles.footerButton,
-          styles.doneButton,
-          pressed && styles.buttonPressed,
-        ]}
-      >
-        <Text style={styles.doneLabel}>{doneLabel}</Text>
-      </Pressable>
+      <View style={styles.clearSlot}>
+        <Button
+          label={clearLabel}
+          variant="secondary"
+          onPress={onClear}
+          testID={`${testID}-clear`}
+        />
+      </View>
+      <View style={styles.doneSlot}>
+        <Button
+          label={doneLabel}
+          variant="primary"
+          onPress={onDone}
+          testID={`${testID}-done`}
+        />
+      </View>
     </View>
   );
 }

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.parts.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.parts.tsx
@@ -1,0 +1,282 @@
+import React from "react";
+import { Pressable, ScrollView, View } from "react-native";
+import { Text } from "../Text";
+import { styles } from "./StepTimingEditor.styles";
+import type { StepTimingCandidate } from "./types";
+
+/** The ordinal badge — "1", "a", or a check for a completed step. */
+export function OrdinalBadge({
+  label,
+  isCompleted,
+}: {
+  label: string;
+  isCompleted?: boolean;
+}) {
+  return (
+    <View style={[styles.ordinal, isCompleted && styles.ordinalCompleted]}>
+      <Text style={styles.ordinalLabel}>{isCompleted ? "✓" : label}</Text>
+    </View>
+  );
+}
+
+/**
+ * The row's truth lines — the same text Focus and Timeline render for the same
+ * data, so a step authored here reads identically wherever it is opened.
+ *
+ * The glyph is a separate element, matching `FocusCurrentTaskCard`'s metadata
+ * band; the *text* is what parity is asserted on.
+ */
+export function TruthLines({
+  afterStepTitle,
+  afterStepIsCompleted,
+  dueDateLabel,
+  afterLineText,
+  dueLineText,
+  doneSuffix,
+  testID,
+}: {
+  afterStepTitle?: string | null;
+  afterStepIsCompleted?: boolean;
+  dueDateLabel?: string | null;
+  afterLineText: string;
+  dueLineText: string;
+  doneSuffix: string;
+  testID: string;
+}) {
+  return (
+    <>
+      {afterStepTitle ? (
+        <View style={styles.truthLine}>
+          <Text style={[styles.truthGlyph, styles.truthGlyphAfter]}>↩</Text>
+          <Text style={styles.truthText} testID={`${testID}-after-line`}>
+            {afterLineText}
+            {/* Opt-in only: the shipped read-out carries no completion suffix,
+                because the resolver supplies no done-state to back it. */}
+            {afterStepIsCompleted ? (
+              <Text style={styles.doneTag}>{doneSuffix}</Text>
+            ) : null}
+          </Text>
+        </View>
+      ) : null}
+
+      {dueDateLabel ? (
+        <View style={styles.truthLine}>
+          <Text style={[styles.truthGlyph, styles.truthGlyphDue]}>▦</Text>
+          <Text style={styles.truthText} testID={`${testID}-due-line`}>
+            {dueLineText}
+          </Text>
+        </View>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * `Depends on` — the C line. Not "comes after": step 4 comes after step 3 by
+ * being step 4, and it stops short of "blocked by", which is forbidden here
+ * (ADR-0010/0012, #384). Nothing is gated — the complete action stays live on a
+ * step whose dependency is still open — so borrowing a gate word would lie.
+ */
+export function DependencyPicker({
+  candidates,
+  selectedId,
+  isOpen,
+  onToggle,
+  onPick,
+  nothingLabel,
+  noCandidatesLabel,
+  dependsOnLabel,
+  testID,
+}: {
+  candidates: readonly StepTimingCandidate[];
+  selectedId: string | null;
+  isOpen: boolean;
+  onToggle: () => void;
+  onPick: (id: string | null) => void;
+  nothingLabel: string;
+  noCandidatesLabel: string;
+  dependsOnLabel: string;
+  testID: string;
+}) {
+  const selected = candidates.find((c) => c.id === selectedId) ?? null;
+
+  return (
+    <View>
+      <Text style={styles.fieldLabel}>{dependsOnLabel}</Text>
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: isOpen }}
+        accessibilityLabel={`${dependsOnLabel}: ${selected ? selected.title : nothingLabel}`}
+        testID={`${testID}-toggle`}
+        onPress={onToggle}
+        style={({ pressed }) => [
+          styles.pickerButton,
+          pressed && styles.pickerButtonPressed,
+        ]}
+      >
+        {selected ? (
+          <>
+            <OrdinalBadge
+              label={selected.label}
+              isCompleted={selected.isCompleted}
+            />
+            <Text style={styles.pickerValue}>{selected.title}</Text>
+          </>
+        ) : (
+          <Text style={styles.pickerPlaceholder}>{nothingLabel}</Text>
+        )}
+        <Text style={styles.caret}>{isOpen ? "▲" : "▼"}</Text>
+      </Pressable>
+
+      {isOpen ? (
+        candidates.length === 0 ? (
+          // A goal's first step has nothing to depend on. Say so plainly —
+          // no "missing", no "needed".
+          <Text style={styles.emptyCandidates} testID={`${testID}-empty`}>
+            {noCandidatesLabel}
+          </Text>
+        ) : (
+          <ScrollView
+            style={styles.candidateList}
+            contentContainerStyle={styles.candidateListContent}
+            testID={`${testID}-list`}
+          >
+            <CandidateRow
+              title={nothingLabel}
+              isSelected={selectedId === null}
+              onPress={() => onPick(null)}
+              testID={`${testID}-option-nothing`}
+            />
+            {candidates.map((candidate) => (
+              <CandidateRow
+                key={candidate.id}
+                title={candidate.title}
+                ordinal={candidate.label}
+                isCompleted={candidate.isCompleted}
+                isSubStep={candidate.isSubStep}
+                isSelected={candidate.id === selectedId}
+                onPress={() => onPick(candidate.id)}
+                testID={`${testID}-option-${candidate.id}`}
+              />
+            ))}
+          </ScrollView>
+        )
+      ) : null}
+    </View>
+  );
+}
+
+function CandidateRow({
+  title,
+  ordinal,
+  isCompleted,
+  isSubStep,
+  isSelected,
+  onPress,
+  testID,
+}: {
+  title: string;
+  ordinal?: string;
+  isCompleted?: boolean;
+  isSubStep?: boolean;
+  isSelected: boolean;
+  onPress: () => void;
+  testID: string;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: isSelected }}
+      accessibilityLabel={title}
+      testID={testID}
+      onPress={onPress}
+      style={[
+        styles.candidateRow,
+        isSubStep && styles.candidateRowChild,
+        isSelected && styles.candidateRowSelected,
+      ]}
+    >
+      {ordinal !== undefined ? (
+        <OrdinalBadge label={ordinal} isCompleted={isCompleted} />
+      ) : null}
+      <Text
+        style={[
+          styles.candidateTitle,
+          isCompleted && styles.candidateTitleCompleted,
+          isSelected && styles.candidateTitleSelected,
+        ]}
+      >
+        {title}
+      </Text>
+      {isSelected ? <Text style={styles.tick}>●</Text> : null}
+    </Pressable>
+  );
+}
+
+/**
+ * The neutral ordering note — what "inform, never enforce" looks like when
+ * there is finally something to inform about.
+ *
+ * Plain body copy. No icon, no red, nothing disabled, nothing refused. The
+ * selection that triggered it stays exactly as the user made it.
+ */
+export function OrderingNote({
+  text,
+  testID,
+}: {
+  text: string;
+  testID: string;
+}) {
+  return (
+    <View style={styles.note} testID={testID}>
+      <Text style={styles.noteText}>{text}</Text>
+    </View>
+  );
+}
+
+export function EditorFooter({
+  clearLabel,
+  doneLabel,
+  onClear,
+  onDone,
+  testID,
+}: {
+  clearLabel: string;
+  doneLabel: string;
+  onClear: () => void;
+  onDone: () => void;
+  testID: string;
+}) {
+  return (
+    <View style={styles.footer}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={clearLabel}
+        testID={`${testID}-clear`}
+        onPress={onClear}
+        style={({ pressed }) => [
+          styles.footerButton,
+          styles.clearButton,
+          pressed && styles.buttonPressed,
+        ]}
+      >
+        <Text style={styles.clearLabel}>{clearLabel}</Text>
+      </Pressable>
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={doneLabel}
+        testID={`${testID}-done`}
+        onPress={onDone}
+        style={({ pressed }) => [
+          styles.footerButton,
+          styles.doneButton,
+          pressed && styles.buttonPressed,
+        ]}
+      >
+        <Text style={styles.doneLabel}>{doneLabel}</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.picker.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.picker.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import { Pressable, ScrollView, View } from "react-native";
+import { CaretDown, CaretUp, Check } from "phosphor-react-native";
+import { useUnistyles } from "react-native-unistyles";
+import { Text } from "../Text";
+import { OrdinalBadge } from "./StepTimingEditor.parts";
+import { styles } from "./StepTimingEditor.styles";
+import type { StepTimingCandidate } from "./types";
+
+/**
+ * `Depends on` — the C line. Not "comes after": step 4 comes after step 3 by
+ * being step 4, and it stops short of "blocked by", which is forbidden here
+ * (ADR-0010/0012, #384). Nothing is gated — the complete action stays live on a
+ * step whose dependency is still open — so borrowing a gate word would lie.
+ */
+export function DependencyPicker({
+  candidates,
+  selectedId,
+  isOpen,
+  onToggle,
+  onPick,
+  nothingLabel,
+  noCandidatesLabel,
+  dependsOnLabel,
+  testID,
+}: {
+  candidates: readonly StepTimingCandidate[];
+  selectedId: string | null;
+  isOpen: boolean;
+  onToggle: () => void;
+  onPick: (id: string | null) => void;
+  nothingLabel: string;
+  noCandidatesLabel: string;
+  dependsOnLabel: string;
+  testID: string;
+}) {
+  const { theme } = useUnistyles();
+  const selected = candidates.find((c) => c.id === selectedId) ?? null;
+  const Caret = isOpen ? CaretUp : CaretDown;
+
+  return (
+    <View>
+      <Text style={styles.fieldLabel}>{dependsOnLabel}</Text>
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: isOpen }}
+        accessibilityLabel={`${dependsOnLabel}: ${selected ? selected.title : nothingLabel}`}
+        testID={`${testID}-toggle`}
+        onPress={onToggle}
+        style={({ pressed }) => [
+          styles.pickerButton,
+          pressed && styles.pickerButtonPressed,
+        ]}
+      >
+        {selected ? (
+          <>
+            <OrdinalBadge
+              label={selected.label}
+              isCompleted={selected.isCompleted}
+            />
+            <Text style={styles.pickerValue}>{selected.title}</Text>
+          </>
+        ) : (
+          <Text style={styles.pickerPlaceholder}>{nothingLabel}</Text>
+        )}
+        <Caret
+          size={theme.size.sm}
+          weight="bold"
+          color={theme.colors.textSecondary}
+        />
+      </Pressable>
+
+      {isOpen ? (
+        <CandidateList
+          candidates={candidates}
+          selectedId={selectedId}
+          onPick={onPick}
+          nothingLabel={nothingLabel}
+          noCandidatesLabel={noCandidatesLabel}
+          testID={testID}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+function CandidateList({
+  candidates,
+  selectedId,
+  onPick,
+  nothingLabel,
+  noCandidatesLabel,
+  testID,
+}: {
+  candidates: readonly StepTimingCandidate[];
+  selectedId: string | null;
+  onPick: (id: string | null) => void;
+  nothingLabel: string;
+  noCandidatesLabel: string;
+  testID: string;
+}) {
+  if (candidates.length === 0) {
+    // A goal's first step has nothing to depend on. Say so plainly.
+    return (
+      <Text style={styles.emptyCandidates} testID={`${testID}-empty`}>
+        {noCandidatesLabel}
+      </Text>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.candidateList}
+      contentContainerStyle={styles.candidateListContent}
+      testID={`${testID}-list`}
+    >
+      <CandidateRow
+        title={nothingLabel}
+        isSelected={selectedId === null}
+        onPress={() => onPick(null)}
+        testID={`${testID}-option-nothing`}
+      />
+      {candidates.map((candidate) => (
+        <CandidateRow
+          key={candidate.id}
+          title={candidate.title}
+          ordinal={candidate.label}
+          isCompleted={candidate.isCompleted}
+          isSubStep={candidate.isSubStep}
+          isSelected={candidate.id === selectedId}
+          onPress={() => onPick(candidate.id)}
+          testID={`${testID}-option-${candidate.id}`}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+function CandidateRow({
+  title,
+  ordinal,
+  isCompleted,
+  isSubStep,
+  isSelected,
+  onPress,
+  testID,
+}: {
+  title: string;
+  ordinal?: string;
+  isCompleted?: boolean;
+  isSubStep?: boolean;
+  isSelected: boolean;
+  onPress: () => void;
+  testID: string;
+}) {
+  const { theme } = useUnistyles();
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: isSelected }}
+      accessibilityLabel={title}
+      testID={testID}
+      onPress={onPress}
+      style={[
+        styles.candidateRow,
+        isSubStep && styles.candidateRowChild,
+        isSelected && styles.candidateRowSelected,
+      ]}
+    >
+      {ordinal !== undefined ? (
+        <OrdinalBadge label={ordinal} isCompleted={isCompleted} />
+      ) : null}
+      <Text
+        style={[
+          styles.candidateTitle,
+          isCompleted && styles.candidateTitleCompleted,
+          isSelected && styles.candidateTitleSelected,
+        ]}
+      >
+        {title}
+      </Text>
+      {/* The selection mark is a state indicator — Phosphor, not a "●" run. */}
+      {isSelected ? (
+        <Check
+          size={theme.size.sm}
+          weight="bold"
+          color={theme.colors.accentPrimary}
+        />
+      ) : null}
+    </Pressable>
+  );
+}

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.stories.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.stories.tsx
@@ -1,0 +1,450 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useRef, useState } from "react";
+import { ScrollView, View, type View as RNView } from "react-native";
+import { ScopedTheme, StyleSheet } from "react-native-unistyles";
+import { Text } from "../Text";
+import { formatDate } from "../../utils/format";
+import { StepTimingEditor } from "./StepTimingEditor";
+import type { StepTimingCandidate, StepTimingValue } from "./types";
+import { themes, themeNames, type ThemeName } from "../../themes/compose";
+
+const meta: Meta<typeof StepTimingEditor> = {
+  title: "Set B & C/StepTimingEditor",
+  component: StepTimingEditor,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StepTimingEditor>;
+
+/** The Direction D prototype's pinned instant — Wed 24 June 2026. */
+const NOW = new Date(2026, 5, 24);
+
+const label = (iso: string | null) => formatDate(iso, "en-US");
+
+/**
+ * The prototype's "Rewire the workshop" plan, flattened the way a caller would
+ * hand it over: every step and sub-step *except* the one being edited.
+ */
+const CANDIDATES: StepTimingCandidate[] = [
+  {
+    id: "s1",
+    title: "Plan layout & buy materials",
+    label: "1",
+    isCompleted: true,
+    dueDate: null,
+  },
+  {
+    id: "s2",
+    title: "Wire the circuits",
+    label: "2",
+    isCompleted: true,
+    dueDate: null,
+  },
+  {
+    id: "s3",
+    title: "Inspection & labels",
+    label: "3",
+    dueDate: "2026-06-30",
+    dueDateLabel: label("2026-06-30"),
+  },
+  {
+    id: "s3a",
+    title: "Book the inspection",
+    label: "a",
+    isSubStep: true,
+    isCompleted: true,
+    dueDate: null,
+  },
+  {
+    id: "s3b",
+    title: "Walk the inspector through",
+    label: "b",
+    isSubStep: true,
+    dueDate: "2026-06-26",
+    dueDateLabel: label("2026-06-26"),
+  },
+  {
+    id: "s3c",
+    title: "Fix any call-outs",
+    label: "c",
+    isSubStep: true,
+    dueDate: null,
+  },
+  { id: "s5", title: "Final walkthrough", label: "5", dueDate: null },
+];
+
+/** The days the rest of the plan sits on, as the grid's marks. */
+const MARKS = CANDIDATES.filter((c) => c.dueDate).map((c) => ({
+  date: c.dueDate as string,
+  label: c.label,
+}));
+
+/**
+ * Every story drives a live component: the timing line is the affordance, so a
+ * reviewer must be able to tap it, edit a draft, and watch what commits.
+ */
+function LiveEditor({
+  initial = { dueDate: null, afterStepId: null },
+  candidates = CANDIDATES,
+  isCompleted,
+  startExpanded,
+}: {
+  initial?: StepTimingValue;
+  candidates?: StepTimingCandidate[];
+  isCompleted?: boolean;
+  startExpanded?: boolean;
+}) {
+  const [value, setValue] = useState<StepTimingValue>(initial);
+  const [log, setLog] = useState<string>("—");
+  // Stories that want to land on the open editor drive expansion through the
+  // controlled prop; tapping the timing line still collapses it from here.
+  const [isOpen, setIsOpen] = useState(Boolean(startExpanded));
+
+  const dependency = candidates.find((c) => c.id === value.afterStepId);
+
+  return (
+    <View style={storyStyles.stack}>
+      <StepTimingEditor
+        value={value}
+        now={NOW}
+        candidates={candidates}
+        isCompleted={isCompleted}
+        marks={MARKS}
+        afterStepTitle={dependency?.title ?? null}
+        afterStepIsCompleted={dependency?.isCompleted}
+        dueDateLabel={value.dueDate ? label(value.dueDate) : null}
+        expanded={isOpen}
+        onExpandedChange={setIsOpen}
+        onCommit={(next) => {
+          setValue(next);
+          setLog(
+            `onCommit → due ${next.dueDate ?? "null"}, after ${next.afterStepId ?? "null"}`,
+          );
+        }}
+        onClear={() => {
+          setValue({ dueDate: null, afterStepId: null });
+          setLog("onClear");
+        }}
+      />
+      <Text style={storyStyles.readout}>{log}</Text>
+    </View>
+  );
+}
+
+function PhoneWidth({ children }: { children: React.ReactNode }) {
+  return (
+    <View style={storyStyles.stage}>
+      <View style={storyStyles.frame}>{children}</View>
+    </View>
+  );
+}
+
+/** Nothing set. One quiet `＋ when?` — one affordance, not two chips. */
+export const Unset: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor />
+    </PhoneWidth>
+  ),
+};
+
+/** A date and no dependency: a single `due` truth line. */
+export const DateOnly: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor initial={{ dueDate: "2026-07-02", afterStepId: null }} />
+    </PhoneWidth>
+  ),
+};
+
+/** A dependency and no date: a single `after` truth line. */
+export const DependencyOnly: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor initial={{ dueDate: null, afterStepId: "s3" }} />
+    </PhoneWidth>
+  ),
+};
+
+/** Both lines, stacked — the most a timing line ever shows. */
+export const Both: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor initial={{ dueDate: "2026-07-02", afterStepId: "s3" }} />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * A date that has already passed. It reads exactly like any other date — no
+ * red, no "overdue", no day count. A passed date never reads as late.
+ */
+export const PastDate: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor initial={{ dueDate: "2026-06-12", afterStepId: null }} />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * Editing an existing pair: tap the timing line to open on the committed
+ * values, change either, and `Done` to commit — or collapse to discard.
+ */
+export const EditingAnExistingPair: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor
+        initial={{ dueDate: "2026-06-30", afterStepId: "s3b" }}
+        startExpanded
+      />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * The ordering note. Open the editor: the draft day (Jun 26) falls before the
+ * day its dependency sits on (Jun 30), so the fact is stated in plain body
+ * copy. Nothing is disabled and the selection stands.
+ */
+export const OrderingNoteVisible: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor
+        initial={{ dueDate: "2026-06-26", afterStepId: "s3" }}
+        startExpanded
+      />
+    </PhoneWidth>
+  ),
+};
+
+/** A goal's first step: nothing to depend on yet, so the picker says so. */
+export const NoCandidates: Story = {
+  render: () => (
+    <PhoneWidth>
+      <LiveEditor candidates={[]} />
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * A completed step with no timing carries **no** `＋ when?` at all — nothing is
+ * left to plan on it. (The row renders nothing here; that is the point.)
+ */
+export const CompletedStep: Story = {
+  render: () => (
+    <PhoneWidth>
+      <View style={storyStyles.stack}>
+        <Text style={storyStyles.readout}>
+          completed + no timing → no affordance at all:
+        </Text>
+        <LiveEditor isCompleted />
+        <Text style={storyStyles.readout}>
+          completed + existing timing → still shows its lines:
+        </Text>
+        <LiveEditor
+          isCompleted
+          initial={{ dueDate: "2026-06-20", afterStepId: "s2" }}
+        />
+      </View>
+    </PhoneWidth>
+  ),
+};
+
+/** A sub-step behaves identically — both tiers use the same editor. */
+export const SubStep: Story = {
+  render: () => (
+    <PhoneWidth>
+      <View style={storyStyles.subStepIndent}>
+        <LiveEditor initial={{ dueDate: null, afterStepId: "s3a" }} />
+      </View>
+    </PhoneWidth>
+  ),
+};
+
+/**
+ * The one that demonstrates the scroll requirement (and the reason `onExpand`
+ * exists): several rows in a `ScrollView`, one open at a time via the
+ * controlled `expanded` prop, each expansion parking its row at the top of the
+ * list. Open the bottom row — without the park, its editor would unfold
+ * off-screen and the tap would read as having done nothing.
+ */
+export const InsideAScrollingList: Story = {
+  render: function InsideAScrollingListStory() {
+    const scrollRef = useRef<ScrollView | null>(null);
+    const contentRef = useRef<RNView | null>(null);
+    const [openId, setOpenId] = useState<string | null>(null);
+
+    const rows = CANDIDATES.filter((c) => !c.isSubStep);
+
+    return (
+      <View style={storyStyles.stage}>
+        <View style={storyStyles.scrollFrame}>
+          <ScrollView ref={scrollRef} testID="story-scroll">
+            <View ref={contentRef}>
+              {rows.map((row) => (
+                <View key={row.id} style={storyStyles.row}>
+                  <Text style={storyStyles.rowTitle}>
+                    {row.label}. {row.title}
+                  </Text>
+                  <StepTimingEditor
+                    value={{
+                      dueDate: row.dueDate,
+                      afterStepId: null,
+                    }}
+                    now={NOW}
+                    candidates={CANDIDATES.filter((c) => c.id !== row.id)}
+                    marks={MARKS}
+                    dueDateLabel={row.dueDate ? label(row.dueDate) : null}
+                    // One editor open at a time: opening another collapses the
+                    // first. A self-contained component cannot enforce this,
+                    // which is what the controlled prop is for.
+                    expanded={openId === row.id}
+                    onExpandedChange={(next) => setOpenId(next ? row.id : null)}
+                    onExpand={(rowRef) => {
+                      // Park the opened row at the top of the list.
+                      const node = rowRef.current;
+                      const content = contentRef.current;
+                      if (!node || !content) return;
+                      node.measureLayout(content, (_x, y) => {
+                        scrollRef.current?.scrollTo({ y, animated: true });
+                      });
+                    }}
+                    onCommit={() => setOpenId(null)}
+                    onClear={() => setOpenId(null)}
+                  />
+                </View>
+              ))}
+            </View>
+          </ScrollView>
+        </View>
+      </View>
+    );
+  },
+};
+
+const MOOD_NAMES: Record<ThemeName, string> = {
+  "light-default": "Full Ride",
+  "dark-default": "Night Ride",
+  "light-highContrast": "Bold Ink",
+  "light-dyslexia": "Warm Studio",
+  "light-autismFriendly": "Still Water",
+  "light-lowVision": "Loud & Clear",
+  "light-lowInfo": "Clean Signal",
+};
+
+/**
+ * All 7 product themes, each rendering the expanded editor with both lines set
+ * and the ordering note visible — the richest chrome the component has.
+ *
+ * `light-lowVision` doubles as #573's `largeText` density check: it carries the
+ * same `sizeL` scale (`src/themes/variants.ts:128`) that `largeText` applies,
+ * and `largeText` is a composable variant rather than a registered theme name.
+ */
+export const AllThemesMatrix: Story = {
+  render: () => (
+    <ScrollView contentContainerStyle={storyStyles.matrixContainer}>
+      {themeNames.map((name) => (
+        <View key={name} style={storyStyles.matrixThemeBlock}>
+          <View style={storyStyles.matrixThemeLabel}>
+            <Text style={storyStyles.matrixThemeName}>{MOOD_NAMES[name]}</Text>
+            <Text style={storyStyles.matrixThemeKey}>{name}</Text>
+          </View>
+          <ScopedTheme name={name}>
+            <View
+              style={[
+                storyStyles.matrixCard,
+                { backgroundColor: themes[name].colors.background },
+              ]}
+            >
+              <StepTimingEditor
+                value={{ dueDate: "2026-06-26", afterStepId: "s3" }}
+                now={NOW}
+                candidates={CANDIDATES}
+                marks={MARKS}
+                afterStepTitle="Inspection & labels"
+                dueDateLabel={label("2026-06-26")}
+                expanded
+                onCommit={() => {}}
+                onClear={() => {}}
+              />
+            </View>
+          </ScopedTheme>
+        </View>
+      ))}
+    </ScrollView>
+  ),
+};
+
+const storyStyles = StyleSheet.create((theme) => ({
+  stage: {
+    alignItems: "center",
+    padding: theme.space[6],
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  frame: {
+    width: 344,
+    padding: theme.space[5],
+    backgroundColor: theme.colors.background,
+  },
+  scrollFrame: {
+    width: 344,
+    height: 560,
+    padding: theme.space[4],
+    backgroundColor: theme.colors.background,
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+  },
+  stack: {
+    gap: theme.space[3],
+  },
+  subStepIndent: {
+    marginLeft: theme.space[4],
+    paddingLeft: theme.space[3],
+    borderLeftWidth: theme.borderWidth.thick,
+    borderLeftColor: theme.colors.backgroundTertiary,
+  },
+  row: {
+    paddingVertical: theme.space[3],
+    borderBottomWidth: theme.borderWidth.thin,
+    borderBottomColor: theme.colors.backgroundTertiary,
+  },
+  rowTitle: {
+    fontSize: theme.size.md,
+    color: theme.colors.text,
+    marginBottom: theme.space[1],
+  },
+  readout: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+  },
+  matrixContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "flex-start",
+    padding: theme.space[4],
+    gap: theme.space[6],
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  matrixThemeBlock: {
+    gap: theme.space[2],
+  },
+  matrixThemeLabel: {
+    gap: theme.space[1],
+  },
+  matrixThemeName: {
+    fontWeight: theme.fontWeight.semibold,
+    color: theme.colors.text,
+  },
+  matrixThemeKey: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    color: theme.colors.textMuted,
+  },
+  matrixCard: {
+    width: 344,
+    padding: theme.space[5],
+  },
+}));

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
@@ -1,0 +1,244 @@
+import { StyleSheet } from "react-native-unistyles";
+import { shadowStyle } from "../../styles/shadows";
+
+/** a11y floor shared by the timing line, every candidate row and both buttons. */
+export const TOUCH_TARGET_MIN = 44;
+
+/** Cap on the candidate list before it scrolls inside the editor. */
+const CANDIDATE_LIST_MAX_HEIGHT = 220;
+
+export const styles = StyleSheet.create((theme) => ({
+  root: {
+    gap: theme.space[2],
+  },
+
+  // --- The timing line: one affordance per step, never two ghost chips. ---
+  timingLine: {
+    minHeight: TOUCH_TARGET_MIN,
+    justifyContent: "center",
+    paddingVertical: theme.space[1],
+    paddingHorizontal: theme.space[1],
+    borderRadius: theme.radius.sm,
+    gap: theme.space[1],
+  },
+  timingLinePressed: {
+    backgroundColor: theme.colors.backgroundTertiary,
+  },
+  truthLine: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.space[2],
+  },
+  truthGlyph: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.sm,
+  },
+  truthGlyphAfter: {
+    color: theme.colors.success,
+  },
+  truthGlyphDue: {
+    color: theme.colors.textSecondary,
+  },
+  truthText: {
+    flex: 1,
+    fontSize: theme.size.sm,
+    color: theme.colors.textSecondary,
+  },
+  doneTag: {
+    color: theme.colors.success,
+  },
+  // The unset state: quiet, singular, and absent entirely on a completed step.
+  whenPrompt: {
+    fontSize: theme.size.sm,
+    color: theme.colors.textMuted,
+  },
+
+  // --- The editor, unfolded in the row. No sheet, no modal, no scrim. ---
+  editor: {
+    marginTop: theme.space[2],
+    paddingTop: theme.space[3],
+    borderTopWidth: theme.borderWidth.thick,
+    borderTopColor: theme.colors.border,
+    borderStyle: "dashed",
+    gap: theme.space[3],
+  },
+  question: {
+    fontFamily: theme.fontFamily.headline,
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.size.md,
+    color: theme.colors.text,
+  },
+  // The ADR-0012 promise for B, in the surface that makes it: intent, not a
+  // deadline. It ships.
+  intentSub: {
+    marginTop: theme.space[1],
+    fontSize: theme.size.sm,
+    color: theme.colors.textSecondary,
+  },
+
+  fieldLabel: {
+    fontFamily: theme.fontFamily.mono,
+    fontSize: theme.size.xs,
+    letterSpacing: theme.letterSpacing.label,
+    color: theme.colors.success,
+    marginBottom: theme.space[1],
+    textTransform: "uppercase",
+  },
+
+  // --- Depends on ---
+  pickerButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.space[2],
+    minHeight: TOUCH_TARGET_MIN,
+    paddingVertical: theme.space[2],
+    paddingHorizontal: theme.space[3],
+    backgroundColor: theme.colors.backgroundSecondary,
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.sm,
+    ...shadowStyle(theme, "cardElevationSmall"),
+  },
+  pickerButtonPressed: {
+    backgroundColor: theme.colors.backgroundTertiary,
+  },
+  pickerValue: {
+    flex: 1,
+    fontSize: theme.size.sm,
+    color: theme.colors.text,
+  },
+  pickerPlaceholder: {
+    flex: 1,
+    fontSize: theme.size.sm,
+    color: theme.colors.textMuted,
+  },
+  caret: {
+    fontSize: theme.size.xs,
+    color: theme.colors.textSecondary,
+  },
+  candidateList: {
+    maxHeight: CANDIDATE_LIST_MAX_HEIGHT,
+    marginTop: theme.space[2],
+  },
+  candidateListContent: {
+    gap: theme.space[1],
+  },
+  candidateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.space[2],
+    minHeight: TOUCH_TARGET_MIN,
+    paddingVertical: theme.space[2],
+    paddingHorizontal: theme.space[2],
+    backgroundColor: theme.colors.backgroundSecondary,
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.backgroundTertiary,
+    borderRadius: theme.radius.sm,
+  },
+  candidateRowSelected: {
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.accentPurpleLight,
+  },
+  // Sub-steps indent, matching the prototype's `.after-opt.is-child`.
+  candidateRowChild: {
+    marginLeft: theme.space[4],
+  },
+  candidateTitle: {
+    flex: 1,
+    fontSize: theme.size.sm,
+    color: theme.colors.textSecondary,
+  },
+  candidateTitleSelected: {
+    color: theme.colors.text,
+  },
+  candidateTitleCompleted: {
+    color: theme.colors.textMuted,
+  },
+  tick: {
+    fontSize: theme.size.xs,
+    color: theme.colors.accentPrimary,
+  },
+  emptyCandidates: {
+    paddingVertical: theme.space[3],
+    paddingHorizontal: theme.space[3],
+    fontSize: theme.size.sm,
+    color: theme.colors.textSecondary,
+  },
+
+  // The ordinal badge, shared by the picker button and every candidate row.
+  ordinal: {
+    minWidth: theme.space[5],
+    height: theme.space[5],
+    paddingHorizontal: theme.space[1],
+    borderRadius: theme.radius.full,
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.backgroundSecondary,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ordinalCompleted: {
+    backgroundColor: theme.colors.accentMint,
+  },
+  ordinalLabel: {
+    fontFamily: theme.fontFamily.headline,
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.size.xs,
+    color: theme.colors.text,
+  },
+
+  /**
+   * The neutral ordering note. Informs, never enforces (ADR-0010/0012): body
+   * copy weight, a quiet left rule, no icon, no error/warning token, nothing
+   * disabled and nothing refused.
+   */
+  note: {
+    backgroundColor: theme.colors.backgroundTertiary,
+    borderLeftWidth: theme.borderWidth.thick,
+    borderLeftColor: theme.colors.border,
+    paddingVertical: theme.space[2],
+    paddingHorizontal: theme.space[3],
+  },
+  noteText: {
+    fontSize: theme.size.sm,
+    lineHeight: theme.lineHeight.md,
+    color: theme.colors.textSecondary,
+  },
+
+  // --- Footer ---
+  footer: {
+    flexDirection: "row",
+    gap: theme.space[3],
+  },
+  footerButton: {
+    minHeight: TOUCH_TARGET_MIN,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: theme.space[4],
+    borderWidth: theme.borderWidth.thick,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.sm,
+    ...shadowStyle(theme, "cardElevation"),
+  },
+  clearButton: {
+    flexGrow: 0,
+    backgroundColor: theme.colors.backgroundSecondary,
+  },
+  clearLabel: {
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.size.sm,
+    color: theme.colors.textSecondary,
+  },
+  doneButton: {
+    flex: 1,
+    backgroundColor: theme.colors.accentPrimary,
+  },
+  doneLabel: {
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.size.sm,
+    color: theme.colors.background,
+  },
+  buttonPressed: {
+    opacity: 0.9,
+  },
+}));

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
@@ -193,6 +193,14 @@ export const styles = StyleSheet.create((theme) => ({
     lineHeight: theme.size.xs,
     textAlign: "center",
     includeFontPadding: false,
+    // Centring the line box is not the same as centring the *glyph*: the box
+    // reserves descender space that a digit or an ordinal letter never uses, so
+    // the ink lands above centre. Nudge back down by (cap - ascent + descent)/2,
+    // which measures at 0.049em for the headline family (Anybody) — cap 8.17,
+    // ascent 10, descent 3 at 12px. Sub-pixel, but visible on a 2x screen, and
+    // it is why these badges read high while the grid's marks (body family,
+    // which needs no correction) do not.
+    transform: [{ translateY: theme.size.xs * 0.05 }],
   },
 
   /**

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
@@ -185,6 +185,12 @@ export const styles = StyleSheet.create((theme) => ({
     fontWeight: theme.fontWeight.bold,
     fontSize: theme.size.xs,
     color: theme.colors.text,
+    // `Text` defaults to the body variant, whose lineHeight is 1.6x the *body*
+    // size (26) — inside a 20pt circle that line box overflows and the glyph
+    // rides high. Pin the line box to the glyph and centre it explicitly.
+    lineHeight: theme.size.xs,
+    textAlign: "center",
+    includeFontPadding: false,
   },
 
   /**
@@ -206,39 +212,17 @@ export const styles = StyleSheet.create((theme) => ({
   },
 
   // --- Footer ---
+  // Layout only: the buttons themselves are the shared `Button`, so the
+  // neo-brutalist fill, border, shadow and pressed-translate all come from
+  // there rather than being restated here.
   footer: {
     flexDirection: "row",
     gap: theme.space[3],
   },
-  footerButton: {
-    minHeight: TOUCH_TARGET_MIN,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: theme.space[4],
-    borderWidth: theme.borderWidth.thick,
-    borderColor: theme.colors.border,
-    borderRadius: theme.radius.sm,
-    ...shadowStyle(theme, "cardElevation"),
-  },
-  clearButton: {
+  clearSlot: {
     flexGrow: 0,
-    backgroundColor: theme.colors.backgroundSecondary,
   },
-  clearLabel: {
-    fontWeight: theme.fontWeight.bold,
-    fontSize: theme.size.sm,
-    color: theme.colors.textSecondary,
-  },
-  doneButton: {
+  doneSlot: {
     flex: 1,
-    backgroundColor: theme.colors.accentPrimary,
-  },
-  doneLabel: {
-    fontWeight: theme.fontWeight.bold,
-    fontSize: theme.size.sm,
-    color: theme.colors.background,
-  },
-  buttonPressed: {
-    opacity: 0.9,
   },
 }));

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.styles.ts
@@ -166,10 +166,12 @@ export const styles = StyleSheet.create((theme) => ({
   },
 
   // The ordinal badge, shared by the picker button and every candidate row.
+  // No horizontal padding: `minWidth === height` makes a one- or two-character
+  // ordinal an exact circle, and a longer one still grows into a pill rather
+  // than clipping. Padding would push every single-character badge into an oval.
   ordinal: {
     minWidth: theme.space[5],
     height: theme.space[5],
-    paddingHorizontal: theme.space[1],
     borderRadius: theme.radius.full,
     borderWidth: theme.borderWidth.thick,
     borderColor: theme.colors.border,

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
@@ -10,7 +10,11 @@ import {
 } from "./StepTimingEditor.parts";
 import { DependencyPicker } from "./StepTimingEditor.picker";
 import { styles } from "./StepTimingEditor.styles";
-import type { StepTimingEditorProps, StepTimingValue } from "./types";
+import type {
+  StepTimingEditorProps,
+  StepTimingValue,
+  TimingLineA11yParts,
+} from "./types";
 
 const DEFAULT_INTENT_SUB =
   "Your intent, not a deadline. A passed date never reads as “late.”";
@@ -18,6 +22,21 @@ const DEFAULT_INTENT_SUB =
 const defaultOrderingNote = (title: string, date: string) =>
   `${title} needs to be done first, and it sits on ${date}. ` +
   `This one lands before it — that's allowed, it just won't read in order.`;
+
+// Reads the truth lines back rather than naming the control, so set and unset
+// announce differently. The `· done ✓` suffix becomes the word "done": a
+// screen reader given the glyph reads punctuation, or nothing.
+const defaultTimingLineA11yLabel = ({
+  afterLine,
+  dueLine,
+  afterStepIsCompleted,
+}: TimingLineA11yParts) => {
+  const lines = [
+    afterLine && afterStepIsCompleted ? `${afterLine}, done` : afterLine,
+    dueLine,
+  ].filter(Boolean);
+  return lines.length ? lines.join(", ") : "Set timing for this step";
+};
 
 /**
  * The in-row editor for a step's **B** (date) and **C** (`depends on`) lines.
@@ -85,7 +104,7 @@ export function StepTimingEditor({
   dueLineLabel = (date) => `due ${date}`,
   doneSuffixLabel = " · done ✓",
   orderingNote = defaultOrderingNote,
-  timingLineA11yLabel = "Timing for this step",
+  timingLineA11yLabel = defaultTimingLineA11yLabel,
   gridCopy,
   testID = "step-timing-editor",
 }: StepTimingEditorProps) {
@@ -175,6 +194,11 @@ export function StepTimingEditor({
     setDraft((current) => ({ ...current, dueDate: next }));
   }, []);
 
+  // Rendered once here rather than inline in the JSX: the timing line's a11y
+  // label is built from the same two strings the line displays.
+  const afterLineText = afterStepTitle ? afterLineLabel(afterStepTitle) : null;
+  const dueLineText = dueDateLabel ? dueLineLabel(dueDateLabel) : null;
+
   const hasTiming = Boolean(afterStepTitle) || Boolean(dueDateLabel);
   // Nothing is left to plan on a finished step, so it carries no placeholder —
   // only the timing it already has, if any.
@@ -194,7 +218,12 @@ export function StepTimingEditor({
         <Pressable
           ref={timingLineRef}
           accessibilityRole="button"
-          accessibilityLabel={timingLineA11yLabel}
+          accessibilityLabel={timingLineA11yLabel({
+            afterLine: afterLineText,
+            dueLine: dueLineText,
+            afterStepIsCompleted:
+              Boolean(afterStepTitle) && afterStepIsCompleted,
+          })}
           accessibilityState={{ expanded: isExpanded }}
           testID={`${testID}-timing-line`}
           onPress={handleTimingLinePress}
@@ -205,10 +234,8 @@ export function StepTimingEditor({
         >
           {hasTiming ? (
             <TruthLines
-              afterLineText={
-                afterStepTitle ? afterLineLabel(afterStepTitle) : null
-              }
-              dueLineText={dueDateLabel ? dueLineLabel(dueDateLabel) : null}
+              afterLineText={afterLineText}
+              dueLineText={dueLineText}
               doneSuffix={
                 afterStepTitle && afterStepIsCompleted ? doneSuffixLabel : null
               }

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
@@ -1,0 +1,260 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "../Text";
+import { StepDayGrid } from "../StepDayGrid";
+import { focusAccessibilityRef } from "../../utils/accessibilityFocus";
+import {
+  DependencyPicker,
+  EditorFooter,
+  OrderingNote,
+  TruthLines,
+} from "./StepTimingEditor.parts";
+import { styles } from "./StepTimingEditor.styles";
+import type { StepTimingEditorProps, StepTimingValue } from "./types";
+
+const DEFAULT_INTENT_SUB =
+  "Your intent, not a deadline. A passed date never reads as “late.”";
+
+const defaultOrderingNote = (title: string, date: string) =>
+  `${title} needs to be done first, and it sits on ${date}. ` +
+  `This one lands before it — that's allowed, it just won't read in order.`;
+
+/**
+ * The in-row editor for a step's **B** (date) and **C** (`depends on`) lines.
+ *
+ * Authoring happens **inside the row**, with the list still on screen: dating a
+ * plan is one pass down the whole list, and every date is decided against the
+ * steps around it ("panels the week after the inspection"). A bottom sheet
+ * scrimmed the list at exactly the moment that context was needed, so there is
+ * no sheet, no `Modal` and no scrim here — and one timing line per row rather
+ * than two ghost chips, because sixteen dashed placeholders on a five-step goal
+ * contradicts the epic's own rule that setting must not feel required.
+ *
+ * Presentational: copy is caller-supplied with English defaults, and dates move
+ * in and out as plain `YYYY-MM-DD`. Draft edits reach the caller only via
+ * `onCommit` / `onClear`; collapsing without `Done` discards them.
+ *
+ * **`afterStepId` stays unvalidated** — no cycle detection, no same-goal check,
+ * no disabled candidates. `updateStep` (`src/db/queries.ts`) writes it through
+ * as given, and the read side already degrades a self-reference or a deleted
+ * target to unresolved (`resolveStepDependencyBand`). Guards inform; they never
+ * refuse.
+ *
+ * **`waiting on` is deliberately absent.** An external wait is a fact about the
+ * world, recorded mid-ride when it starts to bite, on the step the user is
+ * actually standing on — not while laying out a plan. `waitingOnLabel` /
+ * `waitingOnExpectedAt` authoring belongs in Focus and needs its own issue; do
+ * not restore it here.
+ *
+ * **On the `· done ✓` suffix**: `afterStepIsCompleted` defaults to `false`, and
+ * at that default the rendered line is byte-identical to what Focus and
+ * Timeline produce for the same step — which is the read-out parity #573 asks
+ * for. Neither shipped surface renders a completion suffix today, because
+ * `resolveStepDependencyBand` supplies no done-state to back one. Making the
+ * suffix canonical is a change to Focus, Timeline and the resolver together.
+ *
+ * No expand/collapse animation: the animation preference is read from Evolu,
+ * which a presentational component must not require. The prototype gates its
+ * unfold behind `prefers-reduced-motion` anyway, so un-animated is the
+ * accessible default rather than a regression.
+ */
+export function StepTimingEditor({
+  value,
+  now,
+  candidates,
+  isCompleted = false,
+  afterStepTitle,
+  afterStepIsCompleted = false,
+  dueDateLabel,
+  marks,
+  locale,
+  onCommit,
+  onClear,
+  expanded,
+  onExpandedChange,
+  onExpand,
+  whenPromptLabel = "＋ when?",
+  questionLabel = "When do you want this done?",
+  intentSubLabel = DEFAULT_INTENT_SUB,
+  dependsOnLabel = "Depends on",
+  nothingLabel = "nothing",
+  noCandidatesLabel = "No other steps in this goal yet.",
+  clearLabel = "Clear",
+  doneLabel = "Done",
+  afterLineLabel = (title) => `after ${title}`,
+  dueLineLabel = (date) => `due ${date}`,
+  doneSuffixLabel = " · done ✓",
+  orderingNote = defaultOrderingNote,
+  timingLineA11yLabel = "Timing for this step",
+  previousMonthLabel,
+  nextMonthLabel,
+  legendLabel,
+  marksA11ySuffix,
+  testID = "step-timing-editor",
+}: StepTimingEditorProps) {
+  const rowRef = useRef<View | null>(null);
+  const timingLineRef = useRef<View | null>(null);
+  // The heading block rather than its `Text`: the shared `Text` component does
+  // not forward refs, and the block is the right focus target anyway — it reads
+  // the question and the intent sub-line as one announcement.
+  const questionRef = useRef<View | null>(null);
+
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false);
+  const isControlled = expanded !== undefined;
+  const isExpanded = isControlled ? expanded : uncontrolledExpanded;
+
+  // Seeded on every expand, so a discarded draft never leaks into the next open.
+  const [draft, setDraft] = useState<StepTimingValue>(value);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const setExpanded = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledExpanded(next);
+      onExpandedChange?.(next);
+    },
+    [isControlled, onExpandedChange],
+  );
+
+  // Move accessibility focus into the editor on expand and back to the timing
+  // line on collapse, so a screen-reader user is never left where the content
+  // they just summoned is not.
+  const wasExpanded = useRef(isExpanded);
+  useEffect(() => {
+    if (wasExpanded.current === isExpanded) return;
+    wasExpanded.current = isExpanded;
+    return focusAccessibilityRef(isExpanded ? questionRef : timingLineRef);
+  }, [isExpanded]);
+
+  const handleTimingLinePress = useCallback(() => {
+    if (isExpanded) {
+      // Collapse discards the draft — `onCommit` is not called.
+      setPickerOpen(false);
+      setExpanded(false);
+      return;
+    }
+    setDraft(value);
+    setPickerOpen(false);
+    setExpanded(true);
+    // The host parks the row at the top of the list; an editor that unfolds
+    // below the fold reads as having done nothing.
+    onExpand?.(rowRef);
+  }, [isExpanded, onExpand, setExpanded, value]);
+
+  const handleDone = useCallback(() => {
+    onCommit(draft);
+    setPickerOpen(false);
+    setExpanded(false);
+  }, [draft, onCommit, setExpanded]);
+
+  const handleClear = useCallback(() => {
+    onClear();
+    setPickerOpen(false);
+    setExpanded(false);
+  }, [onClear, setExpanded]);
+
+  const hasTiming = Boolean(afterStepTitle) || Boolean(dueDateLabel);
+  // Nothing is left to plan on a finished step, so it carries no placeholder —
+  // only the timing it already has, if any.
+  const showTimingLine = hasTiming || !isCompleted;
+
+  const dependency = candidates.find((c) => c.id === draft.afterStepId) ?? null;
+  const showOrderingNote = Boolean(
+    draft.dueDate && dependency?.dueDate && draft.dueDate < dependency.dueDate,
+  );
+
+  return (
+    <View ref={rowRef} style={styles.root} testID={testID}>
+      {showTimingLine ? (
+        <Pressable
+          ref={timingLineRef}
+          accessibilityRole="button"
+          accessibilityLabel={timingLineA11yLabel}
+          accessibilityState={{ expanded: isExpanded }}
+          testID={`${testID}-timing-line`}
+          onPress={handleTimingLinePress}
+          style={({ pressed }) => [
+            styles.timingLine,
+            pressed && styles.timingLinePressed,
+          ]}
+        >
+          {hasTiming ? (
+            <TruthLines
+              afterStepTitle={afterStepTitle}
+              afterStepIsCompleted={afterStepIsCompleted}
+              dueDateLabel={dueDateLabel}
+              afterLineText={afterLineLabel(afterStepTitle ?? "")}
+              dueLineText={dueLineLabel(dueDateLabel ?? "")}
+              doneSuffix={doneSuffixLabel}
+              testID={testID}
+            />
+          ) : (
+            // One affordance, not two.
+            <Text style={styles.whenPrompt}>{whenPromptLabel}</Text>
+          )}
+        </Pressable>
+      ) : null}
+
+      {isExpanded ? (
+        <View style={styles.editor} testID={`${testID}-editor`}>
+          <View
+            ref={questionRef}
+            accessible
+            accessibilityRole="header"
+            testID={`${testID}-question`}
+          >
+            <Text style={styles.question}>{questionLabel}</Text>
+            <Text style={styles.intentSub}>{intentSubLabel}</Text>
+          </View>
+
+          <StepDayGrid
+            value={draft.dueDate}
+            now={now}
+            marks={marks}
+            locale={locale}
+            onChange={(next) =>
+              setDraft((current) => ({ ...current, dueDate: next }))
+            }
+            previousMonthLabel={previousMonthLabel}
+            nextMonthLabel={nextMonthLabel}
+            legendLabel={legendLabel}
+            marksA11ySuffix={marksA11ySuffix}
+            testID={`${testID}-grid`}
+          />
+
+          <DependencyPicker
+            candidates={candidates}
+            selectedId={draft.afterStepId}
+            isOpen={pickerOpen}
+            onToggle={() => setPickerOpen((open) => !open)}
+            onPick={(id) => {
+              setDraft((current) => ({ ...current, afterStepId: id }));
+              setPickerOpen(false);
+            }}
+            nothingLabel={nothingLabel}
+            noCandidatesLabel={noCandidatesLabel}
+            dependsOnLabel={dependsOnLabel}
+            testID={`${testID}-depends-on`}
+          />
+
+          {showOrderingNote && dependency ? (
+            <OrderingNote
+              text={orderingNote(
+                dependency.title,
+                dependency.dueDateLabel ?? dependency.dueDate ?? "",
+              )}
+              testID={`${testID}-ordering-note`}
+            />
+          ) : null}
+
+          <EditorFooter
+            clearLabel={clearLabel}
+            doneLabel={doneLabel}
+            onClear={handleClear}
+            onDone={handleDone}
+            testID={testID}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
@@ -103,7 +103,6 @@ export function StepTimingEditor({
   const isControlled = expanded !== undefined;
   const isExpanded = isControlled ? expanded : uncontrolledExpanded;
 
-  // Seeded on every expand, so a discarded draft never leaks into the next open.
   const [draft, setDraft] = useState<StepTimingValue>(value);
   const [pickerOpen, setPickerOpen] = useState(false);
 
@@ -114,6 +113,19 @@ export function StepTimingEditor({
     },
     [isControlled, onExpandedChange],
   );
+
+  // Reseed the draft from `value` on every open, so a discarded draft never
+  // leaks into the next one. Keyed on the transition rather than on the timing
+  // line's press handler, because a controlled host can open this row without a
+  // tap ever reaching us.
+  const [seededFor, setSeededFor] = useState(isExpanded);
+  if (isExpanded !== seededFor) {
+    setSeededFor(isExpanded);
+    if (isExpanded) {
+      setDraft(value);
+      setPickerOpen(false);
+    }
+  }
 
   // Move accessibility focus into the editor on expand and back to the timing
   // line on collapse, so a screen-reader user is never left where the content
@@ -132,13 +144,11 @@ export function StepTimingEditor({
       setExpanded(false);
       return;
     }
-    setDraft(value);
-    setPickerOpen(false);
     setExpanded(true);
     // The host parks the row at the top of the list; an editor that unfolds
     // below the fold reads as having done nothing.
     onExpand?.(rowRef);
-  }, [isExpanded, onExpand, setExpanded, value]);
+  }, [isExpanded, onExpand, setExpanded]);
 
   const handleDone = useCallback(() => {
     onCommit(draft);

--- a/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/StepTimingEditor.tsx
@@ -4,11 +4,11 @@ import { Text } from "../Text";
 import { StepDayGrid } from "../StepDayGrid";
 import { focusAccessibilityRef } from "../../utils/accessibilityFocus";
 import {
-  DependencyPicker,
   EditorFooter,
   OrderingNote,
   TruthLines,
 } from "./StepTimingEditor.parts";
+import { DependencyPicker } from "./StepTimingEditor.picker";
 import { styles } from "./StepTimingEditor.styles";
 import type { StepTimingEditorProps, StepTimingValue } from "./types";
 
@@ -86,10 +86,7 @@ export function StepTimingEditor({
   doneSuffixLabel = " · done ✓",
   orderingNote = defaultOrderingNote,
   timingLineA11yLabel = "Timing for this step",
-  previousMonthLabel,
-  nextMonthLabel,
-  legendLabel,
-  marksA11ySuffix,
+  gridCopy,
   testID = "step-timing-editor",
 }: StepTimingEditorProps) {
   const rowRef = useRef<View | null>(null);
@@ -130,6 +127,11 @@ export function StepTimingEditor({
   // Move accessibility focus into the editor on expand and back to the timing
   // line on collapse, so a screen-reader user is never left where the content
   // they just summoned is not.
+  //
+  // The ref exists to suppress the *mount* run — without it, a controlled host
+  // that mounts already-expanded would steal accessibility focus into the
+  // editor on first paint. The dep array alone cannot express that; do not
+  // remove it as redundant.
   const wasExpanded = useRef(isExpanded);
   useEffect(() => {
     if (wasExpanded.current === isExpanded) return;
@@ -137,40 +139,54 @@ export function StepTimingEditor({
     return focusAccessibilityRef(isExpanded ? questionRef : timingLineRef);
   }, [isExpanded]);
 
+  // Collapsing always closes the picker too. A controlled host that ignores
+  // `onExpandedChange` never re-runs the seed block, so this cannot be dropped
+  // as redundant with it.
+  const closeEditor = useCallback(() => {
+    setPickerOpen(false);
+    setExpanded(false);
+  }, [setExpanded]);
+
   const handleTimingLinePress = useCallback(() => {
     if (isExpanded) {
       // Collapse discards the draft — `onCommit` is not called.
-      setPickerOpen(false);
-      setExpanded(false);
+      closeEditor();
       return;
     }
     setExpanded(true);
     // The host parks the row at the top of the list; an editor that unfolds
     // below the fold reads as having done nothing.
     onExpand?.(rowRef);
-  }, [isExpanded, onExpand, setExpanded]);
+  }, [closeEditor, isExpanded, onExpand, setExpanded]);
 
   const handleDone = useCallback(() => {
     onCommit(draft);
-    setPickerOpen(false);
-    setExpanded(false);
-  }, [draft, onCommit, setExpanded]);
+    closeEditor();
+  }, [closeEditor, draft, onCommit]);
 
   const handleClear = useCallback(() => {
     onClear();
-    setPickerOpen(false);
-    setExpanded(false);
-  }, [onClear, setExpanded]);
+    closeEditor();
+  }, [closeEditor, onClear]);
+
+  // Stable identity so the memoised grid actually skips re-rendering its 31
+  // cells when only the dependency picker moved.
+  const handleDayChange = useCallback((next: string | null) => {
+    setDraft((current) => ({ ...current, dueDate: next }));
+  }, []);
 
   const hasTiming = Boolean(afterStepTitle) || Boolean(dueDateLabel);
   // Nothing is left to plan on a finished step, so it carries no placeholder —
   // only the timing it already has, if any.
   const showTimingLine = hasTiming || !isCompleted;
 
+  // The dependency whose day this step's draft day falls before, or null when
+  // there is nothing to inform about. One condition, one narrowing.
   const dependency = candidates.find((c) => c.id === draft.afterStepId) ?? null;
-  const showOrderingNote = Boolean(
-    draft.dueDate && dependency?.dueDate && draft.dueDate < dependency.dueDate,
-  );
+  const orderingConflict =
+    dependency?.dueDate && draft.dueDate && draft.dueDate < dependency.dueDate
+      ? dependency
+      : null;
 
   return (
     <View ref={rowRef} style={styles.root} testID={testID}>
@@ -189,12 +205,13 @@ export function StepTimingEditor({
         >
           {hasTiming ? (
             <TruthLines
-              afterStepTitle={afterStepTitle}
-              afterStepIsCompleted={afterStepIsCompleted}
-              dueDateLabel={dueDateLabel}
-              afterLineText={afterLineLabel(afterStepTitle ?? "")}
-              dueLineText={dueLineLabel(dueDateLabel ?? "")}
-              doneSuffix={doneSuffixLabel}
+              afterLineText={
+                afterStepTitle ? afterLineLabel(afterStepTitle) : null
+              }
+              dueLineText={dueDateLabel ? dueLineLabel(dueDateLabel) : null}
+              doneSuffix={
+                afterStepTitle && afterStepIsCompleted ? doneSuffixLabel : null
+              }
               testID={testID}
             />
           ) : (
@@ -221,13 +238,8 @@ export function StepTimingEditor({
             now={now}
             marks={marks}
             locale={locale}
-            onChange={(next) =>
-              setDraft((current) => ({ ...current, dueDate: next }))
-            }
-            previousMonthLabel={previousMonthLabel}
-            nextMonthLabel={nextMonthLabel}
-            legendLabel={legendLabel}
-            marksA11ySuffix={marksA11ySuffix}
+            onChange={handleDayChange}
+            {...gridCopy}
             testID={`${testID}-grid`}
           />
 
@@ -246,11 +258,11 @@ export function StepTimingEditor({
             testID={`${testID}-depends-on`}
           />
 
-          {showOrderingNote && dependency ? (
+          {orderingConflict ? (
             <OrderingNote
               text={orderingNote(
-                dependency.title,
-                dependency.dueDateLabel ?? dependency.dueDate ?? "",
+                orderingConflict.title,
+                orderingConflict.dueDateLabel ?? orderingConflict.dueDate ?? "",
               )}
               testID={`${testID}-ordering-note`}
             />

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx
@@ -1,0 +1,412 @@
+import React from "react";
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  within,
+} from "../../../__tests__/test-utils";
+import { StepTimingEditor } from "../StepTimingEditor";
+import type { StepTimingCandidate } from "../types";
+
+const NOW = new Date(2026, 5, 24);
+
+const CANDIDATES: StepTimingCandidate[] = [
+  {
+    id: "s2",
+    title: "Wire the circuits",
+    label: "2",
+    isCompleted: true,
+    dueDate: null,
+  },
+  { id: "s3", title: "Inspection & labels", label: "3", dueDate: "2026-06-30" },
+  {
+    id: "s3b",
+    title: "Walk the inspector through",
+    label: "b",
+    isSubStep: true,
+    dueDate: "2026-06-26",
+  },
+];
+
+const baseProps = {
+  value: { dueDate: null, afterStepId: null },
+  now: NOW,
+  candidates: CANDIDATES,
+  onCommit: jest.fn(),
+  onClear: jest.fn(),
+};
+
+const timingLine = () => screen.getByTestId("step-timing-editor-timing-line");
+const expand = () => fireEvent.press(timingLine());
+
+describe("StepTimingEditor timing line", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows exactly one affordance when nothing is set", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+
+    expect(screen.getByText("＋ when?")).toBeOnTheScreen();
+    // One line, not two ghost chips.
+    expect(
+      screen.queryAllByTestId("step-timing-editor-timing-line"),
+    ).toHaveLength(1);
+  });
+
+  it("shows both truth lines when both are set", () => {
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        value={{ dueDate: "2026-07-02", afterStepId: "s3" }}
+        afterStepTitle="Inspection & labels"
+        dueDateLabel="Jul 2, 2026"
+      />,
+    );
+
+    expect(
+      screen.getByTestId("step-timing-editor-after-line"),
+    ).toHaveTextContent("after Inspection & labels");
+    expect(screen.getByTestId("step-timing-editor-due-line")).toHaveTextContent(
+      "due Jul 2, 2026",
+    );
+    expect(screen.queryByText("＋ when?")).toBeNull();
+  });
+
+  // Nothing is left to plan on a finished step.
+  it("renders no affordance at all for a completed step with no timing", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} isCompleted />);
+
+    expect(screen.queryByTestId("step-timing-editor-timing-line")).toBeNull();
+    expect(screen.queryByText("＋ when?")).toBeNull();
+  });
+
+  it("still shows the timing a completed step already has", () => {
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        isCompleted
+        value={{ dueDate: "2026-06-20", afterStepId: null }}
+        dueDateLabel="Jun 20, 2026"
+      />,
+    );
+
+    expect(screen.getByTestId("step-timing-editor-due-line")).toHaveTextContent(
+      "due Jun 20, 2026",
+    );
+  });
+
+  it("reports its expanded state and flips it on tap", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+
+    expect(timingLine().props.accessibilityState.expanded).toBe(false);
+    expand();
+    expect(timingLine().props.accessibilityState.expanded).toBe(true);
+    fireEvent.press(timingLine());
+    expect(timingLine().props.accessibilityState.expanded).toBe(false);
+  });
+
+  it("omits the completion suffix by default, matching Focus and Timeline", () => {
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        value={{ dueDate: null, afterStepId: "s2" }}
+        afterStepTitle="Wire the circuits"
+      />,
+    );
+
+    expect(
+      screen.getByTestId("step-timing-editor-after-line"),
+    ).toHaveTextContent("after Wire the circuits");
+  });
+});
+
+describe("StepTimingEditor draft commit and discard", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("does not call onCommit when the editor is collapsed without Done", () => {
+    const onCommit = jest.fn();
+    renderWithProviders(
+      <StepTimingEditor {...baseProps} onCommit={onCommit} />,
+    );
+
+    expand();
+    fireEvent.press(
+      screen.getByTestId("step-timing-editor-grid-day-2026-06-30"),
+    );
+    fireEvent.press(timingLine());
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("discards the abandoned draft on the next open", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+
+    expand();
+    fireEvent.press(
+      screen.getByTestId("step-timing-editor-grid-day-2026-06-30"),
+    );
+    fireEvent.press(timingLine());
+    expand();
+
+    // Back to the committed value (nothing), not the discarded Jun 30.
+    expect(
+      screen.getByTestId("step-timing-editor-grid-day-2026-06-30").props
+        .accessibilityState.selected,
+    ).toBe(false);
+  });
+
+  it("commits the draft once on Done", () => {
+    const onCommit = jest.fn();
+    renderWithProviders(
+      <StepTimingEditor {...baseProps} onCommit={onCommit} />,
+    );
+
+    expand();
+    fireEvent.press(
+      screen.getByTestId("step-timing-editor-grid-day-2026-06-30"),
+    );
+    fireEvent.press(screen.getByTestId("step-timing-editor-depends-on-toggle"));
+    fireEvent.press(
+      screen.getByTestId("step-timing-editor-depends-on-option-s3"),
+    );
+    fireEvent.press(screen.getByTestId("step-timing-editor-done"));
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith({
+      dueDate: "2026-06-30",
+      afterStepId: "s3",
+    });
+  });
+
+  it("calls onClear and collapses on Clear", () => {
+    const onClear = jest.fn();
+    renderWithProviders(<StepTimingEditor {...baseProps} onClear={onClear} />);
+
+    expand();
+    fireEvent.press(screen.getByTestId("step-timing-editor-clear"));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("step-timing-editor-editor")).toBeNull();
+  });
+
+  // Per-field clearing exists, so `Clear` is a convenience and not the only
+  // route to dateless.
+  it("clears just the date by tapping the selected day again", () => {
+    const onCommit = jest.fn();
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        value={{ dueDate: "2026-06-30", afterStepId: "s3" }}
+        onCommit={onCommit}
+      />,
+    );
+
+    expand();
+    fireEvent.press(
+      screen.getByTestId("step-timing-editor-grid-day-2026-06-30"),
+    );
+    fireEvent.press(screen.getByTestId("step-timing-editor-done"));
+
+    expect(onCommit).toHaveBeenCalledWith({
+      dueDate: null,
+      afterStepId: "s3",
+    });
+  });
+
+  it("clears just the dependency by choosing nothing", () => {
+    const onCommit = jest.fn();
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        value={{ dueDate: "2026-06-30", afterStepId: "s3" }}
+        onCommit={onCommit}
+      />,
+    );
+
+    expand();
+    fireEvent.press(screen.getByTestId("step-timing-editor-depends-on-toggle"));
+    fireEvent.press(
+      screen.getByTestId("step-timing-editor-depends-on-option-nothing"),
+    );
+    fireEvent.press(screen.getByTestId("step-timing-editor-done"));
+
+    expect(onCommit).toHaveBeenCalledWith({
+      dueDate: "2026-06-30",
+      afterStepId: null,
+    });
+  });
+});
+
+describe("StepTimingEditor candidate list", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const openPicker = () => {
+    expand();
+    fireEvent.press(screen.getByTestId("step-timing-editor-depends-on-toggle"));
+  };
+
+  it("offers every candidate plus nothing, including sub-steps", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+    openPicker();
+
+    expect(
+      screen.getByTestId("step-timing-editor-depends-on-option-nothing"),
+    ).toBeOnTheScreen();
+    for (const candidate of CANDIDATES) {
+      expect(
+        screen.getByTestId(
+          `step-timing-editor-depends-on-option-${candidate.id}`,
+        ),
+      ).toBeOnTheScreen();
+    }
+  });
+
+  it("marks the current selection and only it", () => {
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        value={{ dueDate: null, afterStepId: "s3" }}
+      />,
+    );
+    openPicker();
+
+    expect(
+      screen.getByTestId("step-timing-editor-depends-on-option-s3").props
+        .accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      screen.getByTestId("step-timing-editor-depends-on-option-s3b").props
+        .accessibilityState.selected,
+    ).toBe(false);
+    expect(
+      screen.getByTestId("step-timing-editor-depends-on-option-nothing").props
+        .accessibilityState.selected,
+    ).toBe(false);
+  });
+
+  it("marks nothing as selected when there is no dependency", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+    openPicker();
+
+    expect(
+      screen.getByTestId("step-timing-editor-depends-on-option-nothing").props
+        .accessibilityState.selected,
+    ).toBe(true);
+  });
+
+  it("renders a completed candidate as completed rather than refusing it", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+    openPicker();
+
+    const completed = screen.getByTestId(
+      "step-timing-editor-depends-on-option-s2",
+    );
+    // The ordinal slot reads as a check; the candidate stays pickable.
+    expect(within(completed).getByText("✓")).toBeOnTheScreen();
+    expect(completed.props.accessibilityState?.disabled).toBeFalsy();
+  });
+
+  it("shows the empty-state copy instead of an empty box", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} candidates={[]} />);
+    openPicker();
+
+    expect(
+      screen.getByTestId("step-timing-editor-depends-on-empty"),
+    ).toHaveTextContent("No other steps in this goal yet.");
+    expect(
+      screen.queryByTestId("step-timing-editor-depends-on-list"),
+    ).toBeNull();
+  });
+});
+
+describe("StepTimingEditor ordering note", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const note = () => screen.queryByTestId("step-timing-editor-ordering-note");
+
+  const openWith = (dueDate: string | null, afterStepId: string | null) => {
+    renderWithProviders(
+      <StepTimingEditor {...baseProps} value={{ dueDate, afterStepId }} />,
+    );
+    expand();
+  };
+
+  test.each<[string | null, string | null, boolean, string]>([
+    ["2026-06-26", "s3", true, "draft day falls before the dependency's"],
+    ["2026-06-30", "s3", false, "same day as the dependency"],
+    ["2026-07-02", "s3", false, "after the dependency"],
+    ["2026-06-26", "s2", false, "dependency has no day of its own"],
+    ["2026-06-26", null, false, "no dependency at all"],
+    [null, "s3", false, "no day on this step"],
+  ])("due %s + after %s → note shown: %s (%s)", (due, after, shown) => {
+    openWith(due, after);
+    if (shown) {
+      expect(note()).toBeOnTheScreen();
+    } else {
+      expect(note()).toBeNull();
+    }
+  });
+
+  it("states the fact in plain copy, naming the dependency and its day", () => {
+    openWith("2026-06-26", "s3");
+
+    expect(note()).toHaveTextContent(
+      "Inspection & labels needs to be done first, and it sits on 2026-06-30. " +
+        "This one lands before it — that's allowed, it just won't read in order.",
+    );
+  });
+
+  // Informs, never enforces: no alert role, nothing disabled, and the choice
+  // that triggered it stands.
+  it("is neutral — no alert role, and nothing is disabled or refused", () => {
+    openWith("2026-06-26", "s3");
+
+    expect(note()?.props.accessibilityRole).toBeUndefined();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(
+      screen.getByTestId("step-timing-editor-grid-day-2026-06-26").props
+        .accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      screen.getByTestId("step-timing-editor-done").props.accessibilityState
+        ?.disabled,
+    ).toBeFalsy();
+  });
+});
+
+describe("StepTimingEditor a11y", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("gives the timing line a role and a label", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+
+    expect(timingLine().props.accessibilityRole).toBe("button");
+    expect(timingLine().props.accessibilityLabel).toBe("Timing for this step");
+  });
+
+  test.each([
+    ["step-timing-editor-depends-on-toggle"],
+    ["step-timing-editor-clear"],
+    ["step-timing-editor-done"],
+  ])("%s is a labelled button", (testID) => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+    expand();
+
+    const element = screen.getByTestId(testID);
+    expect(element.props.accessibilityRole).toBe("button");
+    expect(element.props.accessibilityLabel).toBeTruthy();
+  });
+
+  it("labels every candidate row", () => {
+    renderWithProviders(<StepTimingEditor {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByTestId("step-timing-editor-depends-on-toggle"));
+
+    for (const candidate of CANDIDATES) {
+      const row = screen.getByTestId(
+        `step-timing-editor-depends-on-option-${candidate.id}`,
+      );
+      expect(row.props.accessibilityRole).toBe("button");
+      expect(row.props.accessibilityLabel).toBe(candidate.title);
+    }
+  });
+});

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx
@@ -300,8 +300,15 @@ describe("StepTimingEditor candidate list", () => {
     const completed = screen.getByTestId(
       "step-timing-editor-depends-on-option-s2",
     );
-    // The ordinal slot reads as a check; the candidate stays pickable.
-    expect(within(completed).getByText("✓")).toBeOnTheScreen();
+    const pending = screen.getByTestId(
+      "step-timing-editor-depends-on-option-s3",
+    );
+
+    // A completed candidate drops its ordinal for a check mark; a pending one
+    // keeps its ordinal. Either way the candidate stays pickable — completed
+    // is a fact about it, not a refusal.
+    expect(within(completed).queryByText("2")).toBeNull();
+    expect(within(pending).getByText("3")).toBeOnTheScreen();
     expect(completed.props.accessibilityState?.disabled).toBeFalsy();
   });
 

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/StepTimingEditor.test.tsx
@@ -383,11 +383,32 @@ describe("StepTimingEditor ordering note", () => {
 describe("StepTimingEditor a11y", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("gives the timing line a role and a label", () => {
+  // The label overrides the children's text, so a constant would announce the
+  // same thing set or unset — it has to carry the state instead.
+  it("labels the unset timing line as a prompt", () => {
     renderWithProviders(<StepTimingEditor {...baseProps} />);
 
     expect(timingLine().props.accessibilityRole).toBe("button");
-    expect(timingLine().props.accessibilityLabel).toBe("Timing for this step");
+    expect(timingLine().props.accessibilityLabel).toBe(
+      "Set timing for this step",
+    );
+  });
+
+  it("reads the truth lines back once timing is set", () => {
+    renderWithProviders(
+      <StepTimingEditor
+        {...baseProps}
+        value={{ dueDate: "2026-07-02", afterStepId: "s2" }}
+        afterStepTitle="Wire the circuits"
+        afterStepIsCompleted
+        dueDateLabel="Jul 2, 2026"
+      />,
+    );
+
+    // "done" as a word: a screen reader given `· done ✓` reads punctuation.
+    expect(timingLine().props.accessibilityLabel).toBe(
+      "after Wire the circuits, done, due Jul 2, 2026",
+    );
   });
 
   test.each([

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/forbiddenCopy.test.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/forbiddenCopy.test.ts
@@ -11,8 +11,7 @@ import { join } from "path";
  * would make the label lie.
  *
  * The rest come from ADR-0012's no-auto-judgment rule — no "overdue"/"late"
- * framing on a passed date, and no "missing"/"needed"/"required" framing on an
- * unset one.
+ * framing on a passed date, and no "missing"/"needed" framing on an unset one.
  */
 const FORBIDDEN = [
   "blocked",
@@ -30,40 +29,95 @@ const FORBIDDEN = [
  */
 const SANCTIONED = ["not a deadline", "reads as “late.”"];
 
+const isSanctioned = (text: string) =>
+  SANCTIONED.some((ok) => text.includes(ok));
+
 const COMPONENT_DIRS = ["StepTimingEditor", "StepDayGrid"];
 
-function sourceFiles(dir: string): string[] {
+/**
+ * String literals that can reach a user, per source file. Comments are stripped
+ * first: doc comments are where the ban is *explained*, and a rule that bans
+ * its own explanation would be undocumentable.
+ */
+function userFacingLiterals(dir: string): string[] {
   const base = join(__dirname, "..", "..", dir);
-  return readdirSync(base)
+  const files = readdirSync(base)
     .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes(".stories."))
     .map((f) => join(base, f));
+
+  expect(files.length).toBeGreaterThan(0);
+
+  return files.flatMap((file) => {
+    const source = readFileSync(file, "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "");
+    return source.match(/"[^"\n]*"|'[^'\n]*'|`[^`\n]*`/g) ?? [];
+  });
 }
 
 describe.each(COMPONENT_DIRS)("%s forbidden copy", (dir) => {
-  const files = sourceFiles(dir);
-
-  it("has source files to check", () => {
-    expect(files.length).toBeGreaterThan(0);
-  });
+  // Read and strip once per directory, not once per forbidden word.
+  const literals = userFacingLiterals(dir).filter((l) => !isSanctioned(l));
 
   test.each(FORBIDDEN)(
     "never ships the word %p in a string literal",
     (word) => {
-      for (const file of files) {
-        // Strip comments first: prose in doc comments is where we explain *why*
-        // these words are banned, and a rule that bans its own explanation would
-        // be undocumentable. Only what can reach a user is checked.
-        const source = readFileSync(file, "utf8")
-          .replace(/\/\*[\s\S]*?\*\//g, "")
-          .replace(/\/\/[^\n]*/g, "");
-
-        const literals = source.match(/"[^"\n]*"|'[^'\n]*'|`[^`\n]*`/g) ?? [];
-
-        for (const literal of literals) {
-          if (SANCTIONED.some((ok) => literal.includes(ok))) continue;
-          expect(literal.toLowerCase()).not.toContain(word);
-        }
+      for (const literal of literals) {
+        expect(literal.toLowerCase()).not.toContain(word);
       }
     },
   );
+});
+
+/**
+ * The half of this guard that survives #576.
+ *
+ * These components deliberately carry English copy defaults today (the D7
+ * convention), but #576 moves that copy into the i18n resources — at which
+ * point a scan of component sources alone would protect nothing and would pass
+ * silently forever. So scan the resources the copy is headed for too.
+ *
+ * Scoped to the namespaces that carry step-planning copy — the surfaces
+ * ADR-0010/0012 actually govern — and deliberately **not** every namespace. The
+ * ban is on planning *framing*, not on the English words: `evidenceViewer`
+ * legitimately says a photo file "is missing" (it is), and `permissions` says
+ * "Camera Access Needed" (it is). Policing those would be a false positive that
+ * teaches people to weaken the guard.
+ *
+ * Widening this to every component and screen, in `src/__tests__/structure/`,
+ * is tracked as a follow-up.
+ */
+const PLANNING_NAMESPACES = ["editGoal", "timelineJourney", "focusMode"];
+
+describe("planning-copy i18n resources", () => {
+  const enDir = join(__dirname, "..", "..", "..", "i18n", "resources", "en");
+
+  /** Every string value in a namespace bundle, flattened depth-first. */
+  function stringValues(node: unknown): string[] {
+    if (typeof node === "string") return [node];
+    if (node && typeof node === "object") {
+      return Object.values(node).flatMap(stringValues);
+    }
+    return [];
+  }
+
+  const copy = PLANNING_NAMESPACES.flatMap((namespace) => {
+    const bundle = JSON.parse(
+      readFileSync(join(enDir, `${namespace}.json`), "utf8"),
+    );
+    return stringValues(bundle)
+      .filter((value) => !isSanctioned(value))
+      .map((value) => ({ namespace, value }));
+  });
+
+  it("has planning copy to check", () => {
+    expect(copy.length).toBeGreaterThan(0);
+  });
+
+  test.each(FORBIDDEN)("no planning copy ships the word %p", (word) => {
+    const offenders = copy.filter((entry) =>
+      entry.value.toLowerCase().includes(word),
+    );
+    expect(offenders).toEqual([]);
+  });
 });

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/forbiddenCopy.test.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/forbiddenCopy.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+/**
+ * The words this surface may never use, in copy or in a11y labels.
+ *
+ * "blocked" is the load-bearing one (ADR-0010/0012, settled in #384): nothing
+ * here is blocked. The complete action stays live on a step whose dependency is
+ * still open, and for an external wait, completing it *is* "the event
+ * happened". Borrowing a gate word for something we deliberately refuse to gate
+ * would make the label lie.
+ *
+ * The rest come from ADR-0012's no-auto-judgment rule — no "overdue"/"late"
+ * framing on a passed date, and no "missing"/"needed"/"required" framing on an
+ * unset one.
+ */
+const FORBIDDEN = [
+  "blocked",
+  "overdue",
+  "missing",
+  "needed",
+  "deadline",
+  "late",
+];
+
+/**
+ * The two sanctioned appearances, both inside the intent sub-line — which is
+ * the copy that *disclaims* those readings: "Your intent, not a deadline. A
+ * passed date never reads as “late.”"
+ */
+const SANCTIONED = ["not a deadline", "reads as “late.”"];
+
+const COMPONENT_DIRS = ["StepTimingEditor", "StepDayGrid"];
+
+function sourceFiles(dir: string): string[] {
+  const base = join(__dirname, "..", "..", dir);
+  return readdirSync(base)
+    .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes(".stories."))
+    .map((f) => join(base, f));
+}
+
+describe.each(COMPONENT_DIRS)("%s forbidden copy", (dir) => {
+  const files = sourceFiles(dir);
+
+  it("has source files to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  test.each(FORBIDDEN)(
+    "never ships the word %p in a string literal",
+    (word) => {
+      for (const file of files) {
+        // Strip comments first: prose in doc comments is where we explain *why*
+        // these words are banned, and a rule that bans its own explanation would
+        // be undocumentable. Only what can reach a user is checked.
+        const source = readFileSync(file, "utf8")
+          .replace(/\/\*[\s\S]*?\*\//g, "")
+          .replace(/\/\/[^\n]*/g, "");
+
+        const literals = source.match(/"[^"\n]*"|'[^'\n]*'|`[^`\n]*`/g) ?? [];
+
+        for (const literal of literals) {
+          if (SANCTIONED.some((ok) => literal.includes(ok))) continue;
+          expect(literal.toLowerCase()).not.toContain(word);
+        }
+      }
+    },
+  );
+});

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/readOutParity.test.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/readOutParity.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { renderWithProviders, screen } from "../../../__tests__/test-utils";
+import { formatDate } from "../../../utils/format";
+import { TimelineStep } from "../../TimelineStep";
+import { StepTimingEditor } from "../StepTimingEditor";
+
+/**
+ * #573's read-out parity check: a step authored in the editor, then opened in
+ * Focus or Timeline, must produce the same line. If it does not, the input is
+ * wrong — so this asserts the strings against each other rather than against a
+ * hard-coded copy of either.
+ *
+ * Both sides are driven from the same `formatDate` output, so a change to the
+ * formatter breaks this test rather than silently diverging the two surfaces.
+ */
+const NOW = new Date(2026, 5, 24);
+const DUE_ISO = "2026-06-30";
+const DUE_LABEL = formatDate(DUE_ISO, "en-US");
+const AFTER_TITLE = "Inspection & labels";
+
+function renderTimelineBand() {
+  const { unmount } = renderWithProviders(
+    <TimelineStep
+      step={{
+        id: "step-4",
+        title: "Mount the panels",
+        status: "pending",
+        evidenceCount: 0,
+        afterStep: AFTER_TITLE,
+        dueDate: DUE_LABEL,
+      }}
+      stepIndex={3}
+      evidence={[]}
+      onNodePress={jest.fn()}
+      onEvidencePress={jest.fn()}
+    />,
+  );
+
+  const lines = {
+    after: screen.getByText(`after ${AFTER_TITLE}`).props.children,
+    due: screen.getByText(`due ${DUE_LABEL}`).props.children,
+  };
+  unmount();
+  return lines;
+}
+
+function renderEditorLines() {
+  const { unmount } = renderWithProviders(
+    <StepTimingEditor
+      value={{ dueDate: DUE_ISO, afterStepId: "s3" }}
+      now={NOW}
+      candidates={[
+        { id: "s3", title: AFTER_TITLE, label: "3", dueDate: DUE_ISO },
+      ]}
+      afterStepTitle={AFTER_TITLE}
+      dueDateLabel={DUE_LABEL}
+      onCommit={jest.fn()}
+      onClear={jest.fn()}
+    />,
+  );
+
+  const lines = {
+    after: screen.getByTestId("step-timing-editor-after-line").props.children,
+    due: screen.getByTestId("step-timing-editor-due-line").props.children,
+  };
+  unmount();
+  return lines;
+}
+
+/** Flatten a Text's children to the string a reader would hear. */
+function textOf(children: unknown): string {
+  if (children == null || typeof children === "boolean") return "";
+  if (Array.isArray(children)) return children.map(textOf).join("");
+  if (typeof children === "object" && "props" in (children as object)) {
+    return textOf(
+      (children as { props: { children?: unknown } }).props.children,
+    );
+  }
+  return String(children);
+}
+
+describe("read-out parity with Timeline", () => {
+  it("renders the same `after` line Timeline renders", () => {
+    const timeline = renderTimelineBand();
+    const editor = renderEditorLines();
+
+    expect(textOf(editor.after)).toBe(textOf(timeline.after));
+  });
+
+  it("renders the same `due` line Timeline renders", () => {
+    const timeline = renderTimelineBand();
+    const editor = renderEditorLines();
+
+    expect(textOf(editor.due)).toBe(textOf(timeline.due));
+  });
+
+  /**
+   * The suffix is opt-in and off by default precisely so the two surfaces
+   * agree. Neither Focus nor Timeline renders a completion suffix today —
+   * `resolveStepDependencyBand` supplies no done-state to back one — so the
+   * default render must carry none either.
+   */
+  it("carries no completion suffix at the default", () => {
+    const editor = renderEditorLines();
+
+    expect(textOf(editor.after)).toBe(`after ${AFTER_TITLE}`);
+    expect(textOf(editor.after)).not.toContain("done");
+    expect(textOf(editor.after)).not.toContain("✓");
+  });
+});

--- a/apps/native-rd/src/components/StepTimingEditor/__tests__/readOutParity.test.tsx
+++ b/apps/native-rd/src/components/StepTimingEditor/__tests__/readOutParity.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { renderWithProviders, screen } from "../../../__tests__/test-utils";
 import { formatDate } from "../../../utils/format";
+import { i18n } from "../../../i18n";
 import { TimelineStep } from "../../TimelineStep";
 import { StepTimingEditor } from "../StepTimingEditor";
 
@@ -106,5 +107,44 @@ describe("read-out parity with Timeline", () => {
     expect(textOf(editor.after)).toBe(`after ${AFTER_TITLE}`);
     expect(textOf(editor.after)).not.toContain("done");
     expect(textOf(editor.after)).not.toContain("✓");
+  });
+});
+
+/**
+ * The tests above compare two *rendered* surfaces, which is the parity that
+ * matters today. But #576 replaces these components' English defaults with
+ * `t()` output, and at that point the default path stops being rendered at all
+ * — so a test that only exercises the defaults would keep passing while the
+ * surfaces silently diverged.
+ *
+ * These pin the defaults to the resources that will replace them. A change to
+ * either JSON now breaks this file, which is the drift actually worth catching.
+ */
+describe("copy defaults match the i18n resources that will replace them", () => {
+  const title = "Inspection & labels";
+  const date = "Jun 30, 2026";
+
+  it("Timeline's `after` resource matches the default", () => {
+    expect(i18n.t("timelineJourney:step.metadata.after", { title })).toBe(
+      `after ${title}`,
+    );
+  });
+
+  it("Focus's `after` resource matches the default", () => {
+    expect(i18n.t("focusMode:currentTask.metadata.after", { title })).toBe(
+      `after ${title}`,
+    );
+  });
+
+  it("Timeline's `due` resource matches the default", () => {
+    expect(i18n.t("timelineJourney:step.metadata.due", { date })).toBe(
+      `due ${date}`,
+    );
+  });
+
+  it("Focus's `due` resource matches the default", () => {
+    expect(i18n.t("focusMode:currentTask.metadata.due", { date })).toBe(
+      `due ${date}`,
+    );
   });
 });

--- a/apps/native-rd/src/components/StepTimingEditor/index.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/index.ts
@@ -1,0 +1,7 @@
+export { StepTimingEditor } from "./StepTimingEditor";
+export { TOUCH_TARGET_MIN } from "./StepTimingEditor.styles";
+export type {
+  StepTimingCandidate,
+  StepTimingEditorProps,
+  StepTimingValue,
+} from "./types";

--- a/apps/native-rd/src/components/StepTimingEditor/index.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/index.ts
@@ -1,5 +1,5 @@
 export { StepTimingEditor } from "./StepTimingEditor";
-export { TOUCH_TARGET_MIN } from "./StepTimingEditor.styles";
+
 export type {
   StepTimingCandidate,
   StepTimingEditorProps,

--- a/apps/native-rd/src/components/StepTimingEditor/index.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/index.ts
@@ -4,4 +4,5 @@ export type {
   StepTimingCandidate,
   StepTimingEditorProps,
   StepTimingValue,
+  TimingLineA11yParts,
 } from "./types";

--- a/apps/native-rd/src/components/StepTimingEditor/types.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/types.ts
@@ -1,0 +1,114 @@
+import type { View } from "react-native";
+import type { RefObject } from "react";
+import type { StepDayMark } from "../StepDayGrid";
+
+/** A step (or sub-step) this one may depend on. */
+export interface StepTimingCandidate {
+  id: string;
+  title: string;
+  /** Ordinal badge text — "1", "2", "a". Assigned by the list, not derived here. */
+  label: string;
+  /** True for a sub-step: indents the row, matching the prototype's `.is-child`. */
+  isSubStep?: boolean;
+  /** Renders the ordinal slot as a check and the title in the completed treatment. */
+  isCompleted?: boolean;
+  /** This candidate's own day, `YYYY-MM-DD` or null — feeds the ordering note. */
+  dueDate: string | null;
+  /** This candidate's day, pre-formatted for the active locale (`formatDate`). */
+  dueDateLabel?: string;
+}
+
+/** The draft values handed back on commit. */
+export interface StepTimingValue {
+  /** `YYYY-MM-DD` or null. Conversion to a branded `DateIso` is #576's job. */
+  dueDate: string | null;
+  /** Candidate id, or null for `nothing`. Unvalidated by design. */
+  afterStepId: string | null;
+}
+
+export interface StepTimingEditorProps {
+  /** Current committed timing for this step. */
+  value: StepTimingValue;
+  /** Required, injected — never read the clock inside (same rule as StepDayGrid). */
+  now: Date;
+  /**
+   * Every step and sub-step in the goal **except this one** — the caller
+   * filters. An empty array is a supported state (a goal's first step) and
+   * renders the empty copy rather than an empty box.
+   */
+  candidates: readonly StepTimingCandidate[];
+  /**
+   * Whether this step is completed. A completed step with no timing renders
+   * **no** `＋ when?` — nothing is left to plan on it — but still shows the
+   * timing it already has.
+   */
+  isCompleted?: boolean;
+  /**
+   * The current dependency's title, pre-resolved by the caller the way
+   * `resolveStepDependencyBand` resolves it (unresolvable → null → no line).
+   */
+  afterStepTitle?: string | null;
+  /**
+   * Whether that dependency is completed. Defaults to `false`, which keeps the
+   * rendered line byte-identical to Focus and Timeline; see the component doc.
+   */
+  afterStepIsCompleted?: boolean;
+  /** `value.dueDate` pre-formatted for the active locale via `formatDate`. */
+  dueDateLabel?: string | null;
+  /** Days other steps sit on, forwarded to the grid. */
+  marks?: readonly StepDayMark[];
+  /** BCP-47 tag, forwarded to the grid and used for nothing else. */
+  locale?: string;
+
+  /** Fires on `Done` with the draft. Never fires on collapse-without-Done. */
+  onCommit: (next: StepTimingValue) => void;
+  /** Fires on `Clear` — removes both the date and the dependency. */
+  onClear: () => void;
+
+  /**
+   * Controlled expansion. Omit for uncontrolled; supply both to enforce
+   * "only one editor open at a time" across sibling rows, which a
+   * self-contained component cannot do alone.
+   */
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  /**
+   * Fired when the row expands, with this row's root `View` ref, so the host
+   * can `measureLayout` against its ScrollView and park the row at the top of
+   * the list. Without it the editor can unfold below the fold and the tap reads
+   * as having done nothing — a verified failure in the prototype.
+   */
+  onExpand?: (rowRef: RefObject<View | null>) => void;
+
+  // --- Copy: caller-supplied with English defaults (the D7 convention). ---
+  /** The single unset affordance. */
+  whenPromptLabel?: string;
+  /** The editor's question. */
+  questionLabel?: string;
+  /** The ADR-0012 promise for B. */
+  intentSubLabel?: string;
+  /** Field label above the dependency control. */
+  dependsOnLabel?: string;
+  /** Placeholder and clear option for the dependency. */
+  nothingLabel?: string;
+  /** Copy shown when `candidates` is empty. */
+  noCandidatesLabel?: string;
+  clearLabel?: string;
+  doneLabel?: string;
+  /** The `after` truth line. Must match Focus/Timeline's wording. */
+  afterLineLabel?: (title: string) => string;
+  /** The `due` truth line. Must match Focus/Timeline's wording. */
+  dueLineLabel?: (date: string) => string;
+  /** Opt-in suffix when the dependency is completed. */
+  doneSuffixLabel?: string;
+  /** The neutral ordering note. */
+  orderingNote?: (dependencyTitle: string, dependencyDate: string) => string;
+  /** a11y label on the timing line. */
+  timingLineA11yLabel?: string;
+  /** Copy forwarded to the embedded grid. */
+  previousMonthLabel?: string;
+  nextMonthLabel?: string;
+  legendLabel?: string;
+  marksA11ySuffix?: (count: number) => string;
+  testID?: string;
+}

--- a/apps/native-rd/src/components/StepTimingEditor/types.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/types.ts
@@ -18,6 +18,16 @@ export interface StepTimingCandidate {
   dueDateLabel?: string;
 }
 
+/** What the timing line currently renders, handed to `timingLineA11yLabel`. */
+export interface TimingLineA11yParts {
+  /** The rendered `after …` line, or null when there is no dependency. */
+  afterLine: string | null;
+  /** The rendered `due …` line, or null when there is no date. */
+  dueLine: string | null;
+  /** Whether the dependency is completed (the `· done ✓` suffix's state). */
+  afterStepIsCompleted: boolean;
+}
+
 /** The draft values handed back on commit. */
 export interface StepTimingValue {
   /** `YYYY-MM-DD` or null. Conversion to a branded `DateIso` is #576's job. */
@@ -103,8 +113,13 @@ export interface StepTimingEditorProps {
   doneSuffixLabel?: string;
   /** The neutral ordering note. */
   orderingNote?: (dependencyTitle: string, dependencyDate: string) => string;
-  /** a11y label on the timing line. */
-  timingLineA11yLabel?: string;
+  /**
+   * a11y label on the timing line, built from what the line renders. A constant
+   * string here would override the children's text and announce the same thing
+   * whether timing is set or not, so this takes the current lines instead —
+   * defaults to reading them back, or to a "set timing" prompt when unset.
+   */
+  timingLineA11yLabel?: (parts: TimingLineA11yParts) => string;
   /**
    * Copy forwarded verbatim to the embedded `StepDayGrid`. Grouped rather than
    * flattened so the grid's copy surface stays the grid's — adding one there

--- a/apps/native-rd/src/components/StepTimingEditor/types.ts
+++ b/apps/native-rd/src/components/StepTimingEditor/types.ts
@@ -1,6 +1,6 @@
 import type { View } from "react-native";
 import type { RefObject } from "react";
-import type { StepDayMark } from "../StepDayGrid";
+import type { StepDayGridProps, StepDayMark } from "../StepDayGrid";
 
 /** A step (or sub-step) this one may depend on. */
 export interface StepTimingCandidate {
@@ -105,10 +105,14 @@ export interface StepTimingEditorProps {
   orderingNote?: (dependencyTitle: string, dependencyDate: string) => string;
   /** a11y label on the timing line. */
   timingLineA11yLabel?: string;
-  /** Copy forwarded to the embedded grid. */
-  previousMonthLabel?: string;
-  nextMonthLabel?: string;
-  legendLabel?: string;
-  marksA11ySuffix?: (count: number) => string;
+  /**
+   * Copy forwarded verbatim to the embedded `StepDayGrid`. Grouped rather than
+   * flattened so the grid's copy surface stays the grid's — adding one there
+   * does not mean editing this file too.
+   */
+  gridCopy?: Pick<
+    StepDayGridProps,
+    "previousMonthLabel" | "nextMonthLabel" | "legendLabel" | "marksA11ySuffix"
+  >;
   testID?: string;
 }


### PR DESCRIPTION
Closes #574. Closes #573.

Both issues in one PR: #573's editor embeds #574's grid, and the two are one interaction that cannot be reviewed apart. Storybook only — no screen wiring (#576) and not the row itself (#575).

## What ships

**`StepDayGrid`** (#574) — a themed month grid, the only way a day gets named in this app, so every day is reachable. Unbounded month navigation, Monday-first weeks, and no day is ever disabled: past days read quieter but stay selectable, because both the `was expected` reading (#571) and an ordinary "I meant last Tuesday" depend on it. Marks render other steps' ordinals on the days they sit on — the point of the redesign is that you place a day against the rest of the plan instead of from memory. Emits plain `YYYY-MM-DD`; the branded `DateIso` conversion stays with the caller (#576).

**`StepTimingEditor`** (#573) — the in-row editor for a step's B and C lines. No sheet, no `Modal`, no scrim; one timing line per row rather than two ghost chips; a completed step carries no `＋ when?` at all. Draft-then-commit, so collapsing without `Done` discards. The ordering note states the fact in plain body copy when a step's day falls before its dependency's — no icon, no red, nothing disabled, nothing refused.

`afterStepId` stays unvalidated by design. `waiting on` is deliberately absent — it belongs in Focus, mid-ride, and needs its own issue under #570.

## Assumptions worth a reviewer's attention

**The `· done ✓` suffix does not ship on by default, and that is deliberate.** #573 asks for the row's set state to show the truth-lines "exactly as Focus and Timeline render them — `↩ after <title> · done ✓`". Focus and Timeline render **no such suffix**, and `FocusCurrentTaskCard.parts.tsx` says why in a comment: `afterStep` carries only the prerequisite's title, not its done-state, so a hard-coded suffix would assert a fact the props cannot back. `resolveStepDependencyBand` returns no completion flag. Read-out parity and the suffix are mutually exclusive as written, and parity is the acceptance criterion — so `afterStepIsCompleted` is opt-in and defaults to `false`, at which point the rendered line is byte-identical to both surfaces (asserted, not assumed). Making the suffix canonical is a change to Focus, Timeline and the resolver together.

**`largeText` is not one of the seven registered themes** — it is a composable variant, and `ScopedTheme` only accepts registered names. The density check renders under `light-lowVision`, which carries the identical `sizeL` scale.

**The prototype's `Jun 30` becomes `Jun 30, 2026`** — `formatDate` has no year-less mode, and parity with the shipped read-out wins.

Candidate empty-state copy (`No other steps in this goal yet.`) was unspecified; it is a prop default.

## Review pass

A reuse / simplification / efficiency / altitude pass ran on the branch and its findings are applied:

- The footer is the shared `Button` and the month nav is `IconButton` with Phosphor carets, so both pick up the neo-brutalist pressed-translate instead of a bespoke `opacity`. The completed-candidate check and selection tick became Phosphor icons (design system Rule 8) — but the truth lines keep `↩`/`▦` as text runs, because `FocusCurrentTaskCard` ships them that way and parity wins.
- Dropping the per-cell wrapper views took the grid from 114 to 77 host nodes and ~24% off a month-nav re-render (measured); the grid is memoised with a stable `onChange` so working the picker no longer re-renders 31 day cells.
- **Both guards had an expiry date.** The parity test and the forbidden-copy test only exercised the English defaults — exactly the strings #576 replaces — so both would have kept passing while the surfaces diverged. Parity now pins the defaults to the i18n resources, and forbidden-copy scans the planning namespaces too. Scoped to those on purpose: `evidenceViewer` legitimately says a photo file "is missing", and `permissions` says "Camera Access Needed".

Eight findings were deliberately deferred rather than bolted on — a shared `MetadataBand` across Timeline/Focus/editor, moving the forbidden-copy check app-wide, a `useParkRowAtTop` hook for #575, and five others. All recorded under "Follow-ups from review" in the dev plan.

## Verification

- 211 suites / 10,159 tests pass; type-check and lint clean (0 errors).
- Forbidden-copy guard verified to **fail** on a planted `"this step is blocked"` before being restored — it is not passing vacuously.
- Badge centring fixed and confirmed in Storybook web: the shared `Text` defaults to the body variant, whose `lineHeight` of 26 overflowed a 20pt badge and pushed the glyph high, and horizontal padding widened single-character badges into ovals.
- 18 new files, **zero existing files modified** — `queries.ts`, `format.ts` and the i18n resources stayed read-only references.

## Knock-ons for the epic

- **#575** still says "row chips `+ depends` / `+ date`". There is now one timing line per row, so it needs rescoping before it starts, and it should adopt the controlled `expanded` prop plus the `onExpand` wiring the `InsideAScrollingList` story demonstrates.
- **PR #582** is not a dependency — there is no sheet in this design. It lands on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL5FMragM6PzBNunF18jof
