### PR TITLE
feat(native-rd): ES256 VC-JWT proof + resolvable P-256 did:key — close gaps 5 and 7

### DIFF
--- a/apps/native-rd/docs/architecture/ob3-compliance-status.md
+++ b/apps/native-rd/docs/architecture/ob3-compliance-status.md
@@ -67,14 +67,16 @@ Each gap below is a real validator error, mapped to the line of code that produc
 | Cause     | `assertion.issuedOn` is set but not surfaced as the VC envelope's `issuanceDate`. |
 | Fix scope | Schema-shape only.                                                                |
 
-### 5. Non-standard cryptosuite
+### 5. Non-standard cryptosuite — **addressed (#598), pending re-validation**
 
-|           |                                                                                                                                                                                                |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Validator | `No proof with type any of ("Ed25519Signature2020", "DataIntegrityProof" with cryptosuite attr of "eddsa-rdfc-2022" or "eddsa-2022") or proof purpose "assertionMethod" found`                 |
-| Source    | [`useCreateBadge.ts:200-205`](../../src/hooks/useCreateBadge.ts)                                                                                                                               |
-| Cause     | Cryptosuite is `eddsa-raw-json-iteration-a`. Signature is over raw `JSON.stringify(credential)`, not RDFC-1.0 canonicalized form. `proofValue` is bare base64url, not multibase `u…`-prefixed. |
-| Fix scope | Crypto. Requires RDFC-1.0 canonicalization (W3C Data Integrity), multibase encoding, cryptosuite rename.                                                                                       |
+|              |                                                                                                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Validator    | `No proof with type any of ("Ed25519Signature2020", "DataIntegrityProof" with cryptosuite attr of "eddsa-rdfc-2022" or "eddsa-2022") or proof purpose "assertionMethod" found`                                           |
+| Was          | Cryptosuite `eddsa-raw-json-iteration-a`. Signature over raw `JSON.stringify(credential)`, not RDFC-1.0 canonicalized form. `proofValue` bare base64url, not multibase `u…`-prefixed.                                    |
+| Now          | The credential **is** a compact ES256 JWS (VC-JWT external proof) — no embedded `proof` member at all. Header is `{alg: "ES256", typ: "JWT", jwk}`; the unsigned VC rides under the `vc` claim.                          |
+| Why not RDFC | The embedded-proof route needs RDFC-1.0 canonicalization, which has no working implementation available to this app. The external route needs none. See [the proof-format spike](../research/ob3-proof-format-spike.md). |
+| Source       | [`vcJwt.ts`](../../src/badges/vcJwt.ts), wired in [`useCreateBadge.ts`](../../src/hooks/useCreateBadge.ts)                                                                                                               |
+| Still open   | Confirming against the live validator is #600's job — the report snapshot linked above predates this change.                                                                                                             |
 
 ### 6. Umbrella `oneOf` failure
 
@@ -83,14 +85,38 @@ Each gap below is a real validator error, mapped to the line of code that produc
 | Validator | `$: must be valid to one and only one schema, but 0 are valid` |
 | Cause     | Consequence of 1–5. Resolves automatically once they're fixed. |
 
-### 7. Non-resolvable `did:key` (related, not flagged by this validator)
+### 7. Non-resolvable `did:key` — **addressed (#598), pending re-validation**
 
-|           |                                                                                                                                                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Source    | [`credentialBuilder.ts:51-56`](../../src/badges/credentialBuilder.ts)                                                                                                                                                           |
-| Cause     | `did:key:${publicKeyJwk.x}` uses raw base64url, not the spec-required multibase (`z…`) + multicodec (`0xed01`) Ed25519 encoding. The DID will not resolve, so signature verification fails even after the cryptosuite is fixed. |
-| Also      | Achievement IDs append a path segment to the DID (`credentialBuilder.ts:76-78`); `did:key` DIDs do not support paths. Use HTTPS URIs instead.                                                                                   |
-| Fix scope | Crypto / identifier. Bundled with #5.                                                                                                                                                                                           |
+|            |                                                                                                                                                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Was        | `did:key:${publicKeyJwk.x}` — raw base64url, not multibase + multicodec. The DID would not resolve, so signature verification failed even with a valid cryptosuite.                                                                                    |
+| Now        | Multibase base58btc (`z`) over multicodec `p256-pub` (`0x1200`) plus a SEC1-compressed point, so a verifier recovers the public key from the DID alone. Encoding: [`did-key.ts`](../../../../packages/openbadges-core/src/crypto/did-key.ts).          |
+| Also (was) | Achievement IDs appended a path segment to the DID; `did:key` DIDs have no path component.                                                                                                                                                             |
+| Also (now) | Achievement IDs are `urn:ulid:<goalId>` — not an HTTPS URI as the earlier note suggested. The app hosts nothing, so a fabricated `https://` achievement URL would never resolve; `urn:ulid:` matches the evidence IRIs already emitted alongside them. |
+| Source     | [`credentialBuilder.ts`](../../src/badges/credentialBuilder.ts)                                                                                                                                                                                        |
+
+---
+
+## Signing-key migration (#598)
+
+The proof format above needs an **ES256** signature: the validator's
+external-proof path accepts only `RS256`/`ES256` and rejects `EdDSA`
+outright. The device signing key therefore moved from Ed25519 to ECDSA P-256.
+
+Two consequences worth knowing before reading the code:
+
+- **Existing badges are never touched.** `badge.credential` is immutable and
+  the old signature covers the exact old byte serialization, so re-shaping a
+  stored credential would invalidate it without re-signing. Old badges keep
+  their Iteration-A JSON form and their Ed25519 signature — `verify-badge.ts`
+  and `BadgeDetailScreen` both still read that shape, and will need to
+  indefinitely.
+- **An existing key is force-rotated, silently.** On the first launch after
+  upgrading, `useUserKey` treats a non-P-256 stored key exactly like an
+  orphaned one: cleared, and a fresh P-256 key generated. No prompt — that
+  matches the hook's existing no-UI design, and an unrotated user could never
+  produce a badge the validator accepts. Rotation only affects the _next_
+  badge signed.
 
 ---
 

--- a/apps/native-rd/docs/plans/dev-plans/issue-598-vc-jwt-proof-did-key.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-598-vc-jwt-proof-did-key.md
@@ -171,9 +171,9 @@ verified since the spike was written.
 
 - [ ] `SecureStoreKeyProvider.generateKeyPair()`: `crypto.subtle.generateKey`
       params → `{name: "ECDSA", namedCurve: "P-256"}`.
-- [ ] `SecureStoreKeyProvider.sign()`: import params → `{name: "ECDSA",
-  namedCurve: "P-256"}`; sign params → `{name: "ECDSA", hash:
-  "SHA-256"}`.
+- [ ] `SecureStoreKeyProvider.sign()`: import params →
+      `{name: "ECDSA", namedCurve: "P-256"}`; sign params →
+      `{name: "ECDSA", hash: "SHA-256"}`.
 - [ ] `useUserKey`'s verification effect: alongside the existing "orphan"
       branch (key not found in SecureStore → clear), add "wrong algorithm"
       (stored public JWK's `kty`/`crv` isn't P-256 → clear) so a pre-upgrade

--- a/apps/native-rd/docs/plans/dev-plans/issue-598-vc-jwt-proof-did-key.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-598-vc-jwt-proof-did-key.md
@@ -1,0 +1,344 @@
+# Development Plan: Issue #598
+
+## Issue Summary
+
+**Title**: [Crypto] eddsa-rdfc-2022 proof + resolvable did:key — close gaps 5 and 7
+**Type**: enhancement / crypto migration
+**Complexity**: LARGE
+**Estimated Lines**: ~950-1000 lines (impl + tests + docs)
+
+**Scope has changed since the issue was filed.** The issue body still describes
+`eddsa-rdfc-2022` + RDFC-1.0 canonicalization. That framing is stale. Per the
+epic's 2026-08-30 amendment (below), the actual scope is **ES256 VC-JWT
+external proof + a P-256 signing-key migration**. The `did:key` half of the
+issue is unchanged. See D1.
+
+## Intent Verification
+
+- [ ] A badge signed after this change is a compact JWS (three dot-separated
+      base64url segments: `header.payload.signature`), decodable without
+      error, with protected header `alg: "ES256"` and an inline `jwk`.
+- [ ] The signing key's `did:key` identifier is multicodec (`0x1200`,
+      P-256-pub) + base58btc `z`-prefixed — decoding it back to a public key
+      and re-encoding round-trips to the same string.
+- [ ] Achievement IRIs no longer append a path segment to the issuer DID (no
+      more `did:key:z.../achievements/<id>`); they use a plain `urn:ulid:`
+      IRI instead, matching the existing evidence-IRI convention.
+- [ ] `bun run verify:badge` on a freshly earned badge reports `gap5` (proof
+      format) and `gap7` (did:key multibase) as PASS, and the local
+      "system round-trip" check cryptographically verifies the ES256
+      signature against the inline JWK (not skipped).
+- [ ] A device with an existing Ed25519 signing key (pre-upgrade install)
+      gets a fresh P-256 key generated automatically on next launch, with no
+      user-visible prompt (matches `useUserKey`'s existing silent,
+      self-healing behavior).
+- [ ] `BadgeDetailScreen`'s evidence section still renders for a badge signed
+      under the new JWS format (it currently `JSON.parse`s the stored
+      credential directly and would silently show nothing otherwise).
+- [ ] A badge that already exists in the DB from before this change still
+      opens, displays, and exports byte-for-byte unchanged — no migration, no
+      re-serialization, no re-signing on read.
+
+## Dependencies
+
+| Issue | Title                                           | Status                                                  | Type                               |
+| ----- | ----------------------------------------------- | ------------------------------------------------------- | ---------------------------------- |
+| #595  | Epic: OB3 external verification                 | Open (epic, tracking only)                              | —                                  |
+| #596  | [Spike] RDFC-1.0 canonicalization under Hermes  | ✅ Closed — reshaped/answered by the proof-format spike | Was a blocker, now moot            |
+| #597  | [Foundation] OB3 schema shape — gaps 1-4        | ✅ Closed, merged as PR #628 (2026-08-30)               | Blocker (stated in epic amendment) |
+| #599  | [Bug] Export never bakes the credential         | Open, independent                                       | Sibling, not a blocker             |
+| #600  | [Verify] Re-run the validator, refresh snapshot | Open, blocked by the rest                               | Downstream of this issue           |
+
+**Status:** ✅ All stated dependencies met. The issue body says "Blocked by the
+canonicalization spike and by the schema-shape issue" — both are resolved:
+the spike (#596) produced a research doc that answers its own question, and
+the epic's amendment explicitly states "#598 is reshaped and no longer waits
+on a canonicalization verdict... Blocked by #597 only," and #597 merged
+2026-08-30 (PR #628, same day as this research). `has_blockers = false`.
+
+## Objective
+
+Close validator gaps 5 and 7 from `ob3-compliance-status.md`:
+
+- **Gap 5 (proof format):** replace the `eddsa-raw-json-iteration-a`
+  DataIntegrityProof (raw `JSON.stringify` signed, bare base64url
+  `proofValue`) with a spec-compliant **ES256 VC-JWT external proof** —
+  the credential becomes a signed compact JWS, not a JSON object with an
+  embedded `proof` array.
+- **Gap 7 (did:key resolution):** replace `did:key:${jwk.x}` (raw base64url)
+  with a proper multicodec + base58btc-encoded `did:key`, and stop appending
+  path segments to it for achievement IDs.
+
+This requires migrating the badge signing key from Ed25519 to P-256, because
+the validator's external-proof path only accepts `RS256`/`ES256` (EdDSA is
+rejected), per the proof-format spike.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                                                                      | Alternatives Considered                                                                                             | Rationale                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| D1  | Implement per the epic's 2026-08-30 amendment (ES256 VC-JWT + P-256 key), not the issue body's `eddsa-rdfc-2022` text                                                                                                                         | Embedded `eddsa-rdfc-2022` DataIntegrityProof with real URDNA2015 canonicalization (Option A in the spike)          | `docs/research/ob3-proof-format-spike.md` reads the validator's own source: `eddsa-jcs-2022` (the cheap fallback) doesn't exist in the allowlist, there is no working RDFC implementation anywhere in this org's prior art to port, and VC-JWT removes the epic's only open unknown. Epic #595 explicitly reshaped #598's checklist item to "ES256 VC-JWT proof + P-256 key migration" the same day.               |
+| D2  | Leave already-earned badges untouched — no migration, no re-serialization, no re-signing on read                                                                                                                                              | Rebake all existing badges under the new key/format; add a dual-format reader                                       | Extends #597's own D5, established in the merged PR #628: `badge.credential` is an immutable JSON string and the old signature covers the exact old byte serialization; reshaping it post-hoc invalidates the signature without re-signing, which is explicitly out of scope. Same logic applies one level further to the proof format and key.                                                                    |
+| D3  | Force-rotate an existing Ed25519 signing key to a fresh P-256 key automatically, the first time `useUserKey` runs post-upgrade (reusing its existing orphan-clear self-healing path), rather than keeping dual-algorithm support indefinitely | (a) Detect key type at sign time and produce an EdDSA VC-JWT for old keys; (b) prompt the user to opt into rotation | (a) fails the validator outright — Finding 2 of the spike shows `alg: EdDSA` is rejected by `ExternalProofProbe`, so an unrotated user could never produce a passing badge, which breaks the issue's own "Done when" promise for that user. (b) contradicts `useUserKey`'s documented "Silent — no UI" design. Rotation only affects the _next_ badge signed (D2 already covers old ones), so it's a safe default. |
+| D4  | Hand-roll compact-JWS construction in `native-rd` (header/payload build → `keyProvider.sign(keyId, bytes)` → base64url assemble), not `openbadges-core`'s existing `generateJWTProof`                                                         | Call `generateJWTProof` directly                                                                                    | `generateJWTProof` needs the raw private-key JWK (`importJWK`/`SignJWT`), which conflicts with `KeyProvider`'s existing boundary — the private key never leaves `SecureStoreKeyProvider`. The current Iteration-A code already hand-rolls its own signing bytes via `keyProvider.sign()` + a local `toBase64Url` helper (`useCreateBadge.ts:92-98, 249-252`); this is the same shape, extended to JWS.             |
+| D5  | Inline the public key as `jwk` in the JWS protected header, not a dereferenceable `kid` URL                                                                                                                                                   | `kid` pointing at a hosted key document                                                                             | Spike Finding 2: "Inline `jwk` is the right choice for us — no network at verification time," matching a local-first app whose badges must verify offline.                                                                                                                                                                                                                                                         |
+| D6  | New `did-key.ts` module (base58btc + multicodec P-256 encode/decode) lives in `packages/openbadges-core/src/crypto/`, not app-local                                                                                                           | Put it directly in `apps/native-rd/src/badges/credentialBuilder.ts`                                                 | Matches existing precedent — `signature.ts`, `jwt-proof.ts`, `key-provider.ts` already live in that directory as shared, platform-agnostic crypto primitives. `credentialBuilder.ts`'s own docstring says it stays "pure" / non-crypto (signing is delegated elsewhere already).                                                                                                                                   |
+| D7  | Implement base58btc + multicodec varint encode/decode dependency-free (hand-rolled)                                                                                                                                                           | Add a library (`multiformats`, `bs58`, etc.)                                                                        | Spike Finding 5: no multibase/multicodec/base58 package exists anywhere in this monorepo's lockfile today, and the only prior art (the archived `openbadges-modular-server`) also did this dependency-free. Adding an RN-untested transitive dependency for ~2 small, well-specified encodings (both independently unit-testable against known vectors) is not worth the risk.                                     |
+| D8  | Achievement IRIs become `urn:ulid:${goal.id}` instead of `${issuerDid}/achievements/${goal.id}`                                                                                                                                               | Mint a fake `https://` URL (app has no hosted endpoint)                                                             | Matches the existing evidence-IRI convention three lines below in the same file: `id: iri(\`urn:ulid:${ev.id}\`)` (`credentialBuilder.ts:117`). `did:key`DIDs don't support path segments (issue body, confirmed by spike Finding 4), and inventing a non-resolving fake HTTPS URL would be worse than an honest`urn:` IRI.                                                                                        |
+| D9  | `BadgeDetailScreen`'s `extractEvidenceItems` becomes format-aware (JSON object vs. 3-segment JWS string)                                                                                                                                      | Leave it as-is, let the evidence section silently disappear for new badges                                          | #598 is what changes the shape actually written to `badge.credential` for new badges; #599 (export-baking bug) doesn't touch this read path. Deferring this would ship a silent regression the same day this issue merges.                                                                                                                                                                                         |
+
+## Affected Areas
+
+- `packages/openbadges-core/src/crypto/did-key.ts` (**new**): base58btc
+  encode/decode + P-256 multicodec (`0x1200`) `did:key` encode/decode,
+  including EC point compression/decompression (P-256 prime is `≡ 3 mod 4`,
+  so decompression is a single modular exponentiation — no bignum library
+  needed beyond native `BigInt`).
+- `packages/openbadges-core/src/crypto/index.ts`: export the new module.
+- `apps/native-rd/src/crypto/SecureStoreKeyProvider.ts`: `generateKeyPair()`
+  switches from `{name: "Ed25519"}` to `{name: "ECDSA", namedCurve:
+"P-256"}`; `sign()` switches from `"Ed25519"` to `{name: "ECDSA", hash:
+"SHA-256"}`. WebCrypto's ECDSA `sign()` already returns the raw
+  IEEE-P1363 `r‖s` format JWS needs — no extra encoding step.
+- `apps/native-rd/src/hooks/useUserKey.ts`: the orphan-clear self-healing
+  effect gains a second trigger — an existing key whose stored public JWK
+  isn't P-256 is treated the same as an orphan (cleared, regenerated).
+- `apps/native-rd/src/badges/credentialBuilder.ts`: `buildDid()` calls the
+  new did-key module instead of `did:key:${jwk.x}`; achievement IRI drops
+  the path segment (D8).
+- `apps/native-rd/src/hooks/useCreateBadge.ts`: replaces the
+  `DataIntegrityProof` construction (lines ~254-273) with compact-JWS
+  construction (header/payload/signature via `keyProvider.sign`); the final
+  "signed credential" written to `badge.credential` and baked into the PNG
+  becomes the JWS string itself, not a JSON envelope.
+- `apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx`:
+  `extractEvidenceItems` becomes format-aware (D9).
+- `apps/native-rd/scripts/verify-badge.ts`: `gap5`/`gap7` checks and the
+  local "system round-trip" signature check are rewritten for the new
+  scheme (JWS parsing, ES256 verification, multicodec-aware DID check).
+- `apps/native-rd/docs/architecture/ob3-compliance-status.md`: gap 5/7
+  rows updated to reflect the shipped scheme + the key-migration note.
+- Test files mirroring every module above.
+
+**Not touched:** `packages/openbadges-core/src/credentials/serializer.ts` —
+native-rd already builds its signed proof outside `serializeOB3` (per #597's
+D2), so the serializer's own embedded-proof branch is unaffected; the
+`vc` claim wraps the same unsigned VC JSON `serializeOB3` already produces.
+Baking (`png-baking.ts`, both copies) already supports JWS strings end to end
+(`getBakingKeyword`/`unbakePNG` both branch on 3-segment-dot-string vs. JSON
+today) — no change needed there.
+
+## Implementation Plan
+
+### Step 1: did:key encoding — base58btc + P-256 multicodec
+
+**Files**: `packages/openbadges-core/src/crypto/did-key.ts` (new),
+`packages/openbadges-core/src/crypto/index.ts`,
+`packages/openbadges-core/tests/crypto/did-key.test.ts` (new)
+**Commit**: `feat(openbadges-core): add dependency-free P-256 did:key encoding`
+**Changes**:
+
+- [ ] `base58btcEncode`/`base58btcDecode` (standard Bitcoin alphabet, no
+      leading-zero edge case skipped).
+- [ ] `compressP256PublicKey(jwk)`: SEC1 point compression from JWK `x`/`y`
+      → 33-byte `0x02`/`0x03`-prefixed point (parity from `y`'s last byte).
+- [ ] `decompressP256PublicKey(bytes)`: reverse via `y² = x³ - 3x + b mod p`,
+      `sqrt = a^((p+1)/4) mod p` (valid since P-256's prime is `≡ 3 mod 4`) —
+      needed by the local verifier in Step 6.
+- [ ] `encodeP256DidKey(jwk): string` — multicodec varint `0x1200` (bytes
+      `[0x80, 0x24]`) + compressed point, base58btc, `z`-prefixed.
+- [ ] `decodeP256DidKey(did: string): JsonWebKey` — inverse.
+- [ ] Unit tests round-trip against a handful of `crypto.subtle`-generated
+      keypairs (Node has real WebCrypto ECDSA support) plus at least one
+      known-answer vector from the W3C did:key spec's P-256 example, so the
+      test doesn't only check "encode then decode gets the same thing back."
+
+**Risk to de-risk first:** confirm `react-native-quick-crypto` 1.1.6
+actually supports `crypto.subtle.generateKey/sign` with `{name: "ECDSA",
+namedCurve: "P-256"}` under Hermes on-device — the proof-format spike
+asserts this but took no on-device measurement. Recommend a throwaway
+on-device smoke test before committing to Steps 2-3 if this hasn't been
+verified since the spike was written.
+
+### Step 2: P-256 signing key migration
+
+**Files**: `apps/native-rd/src/crypto/SecureStoreKeyProvider.ts`,
+`apps/native-rd/src/crypto/__tests__/SecureStoreKeyProvider.test.ts`,
+`apps/native-rd/src/hooks/useUserKey.ts`,
+`apps/native-rd/src/hooks/__tests__/useUserKey.test.ts`
+**Commit**: `feat(native-rd): migrate badge signing key from Ed25519 to P-256`
+**Changes**:
+
+- [ ] `SecureStoreKeyProvider.generateKeyPair()`: `crypto.subtle.generateKey`
+      params → `{name: "ECDSA", namedCurve: "P-256"}`.
+- [ ] `SecureStoreKeyProvider.sign()`: import params → `{name: "ECDSA",
+  namedCurve: "P-256"}`; sign params → `{name: "ECDSA", hash:
+  "SHA-256"}`.
+- [ ] `useUserKey`'s verification effect: alongside the existing "orphan"
+      branch (key not found in SecureStore → clear), add "wrong algorithm"
+      (stored public JWK's `kty`/`crv` isn't P-256 → clear) so a pre-upgrade
+      Ed25519 key gets replaced the same silent way (D3).
+- [ ] Update `SecureStoreKeyProvider.test.ts` mocks (JWK fixtures, `crypto.subtle` call assertions) from Ed25519 to P-256/ECDSA.
+- [ ] Add a `useUserKey.test.ts` case: existing settings row has a stored
+      keyId whose public JWK is `{kty: "OKP", crv: "Ed25519"}` → keyId is
+      cleared and regenerated.
+
+### Step 3: did:key + achievement IRI wiring
+
+**Files**: `apps/native-rd/src/badges/credentialBuilder.ts`,
+`apps/native-rd/src/badges/__tests__/credentialBuilder.test.ts`
+**Commit**: `fix(native-rd): resolvable did:key + drop path segments from achievement IRIs`
+**Changes**:
+
+- [ ] `buildDid()` calls `encodeP256DidKey` from `@rollercoaster-dev/openbadges-core` instead of `did:key:${jwk.x}`.
+- [ ] Achievement IRI: `urn:ulid:${input.goal.id}` instead of
+      `${input.issuerDid}/achievements/${encodeURIComponent(input.goal.id)}`
+      (D8).
+- [ ] Update/replace the Iteration-A-specific `buildDid` unit tests (they
+      currently assert the raw-`x` shape) with P-256 multibase assertions.
+
+### Step 4: ES256 VC-JWT proof construction
+
+**Files**: `apps/native-rd/src/hooks/useCreateBadge.ts`,
+`apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts`
+**Commit**: `feat(native-rd): sign badges as ES256 VC-JWT instead of raw DataIntegrityProof`
+**Changes**:
+
+- [ ] Build JOSE header: `{ alg: "ES256", typ: "JWT", jwk: publicKeyJwk }`
+      (D5).
+- [ ] Build JWT payload: `{ iss: issuerDid, iat, vc: unsignedCredential }`
+      (`unsignedCredential` is the same object `buildUnsignedCredential`
+      already returns — no `proof` field, since native-rd never sets
+      `assertion.verification`).
+- [ ] `signingInput = base64url(header) + "." + base64url(payload)`; sign
+      via `keyProvider.sign(keyId, utf8Bytes(signingInput))`; final JWS =
+      `signingInput + "." + base64url(signatureBytes)`.
+- [ ] Replace the `signedCredential` object + `JSON.stringify(signedCredential)`
+      (lines ~260-273, ~331) with the JWS string directly — this is what
+      gets passed to `bakePNG` and stored via `createBadge`/`updateBadge`
+      (both already accept an arbitrary non-empty string).
+- [ ] Update the Iteration-A comment block (lines 254-259) — it's
+      superseded.
+- [ ] Update `useCreateBadge.test.ts`'s mocked `keyProvider.sign` /
+      assertions for the new signing-input bytes and JWS output shape.
+
+**Open technical risk, not a blocker:** the exact JWT claim shape
+`ExternalProofProbe.java` expects beyond `alg`/`jwk` (e.g. whether `sub`,
+`nbf`, `exp` need to mirror VC fields) isn't pinned down by the spike — it
+only confirmed the header-level `alg` allowlist and the `jwk`/`kid` key
+dereference paths. Confirm against the validator source or empirically
+against verifybadge.org while implementing; final end-to-end confirmation
+is #600's job either way.
+
+### Step 5: BadgeDetailScreen JWS-aware evidence extraction
+
+**Files**: `apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx`,
+`apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx`
+**Commit**: `fix(native-rd): decode JWS credential payload for evidence display`
+**Changes**:
+
+- [ ] `extractEvidenceItems`: detect the 3-segment-dot, non-`{`-prefixed
+      shape (same heuristic `png-baking.ts` already uses); for a JWS, split
+      on `.`, base64url-decode the payload segment, read
+      `payload.vc.evidence` instead of top-level `.evidence`.
+- [ ] For a legacy JSON credential (badges baked before this change), keep
+      the existing top-level `.evidence` read — no behavior change for old
+      badges (D2).
+- [ ] Add a test case: a JWS-shaped `badge.credential` still populates the
+      evidence section.
+
+### Step 6: verify-badge.ts — local conformance script update
+
+**Files**: `apps/native-rd/scripts/verify-badge.ts`
+**Commit**: `chore(native-rd): update verify-badge.ts for VC-JWT + P-256 did:key`
+**Changes**:
+
+- [ ] `loadCredential()`: the loaded value can now be a raw JWS string (from
+      either a `.json` file or an unbaked PNG) — thread that through instead
+      of assuming `Record<string, unknown>`.
+- [ ] New/replaced "system round-trip" check: decode the JWS header + payload,
+      decode the `jwk` (or resolve the `did:key` issuer via
+      `decodeP256DidKey`), verify the ES256 signature with Node's
+      `crypto.verify("sha256", ..., {dsaEncoding: "ieee-p1363"}, ...)` (JWS
+      ECDSA signatures are raw `r‖s`, not DER — Node defaults to DER and
+      needs this flag).
+- [ ] `gap5.cryptosuite` check → rename/replace with a check for "external
+      proof, `alg: ES256`, `jwk` present" instead of the DataIntegrityProof
+      cryptosuite allowlist.
+- [ ] `gap7.didKeyMultibase` check → decode the multibase/multicodec prefix
+      properly (`z` + `0x1200`) instead of the current
+      `startsWith("did:key:z")` string-prefix heuristic, which would also
+      accept a malformed multibase string.
+- [ ] Keep the existing Iteration-A signature check as a fallback path for
+      old badges (`cryptosuite === "eddsa-raw-json-iteration-a"` still
+      routes there) so `bun run verify:badge` keeps working on
+      already-earned badges (D2).
+
+### Step 7: Docs
+
+**Files**: `apps/native-rd/docs/architecture/ob3-compliance-status.md`
+**Commit**: `docs(native-rd): update gap 5/7 status for VC-JWT + P-256 migration`
+**Changes**:
+
+- [ ] Update gap 5 row: cryptosuite → proof-format description (ES256
+      VC-JWT, not DataIntegrityProof).
+- [ ] Update gap 7 row: describe the shipped multicodec + base58btc
+      encoding.
+- [ ] Add a short "Key migration" note recording D2/D3 (old badges
+      untouched, signing key force-rotated) so a future reader doesn't
+      have to reconstruct the reasoning from PR history.
+- [ ] Leave the "NOT compliant" TL;DR and the iteration-mapping table
+      alone — retiring those is explicitly #600's job.
+
+## Testing Strategy
+
+- [ ] Unit tests for `did-key.ts` (round-trip + at least one known-answer
+      vector), Jest 30 / Bun test runner (package convention:
+      `packages/openbadges-core/tests/`, not `src/__tests__/`)
+- [ ] Unit tests for `SecureStoreKeyProvider` (P-256 generate/sign), mirrored
+      at `apps/native-rd/src/crypto/__tests__/`
+- [ ] Unit tests for `useUserKey`'s new force-rotation branch
+- [ ] Unit tests for `credentialBuilder`'s `buildDid` + achievement IRI
+- [ ] Unit tests for `useCreateBadge`'s JWS construction (header/payload/sig
+      shape, not full cryptographic verification — that's `verify-badge.ts`'s
+      job)
+- [ ] Unit test for `BadgeDetailScreen`'s JWS-aware evidence extraction
+- [ ] Use `test.each` for the did-key round-trip cases across a few
+      generated keypairs
+- [ ] Manual: `bun run verify:badge <freshly-baked-badge.png>` — gap5/gap7
+      PASS, system round-trip PASS (not skipped)
+- [ ] Manual: on a P-256-only device build, complete a goal, confirm the
+      badge bakes, displays, and exports without crashing
+- [ ] Manual (existing-user path): seed a test build with a stored Ed25519
+      `keyId`, relaunch, confirm a new P-256 key is generated silently and
+      old badges still open/display/export unchanged
+
+## Not in Scope
+
+| Item                                                                                                                             | Reason                                                                                                                                                      | Follow-up                                                     |
+| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Uploading a badge to verifybadge.org and replacing `ob3-compliance-status.validator-report.json`                                 | Explicitly #600's job per the epic's sub-issue breakdown                                                                                                    | #600                                                          |
+| Fixing "export never bakes the credential"                                                                                       | Separate bug, independent per epic amendment                                                                                                                | #599                                                          |
+| Renaming `exportJSON`'s `.json` extension / `application/ld+json` mimetype to reflect that new exports are a JWS, not JSON-LD    | Cosmetic; validators sniff content not extension, so it doesn't block "Done when." Current behavior is preserved by doing nothing.                          | none filed — worth a follow-up issue if it bothers a reviewer |
+| Dual-algorithm signing (support both Ed25519 and P-256 keys indefinitely)                                                        | D3 — force-rotation is simpler and the validator rejects EdDSA anyway                                                                                       | none                                                          |
+| Rebake-on-reopen interaction                                                                                                     | Feature (#15) isn't implemented yet anywhere in the codebase                                                                                                | none — revisit when #15 lands                                 |
+| Hardware-backed (Secure Enclave) key generation                                                                                  | P-256 _enables_ this per the spike, but actually using it needs a different key-generation API than `crypto.subtle`; this issue only migrates the algorithm | none filed — worth a follow-up issue                          |
+| `openbadges-core`'s `KeyAlgorithm`/`InMemoryKeyProvider` (currently `"Ed25519" \| "RSA"`, used only by that package's own tests) | Not consumed by native-rd's own `KeyProvider`; no caller needs a P-256 variant there today                                                                  | none                                                          |
+
+## Discovery Log
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
+
+## Sizing note for whoever picks this up
+
+This plan is deliberately **not split into two PRs** despite exceeding the
+~500-line single-PR guideline (issue is already labeled `size:l`, 1-3 days).
+The did:key encoding and the P-256 key migration only have a payoff once the
+JWT proof construction lands — splitting at that boundary would leave
+`verify-badge.ts`'s local signature check _regressed_ (Ed25519 assumptions
+break against a P-256 key/did:key) for however long the two PRs are apart.
+If a split is still wanted, land all 7 commits back-to-back in the same
+session as two PRs (Steps 1-3, then Steps 4-7) rather than as separately
+reviewed, independently-mergeable units.

--- a/apps/native-rd/scripts/verify-badge.ts
+++ b/apps/native-rd/scripts/verify-badge.ts
@@ -4,17 +4,22 @@
  *
  * Usage:
  *   bun scripts/verify-badge.ts <path-to-badge.png>
- *   bun scripts/verify-badge.ts <path-to-credential.json>
+ *   bun scripts/verify-badge.ts <path-to-credential.json-or-.jws>
  *
- * The two reports are complementary: a badge can pass the system
- * round-trip and fail OB3 conformance; that's the expected shape for a
- * self-signed Iteration-A badge.
+ * Handles both stored formats. Badges signed since #598 are compact ES256
+ * VC-JWTs (an external proof); badges earned before it are credential JSON
+ * with an embedded Iteration-A DataIntegrityProof. Old badges are never
+ * re-signed, so both paths have to keep working.
+ *
+ * The two reports are complementary: a badge can pass the system round-trip
+ * and fail OB3 conformance.
  */
 
 import { readFileSync } from "node:fs";
 import { createPublicKey, verify as cryptoVerify } from "node:crypto";
 import {
   Cryptosuite,
+  decodeP256DidKey,
   isPNG,
   unbakePNG,
 } from "@rollercoaster-dev/openbadges-core";
@@ -39,23 +44,91 @@ function skipped(name: string, detail?: string): CheckResult {
   return { name, status: "skipped", detail };
 }
 
-function loadCredential(path: string): {
+/** A parsed compact JWS, with the exact bytes the signature covers. */
+interface ParsedJws {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  /** `header.payload` — the ASCII the signature was computed over. */
+  signingInput: string;
+  signature: Buffer;
+}
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(
+    Buffer.from(segment, "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+}
+
+/**
+ * Parses a compact JWS, or returns null if the string isn't one. Same
+ * 3-dot-segment / not-`{`-prefixed heuristic png-baking.ts uses.
+ */
+function parseJws(value: string): ParsedJws | null {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("{")) return null;
+  const parts = trimmed.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    return {
+      header: decodeSegment(parts[0]!),
+      payload: decodeSegment(parts[1]!),
+      signingInput: `${parts[0]}.${parts[1]}`,
+      signature: Buffer.from(parts[2]!, "base64url"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+type LoadedCredential = {
+  /** The VC itself — unwrapped from the `vc` claim when the input is a JWS. */
   credential: Record<string, unknown>;
+  /** Present only for a VC-JWT external proof. */
+  jws: ParsedJws | null;
   source: "png" | "json";
-} {
+};
+
+function loadCredential(path: string): LoadedCredential {
   const buf = readFileSync(path);
+
+  // unbakePNG already returns a raw string for a JWS chunk and a parsed
+  // object for a JSON one, so normalise both to the same two branches below.
+  let raw: string | Record<string, unknown>;
+  let source: "png" | "json";
   if (isPNG(buf)) {
-    const cred = unbakePNG(buf) as Record<string, unknown> | null;
+    const cred = unbakePNG(buf) as string | Record<string, unknown> | null;
     if (!cred) {
       throw new Error(
         "PNG has no OpenBadges credential chunk (looked for iTXt with " +
           "keyword 'openbadgecredential' or 'openbadges').",
       );
     }
-    return { credential: cred, source: "png" };
+    raw = cred;
+    source = "png";
+  } else {
+    raw = buf.toString("utf8");
+    source = "json";
   }
-  // Assume JSON otherwise.
-  return { credential: JSON.parse(buf.toString("utf8")), source: "json" };
+
+  if (typeof raw === "string") {
+    const jws = parseJws(raw);
+    if (jws) {
+      const vc = jws.payload.vc;
+      if (!vc || typeof vc !== "object") {
+        throw new Error(
+          "JWS payload has no `vc` claim — not a VC-JWT credential.",
+        );
+      }
+      return { credential: vc as Record<string, unknown>, jws, source };
+    }
+    return {
+      credential: JSON.parse(raw) as Record<string, unknown>,
+      jws: null,
+      source,
+    };
+  }
+
+  return { credential: raw, jws: null, source };
 }
 
 /**
@@ -72,6 +145,88 @@ function getIterationADidX(did: string): string | null {
   if (tail.startsWith("z")) return null;
   if (!/^[A-Za-z0-9_-]+$/.test(tail)) return null;
   return tail;
+}
+
+/**
+ * Verifies the ES256 signature of a VC-JWT against the key inlined in its
+ * protected header, then confirms that key is the one the issuer DID names.
+ *
+ * A JWS ECDSA signature is the raw IEEE-P1363 `r‖s` pair; Node's verify()
+ * defaults to DER, hence the explicit dsaEncoding.
+ */
+function verifyVcJwtSignature(
+  jws: ParsedJws,
+  credential: Record<string, unknown>,
+): CheckResult {
+  const alg = jws.header.alg;
+  if (alg !== "ES256") {
+    return skipped(
+      "signature.vcJwt",
+      `header alg is '${String(alg)}'; this verifier only checks ES256`,
+    );
+  }
+
+  const jwk = jws.header.jwk;
+  if (!jwk || typeof jwk !== "object") {
+    return fail(
+      "signature.vcJwt",
+      "protected header has no inline `jwk` to verify against",
+    );
+  }
+
+  let pubKey;
+  try {
+    pubKey = createPublicKey({
+      key: jwk as Record<string, unknown>,
+      format: "jwk",
+    });
+  } catch (err) {
+    return fail(
+      "signature.vcJwt",
+      `failed to import the header jwk: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const ok = cryptoVerify(
+    "sha256",
+    Buffer.from(jws.signingInput, "ascii"),
+    { key: pubKey, dsaEncoding: "ieee-p1363" },
+    jws.signature,
+  );
+  if (!ok) {
+    return fail(
+      "signature.vcJwt",
+      "ES256 signature did not verify against the inline header jwk",
+    );
+  }
+
+  // A valid signature over an attacker-chosen key proves nothing on its own —
+  // the header key has to be the one the issuer DID resolves to.
+  const issuerId = (credential.issuer as Record<string, unknown> | undefined)
+    ?.id;
+  const issuerDid = typeof issuerId === "string" ? issuerId : "";
+  let resolved;
+  try {
+    resolved = decodeP256DidKey(issuerDid);
+  } catch (err) {
+    return fail(
+      "signature.vcJwt",
+      `signature verified, but the issuer DID does not resolve to a P-256 key: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const headerJwk = jwk as { x?: unknown; y?: unknown };
+  if (resolved.x !== headerJwk.x || resolved.y !== headerJwk.y) {
+    return fail(
+      "signature.vcJwt",
+      "signature verified, but the header jwk is not the key the issuer DID names",
+    );
+  }
+
+  return pass(
+    "signature.vcJwt",
+    `verified ${jws.signature.length}-byte ES256 signature; header jwk matches ${issuerDid.slice(0, 24)}…`,
+  );
 }
 
 function verifyIterationASignature(
@@ -109,10 +264,8 @@ function verifyIterationASignature(
     );
   }
 
-  // Reproduce the bytes that `useCreateBadge` signs: JSON.stringify of
-  // the credential without the proof field. Drift between this and the
-  // signing path is invisible until verification starts failing — when
-  // either side changes, factor the bytes-to-sign computation out.
+  // Reproduce the bytes that pre-#598 `useCreateBadge` signed: JSON.stringify
+  // of the credential without the proof field.
   const { proof: _omit, ...unsigned } = credential;
   const dataBytes = new TextEncoder().encode(JSON.stringify(unsigned));
 
@@ -157,7 +310,10 @@ function verifyIterationASignature(
  * predicate that returns PASS when the gap has been *fixed*, FAIL while
  * the gap is still present.
  */
-function conformanceChecks(credential: Record<string, unknown>): CheckResult[] {
+function conformanceChecks(
+  credential: Record<string, unknown>,
+  jws: ParsedJws | null,
+): CheckResult[] {
   const cs = credential.credentialSubject as
     | Record<string, unknown>
     | undefined;
@@ -176,13 +332,17 @@ function conformanceChecks(credential: Record<string, unknown>): CheckResult[] {
             `achievement.creator is ${typeof creator}, expected object`,
           );
 
-  // Gap 2: top-level proof should be an array, not a single object.
-  const gap2 = Array.isArray(proof)
-    ? pass("gap2.proofArray", "proof is an array")
-    : fail(
-        "gap2.proofArray",
-        "proof is a single object, OB3 schema requires proof: [...]",
-      );
+  // Gap 2: top-level proof should be an array, not a single object. An
+  // external proof carries no embedded `proof` at all, which is the correct
+  // shape rather than a missing one — the JWS *is* the proof.
+  const gap2 = jws
+    ? pass("gap2.proofArray", "external proof (VC-JWT) — no embedded proof")
+    : Array.isArray(proof)
+      ? pass("gap2.proofArray", "proof is an array")
+      : fail(
+          "gap2.proofArray",
+          "proof is a single object, OB3 schema requires proof: [...]",
+        );
 
   // Gap 3: top-level `name` required.
   const gap3 =
@@ -200,7 +360,11 @@ function conformanceChecks(credential: Record<string, unknown>): CheckResult[] {
         )
       : fail("gap4.issuanceDate", "top-level issuanceDate is missing");
 
-  // Gap 5: cryptosuite must be a standard one.
+  // Gap 5: the proof must be one the validator accepts. Two ways to pass:
+  // an external VC-JWT whose header alg is on the RS256/ES256 allowlist and
+  // that carries a key (inline `jwk` or dereferenceable `kid`), or an
+  // embedded DataIntegrityProof with a standard cryptosuite.
+  //
   // `eddsa-2022` is the second OB3-accepted DataIntegrity cryptosuite;
   // openbadges-core's enum currently only exports the rdfc variant. The
   // enum reference catches a future rename of `EddsaRdfc2022` at compile
@@ -209,22 +373,41 @@ function conformanceChecks(credential: Record<string, unknown>): CheckResult[] {
     Cryptosuite.EddsaRdfc2022,
     "eddsa-2022",
   ]);
+  const EXTERNAL_PROOF_ALGORITHMS = new Set<string>(["ES256", "RS256"]);
   const proofObj = (Array.isArray(proof) ? proof[0] : proof) as
     | Record<string, unknown>
     | undefined;
   const cryptosuite = proofObj?.cryptosuite;
   const proofType = proofObj?.type;
-  const gap5 =
-    proofType === "Ed25519Signature2020" ||
-    (typeof cryptosuite === "string" && STANDARD_CRYPTOSUITES.has(cryptosuite))
-      ? pass(
-          "gap5.cryptosuite",
-          `cryptosuite: ${String(cryptosuite ?? proofType)}`,
-        )
-      : fail(
-          "gap5.cryptosuite",
-          `cryptosuite '${String(cryptosuite)}' is not in the OB3 allowlist (eddsa-rdfc-2022, eddsa-2022, Ed25519Signature2020)`,
-        );
+
+  let gap5: CheckResult;
+  if (jws) {
+    const alg = jws.header.alg;
+    const hasKey = Boolean(jws.header.jwk) || Boolean(jws.header.kid);
+    gap5 =
+      typeof alg === "string" && EXTERNAL_PROOF_ALGORITHMS.has(alg) && hasKey
+        ? pass(
+            "gap5.proofFormat",
+            `external VC-JWT proof, alg: ${alg}, key: ${jws.header.jwk ? "inline jwk" : "kid"}`,
+          )
+        : fail(
+            "gap5.proofFormat",
+            `external proof with alg '${String(alg)}'${hasKey ? "" : " and no jwk/kid"} — the validator accepts only ES256/RS256 with a resolvable key`,
+          );
+  } else {
+    gap5 =
+      proofType === "Ed25519Signature2020" ||
+      (typeof cryptosuite === "string" &&
+        STANDARD_CRYPTOSUITES.has(cryptosuite))
+        ? pass(
+            "gap5.proofFormat",
+            `cryptosuite: ${String(cryptosuite ?? proofType)}`,
+          )
+        : fail(
+            "gap5.proofFormat",
+            `cryptosuite '${String(cryptosuite)}' is not in the OB3 allowlist (eddsa-rdfc-2022, eddsa-2022, Ed25519Signature2020), and this is not an external VC-JWT proof`,
+          );
+  }
 
   // Gap 6: umbrella oneOf — passes when 1–5 all pass.
   const upstream = [gap1, gap2, gap3, gap4, gap5];
@@ -238,19 +421,25 @@ function conformanceChecks(credential: Record<string, unknown>): CheckResult[] {
         `${upstream.filter((c) => c.status !== "pass").length} upstream gap(s) still open`,
       );
 
-  // Gap 7: did:key must use multibase `z` prefix, not raw jwk.x.
+  // Gap 7: the issuer did:key must actually decode — multibase `z` plus the
+  // p256-pub multicodec, not just a `did:key:z` string prefix, which a
+  // malformed multibase payload would also satisfy.
   const issuerId = (credential.issuer as Record<string, unknown> | undefined)
     ?.id;
   const issuerDid = typeof issuerId === "string" ? issuerId : "";
-  const gap7 = issuerDid.startsWith("did:key:z")
-    ? pass(
-        "gap7.didKeyMultibase",
-        `issuer DID is multibase-encoded: ${issuerDid.slice(0, 24)}…`,
-      )
-    : fail(
-        "gap7.didKeyMultibase",
-        `issuer DID is the Iteration-A form (raw jwk.x), not multibase: ${issuerDid}`,
-      );
+  let gap7: CheckResult;
+  try {
+    decodeP256DidKey(issuerDid);
+    gap7 = pass(
+      "gap7.didKeyMultibase",
+      `issuer DID decodes to a P-256 key: ${issuerDid.slice(0, 24)}…`,
+    );
+  } catch (err) {
+    gap7 = fail(
+      "gap7.didKeyMultibase",
+      `issuer DID '${issuerDid}' is not a resolvable P-256 did:key — ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   return [gap1, gap2, gap3, gap4, gap5, gap6, gap7];
 }
@@ -289,9 +478,12 @@ async function main() {
     );
     process.exit(2);
   }
-  const { credential, source } = loaded;
+  const { credential, jws, source } = loaded;
 
-  console.log(`${BOLD}Badge verifier${RESET}  ${DIM}(${source} input)${RESET}`);
+  const format = jws ? "VC-JWT external proof" : "embedded proof";
+  console.log(
+    `${BOLD}Badge verifier${RESET}  ${DIM}(${source} input, ${format})${RESET}`,
+  );
   console.log(`  ${DIM}file:${RESET} ${path}`);
   console.log(`  ${DIM}id:${RESET}   ${String(credential.id ?? "—")}`);
   const ach = (
@@ -300,11 +492,13 @@ async function main() {
   console.log(`  ${DIM}name:${RESET} ${String(ach?.name ?? "—")}`);
 
   printSection("System round-trip");
-  const sigResult = verifyIterationASignature(credential);
+  const sigResult = jws
+    ? verifyVcJwtSignature(jws, credential)
+    : verifyIterationASignature(credential);
   printResult(sigResult);
 
-  printSection("OB 3.0 conformance delta (Iteration A → D)");
-  const conf = conformanceChecks(credential);
+  printSection("OB 3.0 conformance delta");
+  const conf = conformanceChecks(credential, jws);
   conf.forEach(printResult);
 
   const conformancePassed = conf.filter((c) => c.status === "pass").length;
@@ -331,9 +525,9 @@ async function main() {
   );
 
   // Exit non-zero only on a real signature mismatch — a broken pipeline. A
-  // skipped check (non-Iteration-A cryptosuite that we have no code to
-  // verify) is not a pipeline failure but also not a success: exit 0 but
-  // print to stderr so CI logs surface it.
+  // skipped check (a proof scheme we have no code to verify) is not a pipeline
+  // failure but also not a success: exit 0 but print to stderr so CI logs
+  // surface it.
   if (sigResult.status === "skipped") {
     console.error(
       `${YELLOW}warning:${RESET} signature was not verified (${sigResult.detail ?? "no detail"})`,

--- a/apps/native-rd/src/badges/__tests__/credentialBuilder.test.ts
+++ b/apps/native-rd/src/badges/__tests__/credentialBuilder.test.ts
@@ -11,7 +11,7 @@ import type { CredentialInput } from "../credentialBuilder";
 jest.mock("@rollercoaster-dev/openbadges-core", () => ({
   // did:key encoding is NOT mocked — it's pure, dependency-free, and the DID
   // shape is exactly what this issue changed, so assert against the real thing.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+
   encodeP256DidKey:
     require("../../../../../packages/openbadges-core/src/crypto/did-key")
       .encodeP256DidKey,
@@ -73,12 +73,6 @@ const BASE_INPUT: CredentialInput = {
 describe("buildDid", () => {
   it("encodes a P-256 JWK as a multibase did:key", () => {
     expect(buildDid(P256_JWK)).toBe(P256_DID);
-  });
-
-  it("no longer emits the Iteration-A raw-jwk.x form", () => {
-    // Regression guard for gap 7: `did:key:<jwk.x>` is unresolvable, and the
-    // raw x would appear verbatim in the DID if the old path came back.
-    expect(buildDid(P256_JWK)).not.toContain(P256_JWK.x!);
   });
 
   it("throws for a non-P-256 key (a pre-migration Ed25519 key)", () => {

--- a/apps/native-rd/src/badges/__tests__/credentialBuilder.test.ts
+++ b/apps/native-rd/src/badges/__tests__/credentialBuilder.test.ts
@@ -9,6 +9,12 @@ import { buildUnsignedCredential, buildDid } from "../credentialBuilder";
 import type { CredentialInput } from "../credentialBuilder";
 
 jest.mock("@rollercoaster-dev/openbadges-core", () => ({
+  // did:key encoding is NOT mocked — it's pure, dependency-free, and the DID
+  // shape is exactly what this issue changed, so assert against the real thing.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  encodeP256DidKey:
+    require("../../../../../packages/openbadges-core/src/crypto/did-key")
+      .encodeP256DidKey,
   serializeOB3: jest.fn((assertion, badgeClass, issuer) => ({
     "@context": [
       "https://www.w3.org/ns/credentials/v2",
@@ -37,6 +43,19 @@ jest.mock("@rollercoaster-dev/openbadges-core", () => ({
   })),
 }));
 
+/**
+ * The W3C did:key spec's own P-256 example, and the DID it encodes to.
+ * Using the spec pair here keeps the assertion a known answer rather than a
+ * restatement of whatever `encodeP256DidKey` happens to produce.
+ */
+const P256_JWK: JsonWebKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI",
+  y: "hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU",
+};
+const P256_DID = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
+
 const BASE_INPUT: CredentialInput = {
   goal: {
     id: "goal-01",
@@ -44,27 +63,33 @@ const BASE_INPUT: CredentialInput = {
     description: "Build a mobile app",
   },
   evidence: [],
-  issuerDid: "did:key:abc123",
-  publicKeyJwk: { kty: "OKP", crv: "Ed25519", x: "abc123" },
+  issuerDid: P256_DID,
+  publicKeyJwk: P256_JWK,
   credentialId: "urn:uuid:cred-01",
   issuedOn: "2026-02-18T00:00:00.000Z",
   narrative: "Complete all steps for: Learn React Native",
 };
 
 describe("buildDid", () => {
-  it("returns a string starting with did:key:", () => {
-    const did = buildDid({ kty: "OKP", crv: "Ed25519", x: "somekey" });
-    expect(did).toMatch(/^did:key:/);
+  it("encodes a P-256 JWK as a multibase did:key", () => {
+    expect(buildDid(P256_JWK)).toBe(P256_DID);
   });
 
-  it("uses the x value from the JWK", () => {
-    const did = buildDid({ kty: "OKP", crv: "Ed25519", x: "mykey" });
-    expect(did).toBe("did:key:mykey");
+  it("no longer emits the Iteration-A raw-jwk.x form", () => {
+    // Regression guard for gap 7: `did:key:<jwk.x>` is unresolvable, and the
+    // raw x would appear verbatim in the DID if the old path came back.
+    expect(buildDid(P256_JWK)).not.toContain(P256_JWK.x!);
   });
 
-  it("throws when x is absent", () => {
-    expect(() => buildDid({ kty: "OKP", crv: "Ed25519" })).toThrow(
-      "missing x coordinate",
+  it("throws for a non-P-256 key (a pre-migration Ed25519 key)", () => {
+    expect(() => buildDid({ kty: "OKP", crv: "Ed25519", x: "abc" })).toThrow(
+      "Expected a P-256 EC public key JWK",
+    );
+  });
+
+  it("throws when the y coordinate is absent", () => {
+    expect(() => buildDid({ kty: "EC", crv: "P-256", x: P256_JWK.x })).toThrow(
+      "missing x or y coordinate",
     );
   });
 });
@@ -82,6 +107,15 @@ describe("buildUnsignedCredential", () => {
     const subject = cred["credentialSubject"] as Record<string, unknown>;
     const achievement = subject["achievement"] as Record<string, unknown>;
     expect(achievement["name"]).toBe("Learn React Native");
+  });
+
+  it("gives the achievement a urn:ulid: IRI, not a path under the issuer DID", () => {
+    const cred = buildUnsignedCredential(BASE_INPUT);
+    const subject = cred["credentialSubject"] as Record<string, unknown>;
+    const achievement = subject["achievement"] as Record<string, unknown>;
+    // gap 7: did:key DIDs have no path component, so the old
+    // `${issuerDid}/achievements/${goalId}` form was an invalid DID URL.
+    expect(achievement["id"]).toBe("urn:ulid:goal-01");
   });
 
   it("maps goal description to achievement description", () => {

--- a/apps/native-rd/src/badges/__tests__/vcJwt.test.ts
+++ b/apps/native-rd/src/badges/__tests__/vcJwt.test.ts
@@ -6,7 +6,11 @@
  * is the JWS shape: what goes into the header, what goes into the claims, and
  * which bytes are handed to the signer.
  */
-import { signCredentialAsVcJwt, toPublicP256Jwk } from "../vcJwt";
+import {
+  signCredentialAsVcJwt,
+  toPublicP256Jwk,
+  parseStoredCredential,
+} from "../vcJwt";
 import { Buffer } from "buffer";
 
 const PUBLIC_JWK: JsonWebKey = {
@@ -175,5 +179,64 @@ describe("toPublicP256Jwk", () => {
     expect(() =>
       toPublicP256Jwk({ kty: "EC", crv: "P-256", x: "abc" }),
     ).toThrow("missing x or y coordinate");
+  });
+});
+
+describe("parseStoredCredential", () => {
+  it("unwraps the `vc` claim of a JWS produced by signCredentialAsVcJwt", async () => {
+    const jws = await sign();
+    expect(parseStoredCredential(jws)).toEqual(UNSIGNED_CREDENTIAL);
+  });
+
+  it("returns a pre-#598 JSON credential unchanged", () => {
+    // Old badges are never migrated or re-signed, so this path has to survive.
+    const json = JSON.stringify(UNSIGNED_CREDENTIAL);
+    expect(parseStoredCredential(json)).toEqual(UNSIGNED_CREDENTIAL);
+  });
+
+  it("decodes payloads carrying the base64url-only characters `-` and `_`", async () => {
+    // `Buffer.from(s, "base64url")` reads fine under Jest (Node core buffer)
+    // but throws on device, where the feross polyfill is bundled and has no
+    // such encoding. Decoding must not depend on it. These bytes force both
+    // characters into the segment, which plain base64 would spell + and /.
+    const jws = await signCredentialAsVcJwt({
+      unsignedCredential: { ...UNSIGNED_CREDENTIAL, name: "ÿ}ø?ÿ}ø?" },
+      issuerDid: ISSUER_DID,
+      publicKeyJwk: PUBLIC_JWK,
+      issuedOn: ISSUED_ON,
+      credentialId: CREDENTIAL_ID,
+      sign: async () => SIGNATURE,
+    });
+    const segment = jws.split(".")[1]!;
+    expect(segment).toMatch(/[-_]/);
+    expect(parseStoredCredential(jws)).toMatchObject({ name: "ÿ}ø?ÿ}ø?" });
+  });
+
+  it("round-trips multi-byte UTF-8 in credential text", async () => {
+    const jws = await signCredentialAsVcJwt({
+      unsignedCredential: {
+        ...UNSIGNED_CREDENTIAL,
+        name: "Ziel erreicht 🎢 日本語",
+      },
+      issuerDid: ISSUER_DID,
+      publicKeyJwk: PUBLIC_JWK,
+      issuedOn: ISSUED_ON,
+      credentialId: CREDENTIAL_ID,
+      sign: async () => SIGNATURE,
+    });
+    expect(parseStoredCredential(jws)).toMatchObject({
+      name: "Ziel erreicht 🎢 日本語",
+    });
+  });
+
+  it("yields an empty object for a JWS with no `vc` claim", () => {
+    const b64 = (v: unknown) =>
+      Buffer.from(JSON.stringify(v))
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+    const jws = `${b64({ alg: "ES256" })}.${b64({ iss: ISSUER_DID })}.sig`;
+    expect(parseStoredCredential(jws)).toEqual({});
   });
 });

--- a/apps/native-rd/src/badges/__tests__/vcJwt.test.ts
+++ b/apps/native-rd/src/badges/__tests__/vcJwt.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the ES256 VC-JWT proof builder.
+ *
+ * The signature bytes come from a stub `sign` — cryptographic verification of
+ * a real ES256 signature is scripts/verify-badge.ts's job. What's pinned here
+ * is the JWS shape: what goes into the header, what goes into the claims, and
+ * which bytes are handed to the signer.
+ */
+import { signCredentialAsVcJwt, toPublicP256Jwk } from "../vcJwt";
+import { Buffer } from "buffer";
+
+const PUBLIC_JWK: JsonWebKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI",
+  y: "hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU",
+};
+const ISSUER_DID = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
+const ISSUED_ON = "2026-02-18T00:00:00.000Z";
+const CREDENTIAL_ID = "urn:uuid:cred-01";
+
+const UNSIGNED_CREDENTIAL: Record<string, unknown> = {
+  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  id: CREDENTIAL_ID,
+  type: ["VerifiableCredential", "OpenBadgeCredential"],
+  name: "Learn React Native",
+  issuer: { id: ISSUER_DID },
+  issuanceDate: ISSUED_ON,
+  credentialSubject: {
+    id: ISSUER_DID,
+    achievement: { id: "urn:ulid:goal-01" },
+  },
+  evidence: [{ id: "urn:ulid:ev-1", name: "A note" }],
+};
+
+/** 64 bytes — the length of a real IEEE-P1363 `r‖s` P-256 signature. */
+const SIGNATURE = Uint8Array.from({ length: 64 }, (_, i) => i + 1);
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(
+    Buffer.from(segment, "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+}
+
+async function sign(): Promise<string> {
+  return signCredentialAsVcJwt({
+    unsignedCredential: UNSIGNED_CREDENTIAL,
+    issuerDid: ISSUER_DID,
+    publicKeyJwk: PUBLIC_JWK,
+    issuedOn: ISSUED_ON,
+    credentialId: CREDENTIAL_ID,
+    sign: async () => SIGNATURE,
+  });
+}
+
+describe("signCredentialAsVcJwt", () => {
+  it("produces a three-segment compact JWS", async () => {
+    const jws = await sign();
+    expect(jws.split(".")).toHaveLength(3);
+  });
+
+  it("emits base64url segments only (no +, / or = padding)", async () => {
+    const jws = await sign();
+    expect(jws).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  });
+
+  it("declares alg ES256 in the protected header", async () => {
+    const [header] = (await sign()).split(".");
+    // EdDSA here would be rejected outright by the validator's external-proof
+    // probe — the whole reason the signing key moved to P-256.
+    expect(decodeSegment(header!)["alg"]).toBe("ES256");
+    expect(decodeSegment(header!)["typ"]).toBe("JWT");
+  });
+
+  it("inlines the public key as `jwk` so verification needs no network", async () => {
+    const [header] = (await sign()).split(".");
+    expect(decodeSegment(header!)["jwk"]).toEqual(PUBLIC_JWK);
+  });
+
+  it("never leaks private or advisory JWK fields into the header", async () => {
+    const jws = await signCredentialAsVcJwt({
+      unsignedCredential: UNSIGNED_CREDENTIAL,
+      issuerDid: ISSUER_DID,
+      publicKeyJwk: {
+        ...PUBLIC_JWK,
+        d: "PRIVATE-KEY-MATERIAL",
+        ext: true,
+        key_ops: ["sign"],
+      },
+      issuedOn: ISSUED_ON,
+      credentialId: CREDENTIAL_ID,
+      sign: async () => SIGNATURE,
+    });
+    const header = decodeSegment(jws.split(".")[0]!);
+    expect(header["jwk"]).toEqual(PUBLIC_JWK);
+    expect(jws).not.toContain("PRIVATE-KEY-MATERIAL");
+  });
+
+  it("carries the whole unsigned credential under the `vc` claim", async () => {
+    const [, payload] = (await sign()).split(".");
+    expect(decodeSegment(payload!)["vc"]).toEqual(UNSIGNED_CREDENTIAL);
+  });
+
+  it("sets iss, sub and jti from the credential", async () => {
+    const claims = decodeSegment((await sign()).split(".")[1]!);
+    expect(claims["iss"]).toBe(ISSUER_DID);
+    expect(claims["sub"]).toBe(ISSUER_DID);
+    expect(claims["jti"]).toBe(CREDENTIAL_ID);
+  });
+
+  it("sets iat and nbf to issuedOn as epoch seconds", async () => {
+    const claims = decodeSegment((await sign()).split(".")[1]!);
+    expect(claims["iat"]).toBe(Date.parse(ISSUED_ON) / 1000);
+    expect(claims["nbf"]).toBe(claims["iat"]);
+  });
+
+  it("signs exactly the `header.payload` bytes, not the credential JSON", async () => {
+    let signed: Uint8Array | null = null;
+    const jws = await signCredentialAsVcJwt({
+      unsignedCredential: UNSIGNED_CREDENTIAL,
+      issuerDid: ISSUER_DID,
+      publicKeyJwk: PUBLIC_JWK,
+      issuedOn: ISSUED_ON,
+      credentialId: CREDENTIAL_ID,
+      sign: async (bytes) => {
+        signed = bytes;
+        return SIGNATURE;
+      },
+    });
+    const [header, payload] = jws.split(".");
+    expect(Buffer.from(signed!).toString("utf8")).toBe(`${header}.${payload}`);
+  });
+
+  it("appends the signature bytes as the third segment", async () => {
+    const [, , sig] = (await sign()).split(".");
+    expect(Buffer.from(sig!, "base64url").equals(Buffer.from(SIGNATURE))).toBe(
+      true,
+    );
+  });
+
+  it("falls back to the issuer DID when the credential has no subject id", async () => {
+    const jws = await signCredentialAsVcJwt({
+      unsignedCredential: { ...UNSIGNED_CREDENTIAL, credentialSubject: {} },
+      issuerDid: ISSUER_DID,
+      publicKeyJwk: PUBLIC_JWK,
+      issuedOn: ISSUED_ON,
+      credentialId: CREDENTIAL_ID,
+      sign: async () => SIGNATURE,
+    });
+    expect(decodeSegment(jws.split(".")[1]!)["sub"]).toBe(ISSUER_DID);
+  });
+
+  it("rejects an unparseable issuedOn rather than emitting NaN claims", async () => {
+    await expect(
+      signCredentialAsVcJwt({
+        unsignedCredential: UNSIGNED_CREDENTIAL,
+        issuerDid: ISSUER_DID,
+        publicKeyJwk: PUBLIC_JWK,
+        issuedOn: "not-a-date",
+        credentialId: CREDENTIAL_ID,
+        sign: async () => SIGNATURE,
+      }),
+    ).rejects.toThrow("Invalid issuedOn timestamp");
+  });
+});
+
+describe("toPublicP256Jwk", () => {
+  it("rejects a pre-migration Ed25519 key", () => {
+    expect(() =>
+      toPublicP256Jwk({ kty: "OKP", crv: "Ed25519", x: "abc" }),
+    ).toThrow("expected EC/P-256");
+  });
+
+  it("rejects a P-256 JWK missing a coordinate", () => {
+    expect(() =>
+      toPublicP256Jwk({ kty: "EC", crv: "P-256", x: "abc" }),
+    ).toThrow("missing x or y coordinate");
+  });
+});

--- a/apps/native-rd/src/badges/credentialBuilder.ts
+++ b/apps/native-rd/src/badges/credentialBuilder.ts
@@ -5,7 +5,10 @@
  * Uses openbadges-core's serializeOB3 for data structure construction.
  * Signing is handled separately by useCreateBadge via SecureStoreKeyProvider.
  */
-import { serializeOB3 } from "@rollercoaster-dev/openbadges-core";
+import {
+  serializeOB3,
+  encodeP256DidKey,
+} from "@rollercoaster-dev/openbadges-core";
 import type {
   IssuerData,
   BadgeClassData,
@@ -49,19 +52,15 @@ export interface CredentialInput {
 }
 
 /**
- * Constructs a simplified did:key identifier from an Ed25519 public key JWK.
+ * Constructs a resolvable `did:key` identifier from a P-256 public key JWK.
  *
- * NOTE: Simplified implementation for Iteration A only.
- * A fully spec-compliant did:key requires multibase+multicodec encoding
- * (0xed01 prefix + raw 32-byte key, base58btc with 'z' prefix).
- * The JWK 'x' field is the base64url-encoded raw Ed25519 public key.
- * Proper verification is not implemented until Iteration D.
+ * Spec-compliant multibase + multicodec form (`did:key:z…`, p256-pub 0x1200
+ * over a SEC1-compressed point), so a verifier can recover the public key
+ * from the DID alone. Encoding lives in openbadges-core alongside the other
+ * shared crypto primitives; this module stays pure.
  */
 export function buildDid(publicKeyJwk: JsonWebKey): string {
-  if (!publicKeyJwk.x) {
-    throw new Error("Invalid public key JWK: missing x coordinate");
-  }
-  return `did:key:${publicKeyJwk.x}`;
+  return encodeP256DidKey(publicKeyJwk);
 }
 
 /**
@@ -79,12 +78,12 @@ export function buildUnsignedCredential(
     publicKey: input.publicKeyJwk,
   };
 
-  // NOTE (Iteration A): Appending a path segment to a did:key: identifier produces
-  // an invalid DID URL — did:key: DIDs do not support path components per the spec.
-  // A proper achievementId should be a separate HTTPS URI. Fixed in Iteration D.
-  const achievementId = iri(
-    `${input.issuerDid}/achievements/${encodeURIComponent(input.goal.id)}`,
-  );
+  // A `urn:ulid:` IRI rather than a path under the issuer DID: did:key DIDs
+  // have no path component, so the old `${did}/achievements/${id}` form was an
+  // invalid DID URL. The app hosts nothing, so an https:// achievement URL
+  // would be a fake that never resolves — an honest urn: is better, and it
+  // matches the evidence IRIs built below.
+  const achievementId = iri(`urn:ulid:${input.goal.id}`);
 
   // image is intentionally omitted — OB3 Achievement.image is OPTIONAL per spec.
   // A local file:// URI is not a valid or shareable IRI; a hosted URL would be

--- a/apps/native-rd/src/badges/index.ts
+++ b/apps/native-rd/src/badges/index.ts
@@ -5,6 +5,8 @@ export type {
   CredentialInput,
 } from "./credentialBuilder";
 
+export { signCredentialAsVcJwt, toPublicP256Jwk } from "./vcJwt";
+export type { VcJwtInput, PublicP256Jwk } from "./vcJwt";
 export { bakePNG, unbakePNG, isPNG } from "./png-baking";
 export {
   generateBadgeImagePNG,

--- a/apps/native-rd/src/badges/index.ts
+++ b/apps/native-rd/src/badges/index.ts
@@ -5,8 +5,8 @@ export type {
   CredentialInput,
 } from "./credentialBuilder";
 
-export { signCredentialAsVcJwt, toPublicP256Jwk } from "./vcJwt";
-export type { VcJwtInput, PublicP256Jwk } from "./vcJwt";
+export { signCredentialAsVcJwt } from "./vcJwt";
+export type { VcJwtInput } from "./vcJwt";
 export { bakePNG, unbakePNG, isPNG } from "./png-baking";
 export {
   generateBadgeImagePNG,

--- a/apps/native-rd/src/badges/vcJwt.ts
+++ b/apps/native-rd/src/badges/vcJwt.ts
@@ -47,6 +47,70 @@ function toBase64Url(bytes: Uint8Array): string {
     .replace(/=/g, "");
 }
 
+const BASE64URL_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/**
+ * Decodes a base64url segment to a UTF-8 string.
+ *
+ * Hand-rolled on purpose. `Buffer.from(s, "base64url")` works under Jest,
+ * which resolves `buffer` to Node's core module, but the app bundles the
+ * feross `buffer` polyfill (see package.json), and that has no `base64url`
+ * encoding — on device it throws `Unknown encoding`. Callers here swallow
+ * parse errors to hide a section, so the failure would have been silent.
+ */
+function base64UrlToString(segment: string): string {
+  const bytes: number[] = [];
+  let bits = 0;
+  let acc = 0;
+  for (const char of segment) {
+    if (char === "=") break;
+    const digit = BASE64URL_ALPHABET.indexOf(char);
+    if (digit < 0) {
+      throw new Error(`Invalid base64url character: '${char}'`);
+    }
+    acc = (acc << 6) | digit;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((acc >> bits) & 0xff);
+    }
+  }
+  return new TextDecoder().decode(Uint8Array.from(bytes));
+}
+
+/**
+ * True when a stored credential string is a compact JWS rather than
+ * credential JSON. Same shape test `png-baking.ts` uses to decide how to
+ * embed one.
+ */
+function isCompactJws(credential: string): boolean {
+  const trimmed = credential.trim();
+  return !trimmed.startsWith("{") && trimmed.split(".").length === 3;
+}
+
+/**
+ * Unwraps a stored `badge.credential` to the VC object inside it.
+ *
+ * Badges signed since #598 are compact JWS strings carrying the credential
+ * under the payload's `vc` claim; badges earned before it are plain
+ * credential JSON. Old badges are never migrated or re-signed — their
+ * signature covers the exact stored bytes — so both shapes stay readable
+ * indefinitely. Throws on malformed input; callers decide what to show.
+ */
+export function parseStoredCredential(
+  credential: string,
+): Record<string, unknown> {
+  const trimmed = credential.trim();
+  if (!isCompactJws(trimmed)) {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  }
+  const payload = JSON.parse(base64UrlToString(trimmed.split(".")[1]!)) as {
+    vc?: unknown;
+  };
+  return (payload.vc ?? {}) as Record<string, unknown>;
+}
+
 function jsonToBase64Url(value: unknown): string {
   return toBase64Url(new TextEncoder().encode(JSON.stringify(value)));
 }

--- a/apps/native-rd/src/badges/vcJwt.ts
+++ b/apps/native-rd/src/badges/vcJwt.ts
@@ -1,0 +1,112 @@
+/**
+ * ES256 VC-JWT external proof.
+ *
+ * OB 3.0 accepts two proof formats. The embedded DataIntegrityProof form needs
+ * RDFC-1.0 canonicalization, which has no working implementation available to
+ * this app; the external form is a plain compact JWS over the credential and
+ * needs none. See docs/research/ob3-proof-format-spike.md.
+ *
+ * The result is a three-segment `header.payload.signature` string — the whole
+ * credential, not a JSON object carrying a `proof` array. That string is what
+ * gets stored on the badge row and baked into the PNG (both the baker and the
+ * unbaker already branch on JWS-vs-JSON).
+ *
+ * Pure and platform-agnostic apart from `Buffer`: the private key never
+ * appears here, only a `sign` callback that reaches SecureStoreKeyProvider.
+ */
+import { Buffer } from "buffer";
+
+/** The public half of a P-256 JWK, with any private or advisory fields dropped. */
+export interface PublicP256Jwk {
+  kty: "EC";
+  crv: "P-256";
+  x: string;
+  y: string;
+}
+
+export interface VcJwtInput {
+  /** The unsigned OB3 VerifiableCredential, exactly as `buildUnsignedCredential` returns it. */
+  unsignedCredential: Record<string, unknown>;
+  /** Issuer DID — becomes the `iss` claim. */
+  issuerDid: string;
+  /** Public key of the signing key, inlined into the protected header. */
+  publicKeyJwk: JsonWebKey;
+  /** ISO-8601 issuance timestamp — becomes `iat`/`nbf`. */
+  issuedOn: string;
+  /** Credential id — becomes the `jti` claim. */
+  credentialId: string;
+  /** Produces a raw IEEE-P1363 `r‖s` signature over the given bytes. */
+  sign: (signingInput: Uint8Array) => Promise<Uint8Array>;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+function jsonToBase64Url(value: unknown): string {
+  return toBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/**
+ * Narrows a JWK to the four public P-256 fields.
+ *
+ * Deliberately an allowlist, not a `delete d`: `crypto.subtle.exportKey`
+ * returns `key_ops`/`ext` alongside the coordinates, and this object is
+ * published inside every badge — nothing gets in that isn't named here.
+ */
+export function toPublicP256Jwk(jwk: JsonWebKey): PublicP256Jwk {
+  if (jwk.kty !== "EC" || jwk.crv !== "P-256") {
+    throw new Error(
+      `Cannot build an ES256 proof from a ${String(jwk.kty)}/${String(jwk.crv)} key — expected EC/P-256`,
+    );
+  }
+  if (!jwk.x || !jwk.y) {
+    throw new Error("Invalid P-256 public key JWK: missing x or y coordinate");
+  }
+  return { kty: "EC", crv: "P-256", x: jwk.x, y: jwk.y };
+}
+
+/**
+ * Signs an unsigned OB3 credential as a compact ES256 JWS.
+ *
+ * The public key rides in the protected header as an inline `jwk` rather than
+ * a dereferenceable `kid` URL, so a badge verifies with no network access —
+ * which is the whole point for a local-first app.
+ */
+export async function signCredentialAsVcJwt(
+  input: VcJwtInput,
+): Promise<string> {
+  const publicJwk = toPublicP256Jwk(input.publicKeyJwk);
+
+  const header = { alg: "ES256", typ: "JWT", jwk: publicJwk };
+
+  const issuedAtSeconds = Math.floor(new Date(input.issuedOn).getTime() / 1000);
+  if (!Number.isFinite(issuedAtSeconds)) {
+    throw new Error(`Invalid issuedOn timestamp: ${input.issuedOn}`);
+  }
+
+  const subject = input.unsignedCredential["credentialSubject"] as
+    | { id?: unknown }
+    | undefined;
+
+  const payload = {
+    iss: input.issuerDid,
+    // Self-sovereign assertion: the subject is the issuer. Fall back to the
+    // issuer DID only if the credential somehow carries no subject id, so the
+    // claim never silently disagrees with the credential it wraps.
+    sub: typeof subject?.id === "string" ? subject.id : input.issuerDid,
+    jti: input.credentialId,
+    nbf: issuedAtSeconds,
+    iat: issuedAtSeconds,
+    vc: input.unsignedCredential,
+  };
+
+  const signingInput = `${jsonToBase64Url(header)}.${jsonToBase64Url(payload)}`;
+  const signature = await input.sign(new TextEncoder().encode(signingInput));
+
+  return `${signingInput}.${toBase64Url(signature)}`;
+}

--- a/apps/native-rd/src/crypto/SecureStoreKeyProvider.ts
+++ b/apps/native-rd/src/crypto/SecureStoreKeyProvider.ts
@@ -6,6 +6,10 @@
  *   rcd_privkey_<keyId>  — private key JWK
  *   rcd_pubkey_<keyId>   — public key JWK
  *
+ * Keys are ECDSA P-256 (ES256). P-256 rather than Ed25519 because the OB3
+ * external-proof (VC-JWT) path only accepts RS256/ES256 — an EdDSA JWS is
+ * rejected outright by the validator. See docs/research/ob3-proof-format-spike.md.
+ *
  * Requires react-native-quick-crypto to be installed at app entry (index.ts does this).
  */
 import * as SecureStore from "expo-secure-store";
@@ -32,7 +36,7 @@ export class SecureStoreKeyProvider implements KeyProvider {
     publicKeyJwk: JsonWebKey;
   }> {
     const keyPair = await crypto.subtle.generateKey(
-      { name: "Ed25519" },
+      { name: "ECDSA", namedCurve: "P-256" },
       true, // extractable — needed to export as JWK
       ["sign", "verify"],
     );
@@ -60,7 +64,7 @@ export class SecureStoreKeyProvider implements KeyProvider {
       ),
     ]);
 
-    logger.info("Ed25519 keypair generated and stored", { keyId });
+    logger.info("P-256 keypair generated and stored", { keyId });
     return { keyId, publicKeyJwk };
   }
 
@@ -82,7 +86,7 @@ export class SecureStoreKeyProvider implements KeyProvider {
     const cryptoKey = await crypto.subtle.importKey(
       "jwk",
       privateKeyJwk,
-      { name: "Ed25519" },
+      { name: "ECDSA", namedCurve: "P-256" },
       false, // not extractable after import
       ["sign"],
     );
@@ -92,7 +96,13 @@ export class SecureStoreKeyProvider implements KeyProvider {
       data.byteOffset,
       data.byteOffset + data.byteLength,
     ) as ArrayBuffer;
-    const signature = await crypto.subtle.sign("Ed25519", cryptoKey, buffer);
+    // WebCrypto's ECDSA sign() returns the raw IEEE-P1363 `r‖s` pair, which is
+    // exactly the form a JWS ES256 signature takes — no DER unwrapping needed.
+    const signature = await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      cryptoKey,
+      buffer,
+    );
     return new Uint8Array(signature);
   }
 }

--- a/apps/native-rd/src/crypto/__tests__/SecureStoreKeyProvider.test.ts
+++ b/apps/native-rd/src/crypto/__tests__/SecureStoreKeyProvider.test.ts
@@ -14,15 +14,17 @@ const mockSetItem = setItemAsync as jest.Mock;
 
 const MOCK_KEY_ID = "test-uuid-1234";
 const MOCK_PUB_JWK: JsonWebKey = {
-  kty: "OKP",
-  crv: "Ed25519",
-  x: "pubkeydata",
+  kty: "EC",
+  crv: "P-256",
+  x: "pubkeyx",
+  y: "pubkeyy",
   key_ops: ["verify"],
 };
 const MOCK_PRIV_JWK: JsonWebKey = {
-  kty: "OKP",
-  crv: "Ed25519",
-  x: "pubkeydata",
+  kty: "EC",
+  crv: "P-256",
+  x: "pubkeyx",
+  y: "pubkeyy",
   d: "privkeydata",
   key_ops: ["sign"],
 };
@@ -78,10 +80,10 @@ describe("SecureStoreKeyProvider", () => {
   });
 
   describe("generateKeyPair()", () => {
-    it("generates an Ed25519 keypair via crypto.subtle", async () => {
+    it("generates a P-256 ECDSA keypair via crypto.subtle", async () => {
       await provider.generateKeyPair();
       expect(mockSubtle.generateKey).toHaveBeenCalledWith(
-        { name: "Ed25519" },
+        { name: "ECDSA", namedCurve: "P-256" },
         true,
         ["sign", "verify"],
       );
@@ -143,12 +145,14 @@ describe("SecureStoreKeyProvider", () => {
       expect(mockSubtle.importKey).toHaveBeenCalledWith(
         "jwk",
         MOCK_PRIV_JWK,
-        { name: "Ed25519" },
+        { name: "ECDSA", namedCurve: "P-256" },
         false,
         ["sign"],
       );
+      // SHA-256 is what makes this ES256 rather than any other ECDSA variant —
+      // a JWS with alg:ES256 over a differently-hashed signature won't verify.
       expect(mockSubtle.sign).toHaveBeenCalledWith(
-        "Ed25519",
+        { name: "ECDSA", hash: "SHA-256" },
         mockPrivKey,
         expect.any(ArrayBuffer),
       );

--- a/apps/native-rd/src/db/queries.ts
+++ b/apps/native-rd/src/db/queries.ts
@@ -1500,7 +1500,8 @@ export const badgesWithGoalsQuery = evolu.createQuery((db) =>
  * Create a badge for a completed goal
  * @param params - Badge parameters
  * @param params.goalId - Goal ID
- * @param params.credential - OB3 Verifiable Credential JSON string
+ * @param params.credential - Signed OB3 credential: a compact ES256 JWS since
+ *   #598, credential JSON for badges earned before it. Stored opaquely.
  * @param params.imageUri - Local file path to baked badge image
  * @returns Insert command
  * @throws Error if validation fails

--- a/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
@@ -22,9 +22,12 @@ jest.mock("@rollercoaster-dev/openbadges-core", () => ({
 
 jest.mock("../../crypto", () => ({
   keyProvider: {
-    getPublicKey: jest
-      .fn()
-      .mockResolvedValue({ kty: "OKP", crv: "Ed25519", x: "testkey" }),
+    getPublicKey: jest.fn().mockResolvedValue({
+      kty: "EC",
+      crv: "P-256",
+      x: "fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI",
+      y: "hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU",
+    }),
     sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
   },
 }));
@@ -59,7 +62,13 @@ jest.mock("../../badges", () => ({
     id: "urn:uuid:cred-01",
     type: ["VerifiableCredential"],
   })),
-  buildDid: jest.fn(() => "did:key:testkey"),
+  buildDid: jest.fn(
+    () => "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+  ),
+  // Not stubbed: the JWS is the artifact this hook now produces, so the tests
+  // below decode a real one rather than trusting a fake string.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  signCredentialAsVcJwt: require("../../badges/vcJwt").signCredentialAsVcJwt,
   bakePNG: jest.fn(() => Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])),
   isPNG: jest.fn(
     (buf: Buffer) => buf.length >= 8 && buf[0] === 137 && buf[1] === 80,
@@ -71,6 +80,19 @@ jest.mock("../../badges", () => ({
     Promise.resolve(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])),
   ),
 }));
+
+/** Three dot-separated base64url segments — the compact JWS the hook now emits. */
+const JWS_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+function decodeJwsSegment(jws: string, index: number): Record<string, unknown> {
+  return JSON.parse(
+    Buffer.from(jws.split(".")[index]!, "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+}
+
+function decodeJwsPayload(jws: string): Record<string, unknown> {
+  return decodeJwsSegment(jws, 1);
+}
 
 const mockUseQuery = useQuery as jest.Mock;
 const mockCompleteGoal = completeGoal as jest.Mock;
@@ -196,7 +218,7 @@ describe("useCreateBadge", () => {
       expect(mockUpdateBadge).toHaveBeenCalledWith(
         "badge-01",
         expect.objectContaining({
-          credential: expect.stringContaining("VerifiableCredential"),
+          credential: expect.stringMatching(JWS_PATTERN),
           imageUri: "file:///app/badges/test-badge.png",
         }),
       );
@@ -344,15 +366,21 @@ describe("useCreateBadge", () => {
       );
     });
 
-    it("stores a credential JSON string", async () => {
+    it("stores the credential as a compact JWS, not a JSON envelope", async () => {
       renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
       expect(mockCreateBadge).toHaveBeenCalledWith(
         expect.objectContaining({
-          credential: expect.stringContaining("VerifiableCredential"),
+          credential: expect.stringMatching(JWS_PATTERN),
         }),
       );
+      const { credential } = mockCreateBadge.mock.calls[0][0] as {
+        credential: string;
+      };
+      expect(decodeJwsPayload(credential)["vc"]).toMatchObject({
+        type: ["VerifiableCredential"],
+      });
     });
 
     it("reaches status: done after successful creation", async () => {
@@ -582,30 +610,60 @@ describe("useCreateBadge", () => {
     });
   });
 
-  describe("proof value encoding", () => {
-    it("stores a proof with a valid base64url proofValue (no +, /, or = chars)", async () => {
-      // sign returns 64 zero bytes — deterministic base64url output
-      mockKeyProvider.sign.mockResolvedValue(new Uint8Array(64));
-
+  describe("ES256 VC-JWT proof", () => {
+    it("bakes the same JWS string it stores on the badge row", async () => {
       renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       await act(async () => {});
 
-      const callArg = mockCreateBadge.mock.calls[0][0] as {
+      const { credential } = mockCreateBadge.mock.calls[0][0] as {
         credential: string;
       };
-      const credential = JSON.parse(callArg.credential) as Record<
-        string,
-        unknown
-      >;
-      // OB3 requires `proof` to be an array, even with a single entry.
-      const proofs = credential["proof"] as Record<string, unknown>[];
-      expect(proofs).toHaveLength(1);
-      const proof = proofs[0]!;
+      // A divergence here means the PNG carries a different credential from
+      // the DB — the export would verify against something the app can't show.
+      expect(mockBadges.bakePNG).toHaveBeenCalledWith(
+        expect.anything(),
+        credential,
+      );
+    });
 
-      expect(proof["proofValue"]).toMatch(/^[A-Za-z0-9_-]+$/);
-      expect(proof["proofValue"]).not.toContain("=");
-      expect(proof["proofValue"]).not.toContain("+");
-      expect(proof["proofValue"]).not.toContain("/");
+    it("declares alg ES256 with an inline P-256 jwk in the protected header", async () => {
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
+      await act(async () => {});
+
+      const { credential } = mockCreateBadge.mock.calls[0][0] as {
+        credential: string;
+      };
+      const header = decodeJwsSegment(credential, 0);
+      expect(header["alg"]).toBe("ES256");
+      expect(header["jwk"]).toMatchObject({ kty: "EC", crv: "P-256" });
+    });
+
+    it("wraps the unsigned credential under `vc` and issues from the did:key", async () => {
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
+      await act(async () => {});
+
+      const { credential } = mockCreateBadge.mock.calls[0][0] as {
+        credential: string;
+      };
+      const payload = decodeJwsPayload(credential);
+      expect(payload["iss"]).toBe(
+        "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+      );
+      expect(payload["vc"]).toBeDefined();
+    });
+
+    it("signs the header.payload bytes with the user's key", async () => {
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
+      await act(async () => {});
+
+      const { credential } = mockCreateBadge.mock.calls[0][0] as {
+        credential: string;
+      };
+      const [header, payload] = credential.split(".");
+      expect(mockKeyProvider.sign).toHaveBeenCalledWith(
+        "key-001",
+        new TextEncoder().encode(`${header}.${payload}`),
+      );
     });
   });
 

--- a/apps/native-rd/src/hooks/__tests__/useUserKey.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useUserKey.test.ts
@@ -25,7 +25,7 @@ jest.mock("../../crypto", () => ({
       .mockResolvedValue({ keyId: "generated-key-id", publicKeyJwk: {} }),
     getPublicKey: jest
       .fn()
-      .mockResolvedValue({ kty: "OKP", crv: "Ed25519", x: "pubkey" }),
+      .mockResolvedValue({ kty: "EC", crv: "P-256", x: "pubx", y: "puby" }),
   },
 }));
 
@@ -219,9 +219,10 @@ describe("useUserKey", () => {
       );
       // Second probe (for keyId-B) resolves immediately.
       mockKeyProvider.getPublicKey.mockResolvedValueOnce({
-        kty: "OKP",
-        crv: "Ed25519",
-        x: "B",
+        kty: "EC",
+        crv: "P-256",
+        x: "Bx",
+        y: "By",
       });
 
       mockUseQuery.mockReturnValue([{ id: MOCK_SETTINGS_ID, keyId: "key-A" }]);
@@ -240,13 +241,80 @@ describe("useUserKey", () => {
 
       // Now the stale first probe resolves with key-A's data.
       await act(async () => {
-        resolveFirstProbe({ kty: "OKP", crv: "Ed25519", x: "A" });
+        resolveFirstProbe({ kty: "EC", crv: "P-256", x: "Ax", y: "Ay" });
       });
 
       // The late result must NOT clobber the verified key-B state.
       expect(result.current.keyId).toBe("key-B");
       expect(result.current.isReady).toBe(true);
       expect(mockClearUserSettingsKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the stored key predates the P-256 migration (#598)", () => {
+    it("clears an Ed25519 keyId so a fresh P-256 keypair is generated", async () => {
+      mockUseQuery.mockReturnValue([
+        { id: MOCK_SETTINGS_ID, keyId: "ed25519-key-id" },
+      ]);
+      mockKeyProvider.getPublicKey.mockResolvedValueOnce({
+        kty: "OKP",
+        crv: "Ed25519",
+        x: "legacy-pubkey",
+      });
+
+      renderHook(() => useUserKey());
+      await act(async () => {});
+
+      expect(mockClearUserSettingsKey).toHaveBeenCalledWith(MOCK_SETTINGS_ID);
+    });
+
+    it("isReady stays false while the stale key is being rotated out", async () => {
+      mockUseQuery.mockReturnValue([
+        { id: MOCK_SETTINGS_ID, keyId: "ed25519-key-id" },
+      ]);
+      mockKeyProvider.getPublicKey.mockResolvedValueOnce({
+        kty: "OKP",
+        crv: "Ed25519",
+        x: "legacy-pubkey",
+      });
+
+      const { result } = renderHook(() => useUserKey());
+      await act(async () => {});
+
+      expect(result.current.isReady).toBe(false);
+      // Rotation is silent — a wrong-algorithm key is a migration, not a fault.
+      expect(result.current.error).toBeNull();
+    });
+
+    it("keeps a P-256 key (does not rotate a current key)", async () => {
+      mockUseQuery.mockReturnValue([
+        { id: MOCK_SETTINGS_ID, keyId: "p256-key-id" },
+      ]);
+
+      const { result } = renderHook(() => useUserKey());
+      await act(async () => {});
+
+      expect(mockClearUserSettingsKey).not.toHaveBeenCalled();
+      expect(result.current.isReady).toBe(true);
+    });
+
+    it("emits a 'key/rotate' breadcrumb when rotating, not when keeping", async () => {
+      mockUseQuery.mockReturnValue([
+        { id: MOCK_SETTINGS_ID, keyId: "ed25519-key-id" },
+      ]);
+      mockKeyProvider.getPublicKey.mockResolvedValueOnce({
+        kty: "OKP",
+        crv: "Ed25519",
+        x: "legacy-pubkey",
+      });
+
+      renderHook(() => useUserKey());
+      await act(async () => {});
+
+      expect(mockBreadcrumb).toHaveBeenCalledWith({
+        category: "key",
+        message: "rotate",
+      });
     });
   });
 

--- a/apps/native-rd/src/hooks/useCreateBadge.ts
+++ b/apps/native-rd/src/hooks/useCreateBadge.ts
@@ -52,6 +52,7 @@ import { keyProvider } from "../crypto";
 import {
   buildUnsignedCredential,
   buildDid,
+  signCredentialAsVcJwt,
   bakePNG,
   isPNG,
   saveBadgePNG,
@@ -87,14 +88,6 @@ export interface UseCreateBadgeResult {
    * "Terminal error state and recovery" note above.
    */
   retryBake: () => void;
-}
-
-function toBase64Url(bytes: Uint8Array): string {
-  return Buffer.from(bytes)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
 }
 
 export interface UseCreateBadgeOptions {
@@ -246,31 +239,20 @@ export function useCreateBadge(
         setStatus("signing");
         breadcrumb({ category: "badge", message: "sign" });
 
-        const credentialJson = JSON.stringify(unsignedCredential);
-        const encoded = new TextEncoder().encode(credentialJson);
-        const signatureBytes = await keyProvider.sign(keyId, encoded);
-        const proofValue = toBase64Url(signatureBytes);
-
-        // NOTE (Iteration A): The `eddsa-rdfc-2022` cryptosuite spec requires
-        // RDFC-1.0 canonicalization and a multibase `u`-prefixed proofValue.
-        // We sign raw JSON.stringify() and emit plain base64url instead, so
-        // this proof will NOT verify under a spec-compliant verifier.
-        // Full spec-compliant signing (RDFC canonicalization + multibase) is
-        // Iteration D work.
-        const signedCredential = {
-          ...unsignedCredential,
-          // OB3 requires `proof` to be an array, even with a single entry.
-          proof: [
-            {
-              type: "DataIntegrityProof",
-              cryptosuite: "eddsa-raw-json-iteration-a",
-              created: issuedOn,
-              proofPurpose: "assertionMethod",
-              verificationMethod: `${issuerDid}#key-1`,
-              proofValue,
-            },
-          ],
-        };
+        // OB3 external proof: the signed credential IS a compact ES256 JWS,
+        // not a JSON object carrying a `proof` array. The embedded
+        // DataIntegrityProof form would need RDFC-1.0 canonicalization, which
+        // this app has no implementation for; see docs/research/
+        // ob3-proof-format-spike.md. Badges signed before this change keep
+        // their old JSON form — nothing re-serializes or re-signs them.
+        const signedCredential = await signCredentialAsVcJwt({
+          unsignedCredential,
+          issuerDid,
+          publicKeyJwk,
+          issuedOn,
+          credentialId,
+          sign: (bytes) => keyProvider.sign(keyId, bytes),
+        });
 
         setStatus("baking");
         breadcrumb({ category: "badge", message: "bake" });
@@ -328,8 +310,7 @@ export function useCreateBadge(
           }
           pngBuffer = capturedPngRef.current;
         }
-        const credentialJsonOut = JSON.stringify(signedCredential);
-        const bakedPng = bakePNG(pngBuffer, credentialJsonOut);
+        const bakedPng = bakePNG(pngBuffer, signedCredential);
 
         // Save to disk — legitimately recoverable (filesystem errors). Fall back
         // to placeholder so badge creation still succeeds without a baked image.
@@ -373,12 +354,12 @@ export function useCreateBadge(
         // Result would let a failed persist fall through to setStatus("done").
         const badgeResult = existingBadge
           ? updateBadge(existingBadge.id as BadgeId, {
-              credential: credentialJsonOut,
+              credential: signedCredential,
               imageUri,
             })
           : createBadge({
               goalId,
-              credential: credentialJsonOut,
+              credential: signedCredential,
               imageUri,
               ...(designRef.current ? { design: designRef.current } : {}),
             });

--- a/apps/native-rd/src/hooks/useUserKey.ts
+++ b/apps/native-rd/src/hooks/useUserKey.ts
@@ -1,7 +1,7 @@
 /**
  * useUserKey
  *
- * Ensures an Ed25519 keypair exists for the current user/device.
+ * Ensures a P-256 (ES256) keypair exists for the current user/device.
  * On first mount (when UserSettings has no keyId), generates a keypair
  * via SecureStoreKeyProvider and persists the keyId to UserSettings.
  *
@@ -9,6 +9,13 @@
  * (e.g. iOS keychain wipe on reinstall, simulator reset, bundle id change),
  * the orphan keyId is cleared so the generation effect can produce a fresh
  * keypair. Without this, badge creation fails with "Public key not found".
+ *
+ * Also self-heals across the Ed25519 → P-256 migration (#598): a key stored
+ * by a pre-upgrade build is the wrong algorithm for the ES256 VC-JWT proof
+ * the app now signs, and the validator rejects EdDSA outright, so such a key
+ * is cleared exactly like an orphan and a fresh P-256 key is generated in its
+ * place. Badges already earned under the old key are left untouched — the
+ * rotation only affects the next badge signed.
  *
  * Idempotent — does nothing if a verified keyId is already stored.
  * Silent — no UI, key generation happens in the background.
@@ -21,6 +28,15 @@ import { reportError, breadcrumb } from "../services/sentry-report";
 import { Logger } from "../shims/rd-logger";
 
 const logger = new Logger("useUserKey");
+
+/**
+ * True for the ECDSA P-256 public keys `SecureStoreKeyProvider` now mints.
+ * Anything else — most concretely a pre-#598 `{kty: "OKP", crv: "Ed25519"}`
+ * key — is stale and gets rotated out.
+ */
+function isP256Jwk(jwk: JsonWebKey | null | undefined): boolean {
+  return jwk?.kty === "EC" && jwk.crv === "P-256";
+}
 
 export interface UserKeyState {
   /** The keyId stored in UserSettings (null until generation completes) */
@@ -78,10 +94,25 @@ export function useUserKey(): UserKeyState {
     (async () => {
       try {
         breadcrumb({ category: "key", message: "verify" });
-        await keyProvider.getPublicKey(verifyingKeyId);
+        const publicKeyJwk = await keyProvider.getPublicKey(verifyingKeyId);
         // Stale-result guard: if settings.keyId changed during verification,
         // discard this result rather than marking a different key verified.
         if (pendingKeyId.current !== verifyingKeyId) return;
+
+        // Wrong-algorithm branch (#598): a pre-upgrade Ed25519 key can never
+        // produce a badge the OB3 validator accepts, so treat it exactly like
+        // an orphan — clear it and let the generation effect mint a P-256 key.
+        if (!isP256Jwk(publicKeyJwk)) {
+          logger.warn(
+            "Stored key is not P-256 — clearing so a fresh P-256 keypair can be generated",
+            { keyId: verifyingKeyId },
+          );
+          breadcrumb({ category: "key", message: "rotate" });
+          clearUserSettingsKey(settings.id);
+          setVerified(false);
+          return;
+        }
+
         verifiedKeyId.current = verifyingKeyId;
         setVerified(true);
       } catch (err) {
@@ -127,7 +158,7 @@ export function useUserKey(): UserKeyState {
         const { keyId } = await keyProvider.generateKeyPair();
         // Evolu mutations are synchronous CRDT operations — no await needed.
         updateUserSettingsKey(settings.id, keyId);
-        logger.info("Ed25519 keypair ready", { keyId });
+        logger.info("P-256 keypair ready", { keyId });
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";
         setError(`Key generation failed: ${message}`);

--- a/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
@@ -14,6 +14,7 @@ import { useUnistyles } from "react-native-unistyles";
 import { useQuery } from "@evolu/react";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "phosphor-react-native";
+import { Buffer } from "buffer";
 import { Text } from "../../components/Text";
 import { Button } from "../../components/Button";
 import { Card } from "../../components/Card";
@@ -69,14 +70,37 @@ const EVIDENCE_ID_PREFIX = "urn:ulid:";
 const logger = new Logger("BadgeDetailScreen");
 
 /**
+ * Unwraps a stored `badge.credential` to the VC object holding `evidence`.
+ *
+ * Two shapes reach this screen. Badges signed since #598 are compact ES256
+ * JWS strings whose credential sits under the payload's `vc` claim; badges
+ * earned before it are plain credential JSON. Old badges are never migrated
+ * or re-signed (their signature covers the exact stored bytes), so both
+ * shapes have to stay readable indefinitely. The 3-dot-segment /
+ * not-`{`-prefixed test is the same heuristic png-baking.ts uses to tell them
+ * apart.
+ */
+function parseStoredCredential(credential: string): Record<string, unknown> {
+  const trimmed = credential.trim();
+  if (!trimmed.startsWith("{") && trimmed.split(".").length === 3) {
+    const payload = JSON.parse(
+      Buffer.from(trimmed.split(".")[1]!, "base64url").toString("utf8"),
+    ) as { vc?: unknown };
+    return (payload.vc ?? {}) as Record<string, unknown>;
+  }
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+/**
  * Pulls the achievement criteria narrative out of a stored OB3
- * VerifiableCredential (the "how it was earned" text). Defensive: any parse
- * failure or shape mismatch returns null so the UI just hides the section.
+ * VerifiableCredential (the "how it was earned" text), in either stored
+ * format. Defensive: any parse failure or shape mismatch returns null so the
+ * UI just hides the section.
  */
 function extractCriteriaNarrative(credential: string | null): string | null {
   if (!credential) return null;
   try {
-    const parsed: unknown = JSON.parse(credential);
+    const parsed = parseStoredCredential(credential);
     const subject = (parsed as { credentialSubject?: unknown })
       ?.credentialSubject;
     const achievement = (subject as { achievement?: unknown })?.achievement;
@@ -134,7 +158,7 @@ function extractEvidenceItems(
 ): CredentialEvidence[] | null {
   if (!credential) return null;
   try {
-    const parsed: unknown = JSON.parse(credential);
+    const parsed = parseStoredCredential(credential);
     const rawList = (parsed as { evidence?: unknown })?.evidence;
     if (!Array.isArray(rawList) || rawList.length === 0) return null;
 

--- a/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/BadgeDetailScreen.tsx
@@ -14,7 +14,6 @@ import { useUnistyles } from "react-native-unistyles";
 import { useQuery } from "@evolu/react";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "phosphor-react-native";
-import { Buffer } from "buffer";
 import { Text } from "../../components/Text";
 import { Button } from "../../components/Button";
 import { Card } from "../../components/Card";
@@ -26,6 +25,9 @@ import { ConfirmDeleteModal } from "../../components/ConfirmDeleteModal";
 import { badgeWithGoalQuery, deleteBadge } from "../../db";
 import type { BadgeId } from "../../db";
 import { PLACEHOLDER_IMAGE_URI } from "../../hooks/useCreateBadge";
+// Deep import, not the barrel: `badges/index` pulls in credentialBuilder ->
+// openbadges-core, which is ESM and unloadable in this screen's Jest runtime.
+import { parseStoredCredential } from "../../badges/vcJwt";
 import { useBadgeExport } from "../../hooks/useBadgeExport";
 import { useAnimationPref } from "../../hooks/useAnimationPref";
 import { parseBadgeDesign } from "../../badges/types";
@@ -68,28 +70,6 @@ const OVERFLOW_POPOVER_TOP_OFFSET = 56;
 const EVIDENCE_ID_PREFIX = "urn:ulid:";
 
 const logger = new Logger("BadgeDetailScreen");
-
-/**
- * Unwraps a stored `badge.credential` to the VC object holding `evidence`.
- *
- * Two shapes reach this screen. Badges signed since #598 are compact ES256
- * JWS strings whose credential sits under the payload's `vc` claim; badges
- * earned before it are plain credential JSON. Old badges are never migrated
- * or re-signed (their signature covers the exact stored bytes), so both
- * shapes have to stay readable indefinitely. The 3-dot-segment /
- * not-`{`-prefixed test is the same heuristic png-baking.ts uses to tell them
- * apart.
- */
-function parseStoredCredential(credential: string): Record<string, unknown> {
-  const trimmed = credential.trim();
-  if (!trimmed.startsWith("{") && trimmed.split(".").length === 3) {
-    const payload = JSON.parse(
-      Buffer.from(trimmed.split(".")[1]!, "base64url").toString("utf8"),
-    ) as { vc?: unknown };
-    return (payload.vc ?? {}) as Record<string, unknown>;
-  }
-  return JSON.parse(trimmed) as Record<string, unknown>;
-}
 
 /**
  * Pulls the achievement criteria narrative out of a stored OB3

--- a/apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx
+++ b/apps/native-rd/src/screens/BadgeDetailScreen/__tests__/BadgeDetailScreen.test.tsx
@@ -630,6 +630,57 @@ describe("BadgeDetailScreen", () => {
         evidence,
       });
 
+    /**
+     * The shape #598 writes: a compact ES256 JWS whose payload carries the
+     * credential under `vc`. Signature bytes are irrelevant to this read path
+     * — the screen never verifies, it only displays.
+     */
+    const jwsCredentialWith = (evidence: unknown[], narrative = "Did it.") => {
+      const b64 = (value: unknown) =>
+        Buffer.from(JSON.stringify(value)).toString("base64url");
+      return [
+        b64({ alg: "ES256", typ: "JWT" }),
+        b64({
+          iss: "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+          vc: JSON.parse(credentialWith(evidence, narrative)) as unknown,
+        }),
+        Buffer.from(new Uint8Array(64)).toString("base64url"),
+      ].join(".");
+    };
+
+    it("renders proof cards for a JWS-signed credential (#598 format)", () => {
+      const credential = jwsCredentialWith([
+        {
+          id: "urn:ulid:ev-1",
+          type: ["Evidence"],
+          name: "Watch intro video",
+          genre: "video",
+        },
+      ]);
+      mockUseQuery.mockReturnValue([makeRow({ credential })]);
+
+      renderWithProviders(
+        <BadgeDetailScreen route={mockRoute} navigation={{} as never} />,
+      );
+
+      expect(screen.getByText("Watch intro video")).toBeOnTheScreen();
+      expect(screen.getByText("Video")).toBeOnTheScreen();
+    });
+
+    it("renders the criteria narrative from a JWS-signed credential", () => {
+      const credential = jwsCredentialWith(
+        [{ id: "urn:ulid:ev-1", type: ["Evidence"], name: "A step" }],
+        "Finished every step.",
+      );
+      mockUseQuery.mockReturnValue([makeRow({ credential })]);
+
+      renderWithProviders(
+        <BadgeDetailScreen route={mockRoute} navigation={{} as never} />,
+      );
+
+      expect(screen.getByText("Finished every step.")).toBeOnTheScreen();
+    });
+
     it("renders a proof card per evidence item, with its translated type label", () => {
       const credential = credentialWith([
         {

--- a/apps/native-rd/src/services/sentry-report.ts
+++ b/apps/native-rd/src/services/sentry-report.ts
@@ -142,7 +142,9 @@ export type BreadcrumbInput =
       kind: EvidenceTypeValue;
     }
   | { category: "badge"; message: "build" | "sign" | "bake" | "store" }
-  | { category: "key"; message: "generate" | "verify" }
+  // "rotate" is the Ed25519 -> P-256 migration (#598): a stale-algorithm key
+  // is cleared and regenerated, which otherwise looks like an orphan clear.
+  | { category: "key"; message: "generate" | "verify" | "rotate" }
   | { category: "focus"; message: "enter" | "exit" }
   // The cockpit pin writes userSettings, not goal — filing it under "goal"
   // would plant a phantom "goal updated" crumb ahead of unrelated goal errors.

--- a/packages/openbadges-core/src/crypto/did-key.ts
+++ b/packages/openbadges-core/src/crypto/did-key.ts
@@ -277,13 +277,3 @@ export function decodeP256DidKey(did: string): JsonWebKey {
 
   return decompressP256PublicKey(decoded.slice(P256_PUB_MULTICODEC.length));
 }
-
-/** True when `did` is a well-formed `did:key` P-256 identifier this module can decode. */
-export function isP256DidKey(did: string): boolean {
-  try {
-    decodeP256DidKey(did);
-    return true;
-  } catch {
-    return false;
-  }
-}

--- a/packages/openbadges-core/src/crypto/did-key.ts
+++ b/packages/openbadges-core/src/crypto/did-key.ts
@@ -1,0 +1,289 @@
+/**
+ * did:key encoding for P-256 (ES256) public keys.
+ *
+ * Produces the spec-compliant `did:key:z…` form: multibase base58btc (`z`)
+ * over a multicodec-prefixed, SEC1-compressed public key.
+ *
+ *   did:key:z<base58btc( varint(0x1200) || compressed-point )>
+ *
+ * `0x1200` is the multicodec code for `p256-pub`; its unsigned-varint
+ * encoding is the two bytes `0x80 0x24`. The compressed point is 33 bytes:
+ * a `0x02`/`0x03` parity prefix followed by the 32-byte X coordinate.
+ *
+ * Dependency-free by design — no multiformats/base58 package exists in this
+ * monorepo, and both encodings are small and fully specified. Uses only
+ * native `BigInt`, so it runs unchanged under Hermes, Node, and Bun.
+ */
+
+/** Multicodec `p256-pub` (0x1200) as an unsigned varint. */
+const P256_PUB_MULTICODEC = Uint8Array.from([0x80, 0x24]);
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/** P-256 field prime (`p ≡ 3 mod 4`, which is what makes sqrt a single exponentiation). */
+const P256_PRIME = BigInt(
+  "115792089210356248762697446949407573530086143415290314195533631308867097853951",
+);
+/** P-256 curve coefficient `b`. `a` is fixed at -3 and inlined below. */
+const P256_B = BigInt(
+  "41058363725152142129326129780047268409114441015993725554835256314039467401291",
+);
+
+/** Encodes bytes as base58btc (Bitcoin alphabet), preserving leading zeros as `1`s. */
+export function base58btcEncode(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+
+  // Leading zero bytes carry no numeric weight, so they must be re-added as
+  // '1' characters rather than falling out of the big-integer conversion.
+  let leadingZeros = 0;
+  while (leadingZeros < bytes.length && bytes[leadingZeros] === 0) {
+    leadingZeros++;
+  }
+
+  let value = 0n;
+  for (const byte of bytes) {
+    value = (value << 8n) | BigInt(byte);
+  }
+
+  let out = "";
+  while (value > 0n) {
+    const remainder = Number(value % 58n);
+    value /= 58n;
+    out = BASE58_ALPHABET[remainder] + out;
+  }
+
+  return "1".repeat(leadingZeros) + out;
+}
+
+/** Decodes a base58btc (Bitcoin alphabet) string. Throws on any character outside the alphabet. */
+export function base58btcDecode(encoded: string): Uint8Array {
+  if (encoded.length === 0) return new Uint8Array(0);
+
+  let leadingOnes = 0;
+  while (leadingOnes < encoded.length && encoded[leadingOnes] === "1") {
+    leadingOnes++;
+  }
+
+  let value = 0n;
+  for (const char of encoded) {
+    const digit = BASE58_ALPHABET.indexOf(char);
+    if (digit < 0) {
+      throw new Error(`Invalid base58btc character: '${char}'`);
+    }
+    value = value * 58n + BigInt(digit);
+  }
+
+  const digits: number[] = [];
+  while (value > 0n) {
+    digits.unshift(Number(value & 0xffn));
+    value >>= 8n;
+  }
+
+  const out = new Uint8Array(leadingOnes + digits.length);
+  out.set(digits, leadingOnes);
+  return out;
+}
+
+const BASE64URL_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+// Hand-rolled rather than via atob/btoa or Buffer: this module has to run
+// unchanged under Hermes, where neither is guaranteed to be on the global.
+function base64UrlToBytes(input: string): Uint8Array {
+  const out: number[] = [];
+  let bits = 0;
+  let acc = 0;
+  for (const char of input) {
+    if (char === "=") break;
+    const digit = BASE64URL_ALPHABET.indexOf(char);
+    if (digit < 0) {
+      throw new Error(`Invalid base64url character: '${char}'`);
+    }
+    acc = (acc << 6) | digit;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out.push((acc >> bits) & 0xff);
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let out = "";
+  let bits = 0;
+  let acc = 0;
+  for (const byte of bytes) {
+    acc = (acc << 8) | byte;
+    bits += 8;
+    while (bits >= 6) {
+      bits -= 6;
+      out += BASE64URL_ALPHABET[(acc >> bits) & 0x3f];
+    }
+  }
+  if (bits > 0) {
+    out += BASE64URL_ALPHABET[(acc << (6 - bits)) & 0x3f];
+  }
+  return out;
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  return value;
+}
+
+function bigIntTo32Bytes(value: bigint): Uint8Array {
+  const out = new Uint8Array(32);
+  let remaining = value;
+  for (let i = 31; i >= 0; i--) {
+    out[i] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return out;
+}
+
+function modPow(base: bigint, exponent: bigint, modulus: bigint): bigint {
+  let result = 1n;
+  let b = base % modulus;
+  let e = exponent;
+  while (e > 0n) {
+    if (e & 1n) result = (result * b) % modulus;
+    b = (b * b) % modulus;
+    e >>= 1n;
+  }
+  return result;
+}
+
+/** Reads and validates the 32-byte `x`/`y` coordinates of a P-256 public-key JWK. */
+function readP256Coordinates(jwk: JsonWebKey): {
+  x: Uint8Array;
+  y: Uint8Array;
+} {
+  if (jwk.kty !== "EC" || jwk.crv !== "P-256") {
+    throw new Error(
+      `Expected a P-256 EC public key JWK, got kty='${String(jwk.kty)}' crv='${String(jwk.crv)}'`,
+    );
+  }
+  if (!jwk.x || !jwk.y) {
+    throw new Error("Invalid P-256 public key JWK: missing x or y coordinate");
+  }
+  const x = base64UrlToBytes(jwk.x);
+  const y = base64UrlToBytes(jwk.y);
+  if (x.length !== 32 || y.length !== 32) {
+    throw new Error(
+      `Invalid P-256 public key JWK: coordinates must be 32 bytes (got x=${x.length}, y=${y.length})`,
+    );
+  }
+  return { x, y };
+}
+
+/**
+ * SEC1 point compression: a P-256 public-key JWK to a 33-byte point whose
+ * leading byte encodes the parity of `y` (`0x02` even, `0x03` odd).
+ */
+export function compressP256PublicKey(jwk: JsonWebKey): Uint8Array {
+  const { x, y } = readP256Coordinates(jwk);
+  const out = new Uint8Array(33);
+  out[0] = (y[31]! & 1) === 0 ? 0x02 : 0x03;
+  out.set(x, 1);
+  return out;
+}
+
+/**
+ * Reverses {@link compressP256PublicKey}: recovers `y` from `x` via
+ * `y² = x³ - 3x + b mod p`, taking the square root as `y = (y²)^((p+1)/4) mod p`
+ * — valid because P-256's prime is `≡ 3 mod 4` — then picking the root whose
+ * parity matches the compression prefix.
+ */
+export function decompressP256PublicKey(point: Uint8Array): JsonWebKey {
+  if (point.length !== 33) {
+    throw new Error(
+      `Invalid compressed P-256 point: expected 33 bytes, got ${point.length}`,
+    );
+  }
+  const prefix = point[0]!;
+  if (prefix !== 0x02 && prefix !== 0x03) {
+    throw new Error(
+      `Invalid compressed P-256 point: prefix must be 0x02 or 0x03, got 0x${prefix.toString(16)}`,
+    );
+  }
+
+  const xBytes = point.slice(1);
+  const x = bytesToBigInt(xBytes);
+  if (x >= P256_PRIME) {
+    throw new Error("Invalid compressed P-256 point: x is not in the field");
+  }
+
+  const ySquared = (((x * x * x - 3n * x) % P256_PRIME) + P256_B) % P256_PRIME;
+  let y = modPow(ySquared, (P256_PRIME + 1n) / 4n, P256_PRIME);
+
+  // The exponentiation always returns *something*; only squaring it back
+  // proves x was actually on the curve.
+  if ((y * y) % P256_PRIME !== ySquared) {
+    throw new Error("Invalid compressed P-256 point: x is not on the curve");
+  }
+
+  const wantOdd = prefix === 0x03;
+  const isOdd = (y & 1n) === 1n;
+  if (isOdd !== wantOdd) {
+    y = P256_PRIME - y;
+  }
+
+  return {
+    kty: "EC",
+    crv: "P-256",
+    x: bytesToBase64Url(xBytes),
+    y: bytesToBase64Url(bigIntTo32Bytes(y)),
+  };
+}
+
+/** Encodes a P-256 public-key JWK as a spec-compliant `did:key:z…` identifier. */
+export function encodeP256DidKey(jwk: JsonWebKey): string {
+  const compressed = compressP256PublicKey(jwk);
+  const prefixed = new Uint8Array(
+    P256_PUB_MULTICODEC.length + compressed.length,
+  );
+  prefixed.set(P256_PUB_MULTICODEC, 0);
+  prefixed.set(compressed, P256_PUB_MULTICODEC.length);
+  return `did:key:z${base58btcEncode(prefixed)}`;
+}
+
+/**
+ * Decodes a `did:key:z…` P-256 identifier back to a public-key JWK.
+ * Any fragment (`#…`) or path is rejected rather than silently stripped —
+ * this app never mints one, so its presence means the DID isn't ours.
+ */
+export function decodeP256DidKey(did: string): JsonWebKey {
+  if (!did.startsWith("did:key:z")) {
+    throw new Error(`Not a multibase did:key identifier: ${did}`);
+  }
+  const multibase = did.slice("did:key:z".length);
+  if (multibase.length === 0) {
+    throw new Error(`Empty did:key multibase payload: ${did}`);
+  }
+
+  const decoded = base58btcDecode(multibase);
+  if (
+    decoded.length < P256_PUB_MULTICODEC.length ||
+    decoded[0] !== P256_PUB_MULTICODEC[0] ||
+    decoded[1] !== P256_PUB_MULTICODEC[1]
+  ) {
+    throw new Error(
+      "did:key does not carry the p256-pub multicodec prefix (0x1200)",
+    );
+  }
+
+  return decompressP256PublicKey(decoded.slice(P256_PUB_MULTICODEC.length));
+}
+
+/** True when `did` is a well-formed `did:key` P-256 identifier this module can decode. */
+export function isP256DidKey(did: string): boolean {
+  try {
+    decodeP256DidKey(did);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/openbadges-core/src/crypto/index.ts
+++ b/packages/openbadges-core/src/crypto/index.ts
@@ -35,6 +35,17 @@ export {
 export type { CryptoProvider, PlatformConfig } from "./adapters/types.js";
 export { NodeCryptoAdapter } from "./adapters/node-crypto.adapter.js";
 
+// did:key encoding (P-256)
+export {
+  base58btcEncode,
+  base58btcDecode,
+  compressP256PublicKey,
+  decompressP256PublicKey,
+  encodeP256DidKey,
+  decodeP256DidKey,
+  isP256DidKey,
+} from "./did-key.js";
+
 // JWT proof
 export type {
   JWTProof,

--- a/packages/openbadges-core/src/crypto/index.ts
+++ b/packages/openbadges-core/src/crypto/index.ts
@@ -35,16 +35,10 @@ export {
 export type { CryptoProvider, PlatformConfig } from "./adapters/types.js";
 export { NodeCryptoAdapter } from "./adapters/node-crypto.adapter.js";
 
-// did:key encoding (P-256)
-export {
-  base58btcEncode,
-  base58btcDecode,
-  compressP256PublicKey,
-  decompressP256PublicKey,
-  encodeP256DidKey,
-  decodeP256DidKey,
-  isP256DidKey,
-} from "./did-key.js";
+// did:key encoding (P-256). The base58btc and point-compression primitives
+// stay module-local — they are unit-tested directly and have no consumer of
+// their own; export them when one appears.
+export { encodeP256DidKey, decodeP256DidKey } from "./did-key.js";
 
 // JWT proof
 export type {

--- a/packages/openbadges-core/tests/crypto/did-key.test.ts
+++ b/packages/openbadges-core/tests/crypto/did-key.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "bun:test";
+import { createPublicKey } from "node:crypto";
+import {
+  base58btcEncode,
+  base58btcDecode,
+  compressP256PublicKey,
+  decompressP256PublicKey,
+  encodeP256DidKey,
+  decodeP256DidKey,
+  isP256DidKey,
+} from "../../src/crypto/did-key";
+
+/**
+ * Known-answer vector from the W3C did:key method spec's P-256 example.
+ * Anchors the whole pipeline (base58btc + multicodec + point decompression)
+ * against a value this repo did not compute, so a round-trip test can't pass
+ * on a self-consistently wrong encoding.
+ */
+const SPEC_DID = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
+const SPEC_JWK: JsonWebKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI",
+  y: "hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU",
+};
+
+async function generateP256Jwk(): Promise<JsonWebKey> {
+  const pair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  );
+  return crypto.subtle.exportKey("jwk", pair.publicKey);
+}
+
+describe("base58btc", () => {
+  test.each([
+    [[0x00], "1"],
+    [[0x00, 0x00, 0x01], "112"],
+    [[0x61], "2g"],
+    [[0x62, 0x62, 0x62], "a3gV"],
+    [[0x80, 0x24], "Akb"], // the p256-pub multicodec varint
+  ])("encodes %p and decodes back", (bytes, expected) => {
+    const input = Uint8Array.from(bytes);
+    expect(base58btcEncode(input)).toBe(expected);
+    expect(Array.from(base58btcDecode(expected))).toEqual(bytes);
+  });
+
+  test("rejects characters outside the Bitcoin alphabet", () => {
+    // '0', 'O', 'I' and 'l' are the four deliberately-omitted characters.
+    expect(() => base58btcDecode("0OIl")).toThrow(
+      "Invalid base58btc character",
+    );
+  });
+
+  test("round-trips 33 random bytes", () => {
+    const bytes = crypto.getRandomValues(new Uint8Array(33));
+    expect(Array.from(base58btcDecode(base58btcEncode(bytes)))).toEqual(
+      Array.from(bytes),
+    );
+  });
+});
+
+describe("P-256 point compression", () => {
+  test("compresses to 33 bytes with a parity prefix", () => {
+    const point = compressP256PublicKey(SPEC_JWK);
+    expect(point.length).toBe(33);
+    expect([0x02, 0x03]).toContain(point[0]);
+  });
+
+  test("decompresses back to the original coordinates", () => {
+    expect(decompressP256PublicKey(compressP256PublicKey(SPEC_JWK))).toEqual(
+      SPEC_JWK,
+    );
+  });
+
+  test("rejects a non-P-256 JWK", () => {
+    expect(() =>
+      compressP256PublicKey({ kty: "OKP", crv: "Ed25519", x: "abc" }),
+    ).toThrow("Expected a P-256 EC public key JWK");
+  });
+
+  test("rejects a JWK missing the y coordinate", () => {
+    expect(() =>
+      compressP256PublicKey({ kty: "EC", crv: "P-256", x: SPEC_JWK.x }),
+    ).toThrow("missing x or y coordinate");
+  });
+
+  test("rejects an x that is not on the curve", () => {
+    const point = compressP256PublicKey(SPEC_JWK);
+    point[1] ^= 0xff; // perturb the high byte of x
+    expect(() => decompressP256PublicKey(point)).toThrow("not on the curve");
+  });
+
+  test("rejects a point of the wrong length", () => {
+    expect(() => decompressP256PublicKey(new Uint8Array(32))).toThrow(
+      "expected 33 bytes",
+    );
+  });
+
+  test("rejects an uncompressed-point prefix", () => {
+    const point = compressP256PublicKey(SPEC_JWK);
+    point[0] = 0x04;
+    expect(() => decompressP256PublicKey(point)).toThrow(
+      "prefix must be 0x02 or 0x03",
+    );
+  });
+});
+
+describe("encodeP256DidKey / decodeP256DidKey", () => {
+  test("encodes the spec's P-256 example to the spec's DID", () => {
+    expect(encodeP256DidKey(SPEC_JWK)).toBe(SPEC_DID);
+  });
+
+  test("decodes the spec's DID to the spec's JWK", () => {
+    expect(decodeP256DidKey(SPEC_DID)).toEqual(SPEC_JWK);
+  });
+
+  test("produces a DID whose decoded key Node accepts as a P-256 point", () => {
+    const key = createPublicKey({
+      key: decodeP256DidKey(SPEC_DID) as Record<string, unknown>,
+      format: "jwk",
+    });
+    expect(key.asymmetricKeyType).toBe("ec");
+  });
+
+  test.each([0, 1, 2])(
+    "round-trips a freshly generated P-256 keypair (#%i)",
+    async () => {
+      const jwk = await generateP256Jwk();
+      const did = encodeP256DidKey(jwk);
+      expect(did.startsWith("did:key:zDna")).toBe(true);
+      const decoded = decodeP256DidKey(did);
+      expect(decoded.x).toBe(jwk.x!);
+      expect(decoded.y).toBe(jwk.y!);
+    },
+  );
+
+  test("rejects a DID without the multibase `z` prefix", () => {
+    expect(() => decodeP256DidKey("did:key:abc123")).toThrow(
+      "Not a multibase did:key identifier",
+    );
+  });
+
+  test("rejects an empty multibase payload", () => {
+    expect(() => decodeP256DidKey("did:key:z")).toThrow(
+      "Empty did:key multibase payload",
+    );
+  });
+
+  test("rejects an Ed25519 did:key (wrong multicodec)", () => {
+    // Ed25519 multicodec is 0xed01, not 0x1200 — a real, spec-valid DID that
+    // this P-256-only decoder must refuse rather than mis-decode.
+    const ed25519Did =
+      "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    expect(() => decodeP256DidKey(ed25519Did)).toThrow(
+      "p256-pub multicodec prefix",
+    );
+  });
+
+  test("isP256DidKey distinguishes decodable DIDs from malformed ones", () => {
+    expect(isP256DidKey(SPEC_DID)).toBe(true);
+    // Iteration-A form: raw jwk.x with no multibase/multicodec at all.
+    expect(
+      isP256DidKey("did:key:fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI"),
+    ).toBe(false);
+  });
+});

--- a/packages/openbadges-core/tests/crypto/did-key.test.ts
+++ b/packages/openbadges-core/tests/crypto/did-key.test.ts
@@ -7,7 +7,6 @@ import {
   decompressP256PublicKey,
   encodeP256DidKey,
   decodeP256DidKey,
-  isP256DidKey,
 } from "../../src/crypto/did-key";
 
 /**
@@ -124,17 +123,18 @@ describe("encodeP256DidKey / decodeP256DidKey", () => {
     expect(key.asymmetricKeyType).toBe("ec");
   });
 
-  test.each([0, 1, 2])(
-    "round-trips a freshly generated P-256 keypair (#%i)",
-    async () => {
+  test("round-trips freshly generated P-256 keypairs", async () => {
+    // Several keys, not one: decompression picks a parity branch, so a single
+    // key exercises only half of it even when the assertion passes.
+    for (let i = 0; i < 8; i++) {
       const jwk = await generateP256Jwk();
       const did = encodeP256DidKey(jwk);
       expect(did.startsWith("did:key:zDna")).toBe(true);
       const decoded = decodeP256DidKey(did);
       expect(decoded.x).toBe(jwk.x!);
       expect(decoded.y).toBe(jwk.y!);
-    },
-  );
+    }
+  });
 
   test("rejects a DID without the multibase `z` prefix", () => {
     expect(() => decodeP256DidKey("did:key:abc123")).toThrow(
@@ -156,13 +156,5 @@ describe("encodeP256DidKey / decodeP256DidKey", () => {
     expect(() => decodeP256DidKey(ed25519Did)).toThrow(
       "p256-pub multicodec prefix",
     );
-  });
-
-  test("isP256DidKey distinguishes decodable DIDs from malformed ones", () => {
-    expect(isP256DidKey(SPEC_DID)).toBe(true);
-    // Iteration-A form: raw jwk.x with no multibase/multicodec at all.
-    expect(
-      isP256DidKey("did:key:fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI"),
-    ).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #598.

Gaps 5 and 7 of #595 — the half that makes a signature actually check out.

## What changed

The issue asked for an **embedded** `eddsa-rdfc-2022` DataIntegrityProof. The spike (#623, `docs/research/ob3-proof-format-spike.md`) found no working RDFC-1.0 canonicalization available to this app, and that the validator rejects EdDSA JWTs outright. So this takes OB 3.0's other sanctioned route: an **external proof — a compact ES256 VC-JWT**. Same destination, different road; the title's `eddsa-rdfc` is now a misnomer.

That forced the key algorithm too: the VC-JWT path accepts RS256/ES256 only, so the signing key moves **Ed25519 → P-256**.

**Gap 5 — proof format.** `src/badges/vcJwt.ts` (new) signs the credential as `header.payload.signature`, public key inlined in the header as a `jwk` so a badge verifies with no network access. Replaces the `eddsa-raw-json-iteration-a` cryptosuite and its bare-base64url `proofValue`.

**Gap 7 — resolvable DID.** `packages/openbadges-core/src/crypto/did-key.ts` (new) does dependency-free P-256 `did:key` encoding — multibase `z…` + `0x1200` multicodec. Achievement IRIs no longer append path segments to a DID (`did:key` has no paths); they're HTTPS IRIs now.

**Key rotation.** `useUserKey` detects a stale Ed25519 key, clears it and regenerates as P-256. New `key: "rotate"` Sentry breadcrumb so this doesn't read as an orphan clear.

## Migration — existing badges

Badges signed under the old scheme are **never re-signed or migrated**; their signature covers the exact stored bytes. Both shapes stay readable indefinitely:

- `parseStoredCredential()` branches JWS-vs-JSON, as do the PNG baker/unbaker
- `scripts/verify-badge.ts` verifies both paths
- `BadgeDetailScreen` decodes JWS payloads for evidence and narrative display

The base64url decode is hand-rolled on purpose: the app bundles the feross `buffer` polyfill, which has no `base64url` encoding and throws `Unknown encoding` on device, while Jest resolves `buffer` to Node's core module and hides it.

## Validation

| Gate | Result |
| --- | --- |
| `bun run type-check` | pass |
| `bun run lint` | pass (pre-existing warnings only) |
| `bun run test` | 10342 tests / 216 suites pass |
| `bun run test:e2e:required` | 3/6 fail — **all three reproduce identically on `origin/main`**, see #636 |

## Not verified — read before merging

**#598's "done when" is not met.** It asks for a badge exported from the app validating clean at verifybadge.org, with the report replacing `ob3-compliance-status.validator-report.json`. No badge has been minted end-to-end on device on this branch: the only UI path to a bake is blocked by the pre-existing E2E failures in #636. The format is covered by unit tests (`vcJwt.test.ts`, `did-key.test.ts`, serializer tests) and `scripts/verify-badge.ts`, but not by a real device round-trip through the validator.

## Issues filed while validating

- #635 — a goal with **zero completed steps** can mint a badge; the only thing stopping it is a thrown error rendered as a failure alert, and a `required` E2E flow depends on that hole staying open. Pre-existing, unrelated to this branch, `needs:design`.
- #636 — the required E2E gate is 3/6 red on `main`. `bake-recovery`'s cause is diagnosed (a dev-only LogBox toast covers the celebrate-stage CTA); the other two are undiagnosed.
