### PR TITLE
test(native-rd): pin baked credential in exported PNG + JSON (#599)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-599-bake-credential-export.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-599-bake-credential-export.md
@@ -1,0 +1,142 @@
+# Development Plan: Issue #599
+
+## Issue Summary
+
+**Title**: [Bug] Badge export never bakes the credential — exported PNGs carry no iTXt chunk
+**Type**: bug (regression-test gap; production bug already fixed)
+**Complexity**: SMALL
+**Estimated Lines**: ~120-160 lines (tests only)
+
+## Key Finding — read before implementing
+
+The bug as described (`BadgeDetailScreen.tsx:241-245` branching on `design ?` to call a
+re-rasterizing `exportDesignImage`, skipping `bakePNG`) **no longer exists on `main`**.
+It was fixed by `6d65787a` — "fix(native-rd): bake-aware badge export + local verifier (#96)"
+— merged the same day (2026-05-18) as the linked research doc, three months before this
+issue was filed (2026-08-23). Verified on this branch (`fix/issue-599-bake-credential-export`,
+0 commits ahead of `main`):
+
+- `exportDesignImage` does not exist anywhere in `apps/native-rd/src` (confirmed via grep).
+- `BadgeDetailScreen.tsx` now calls `exportVerifiableBadge(imageUri, ...)` / `exportImage(imageUri)`
+  unconditionally — both always forward `badge.imageUri` (the on-disk **baked** file), never the
+  live `design`. `useBadgeExport.ts` never re-rasterizes.
+- `png-chunk-utils.ts::createiTXtChunk` hardcodes the compression flag byte to `0` — already
+  spec-uncompressed.
+- `png-baking.ts` already uses `openbadgecredential` as `OB3_KEYWORD`.
+- `useCreateBadge.ts:331` calls `bakePNG(pngBuffer, signedCredential)` and then persists
+  `credential: signedCredential` on the same badge record (`useCreateBadge.ts:381/386`) — the
+  exact same string is baked into the PNG and stored for JSON export. Guaranteed identical by
+  construction, not just by accident.
+- `BadgeDetailScreen.test.tsx` already has a named regression test (`it.each`, lines ~573-602)
+  pinning that both `share-row-verifiable` and `share-row-image` forward the baked `imageUri`
+  even when `design` is set — this is the wiring-level version of the exact bug this issue
+  describes.
+
+**What's actually missing**, matching the issue's literal "Done when" line ("Regression test
+pins the chunk"): every existing test either (a) unit-tests `bakePNG`/`unbakePNG` symmetrically
+— a bug that corrupted the keyword identically on both the write and read side would still pass
+— or (b) mocks `bakePNG` entirely in `useCreateBadge.test.ts` (`expect.any(String)`, not the
+exact persisted value). Nothing asserts, independently of the module's own round-trip, that the
+literal byte sequence `"openbadgecredential"` is what ends up in the iTXt keyword field, and
+nothing asserts that the string baked into the PNG is _identical_ to the string persisted as
+`badge.credential` (the value `exportJSON` ships verbatim — already pinned in
+`useBadgeExport.test.ts`).
+
+This plan closes that gap. No production code changes are anticipated.
+
+## Intent Verification
+
+- [ ] A test parses a real `bakePNG(...)` output with `extractChunks` + `findiTXtChunk` and
+      fails if the keyword byte sequence is anything other than the literal string
+      `"openbadgecredential"` — independent of `unbakePNG`'s own keyword search.
+- [ ] A test fails if the iTXt chunk's compression flag byte is non-zero (spec: "must not be
+      used").
+- [ ] A test fails if `useCreateBadge`'s `bakePNG(...)` second argument ever diverges from the
+      `credential` field persisted via `createBadge`/`updateBadge`, for both the initial-bake and
+      re-bake code paths.
+
+## Dependencies
+
+| Issue | Title                                                         | Status  | Type                                         |
+| ----- | ------------------------------------------------------------- | ------- | -------------------------------------------- |
+| #595  | Epic: OB3 external verification — make a badge verify outside | 🟡 Open | Soft (parent epic, "Part of", not a blocker) |
+
+**Status**: ✅ All dependencies met — #595 is a tracking epic, not a hard blocker.
+
+## Objective
+
+Add regression coverage that pins the two remaining unverified claims in the issue's "Done
+when": the literal OB3 `iTXt` `openbadgecredential` keyword (uncompressed), and byte-identical
+credential content between the baked PNG and the JSON export. No behavior change — the
+underlying export-path bug is already fixed on `main`.
+
+## Decisions
+
+| ID  | Decision                                                                                                                              | Alternatives Considered                                  | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| D1  | Test-only PR; no production code changes                                                                                              | Re-verify/re-implement the fix from scratch              | Grep + read confirms `exportDesignImage` is gone and both export paths already forward `imageUri` unconditionally; a wiring regression test for this already exists in `BadgeDetailScreen.test.tsx`. Redoing already-shipped work would be pure churn.                                                                                                                                                                                                                                                                   |
+| D2  | Assert the iTXt keyword via a fresh `extractChunks`/`findiTXtChunk` call rather than trusting `unbakePNG`'s round-trip                | Rely on existing `bakePNG`/`unbakePNG` roundtrip tests   | Bake and unbake both read `OB3_KEYWORD`/`BAKING_KEYWORDS` from the same module constants — a symmetric typo in that constant would still round-trip green. A test that hardcodes the literal string `"openbadgecredential"` catches that class of bug; the existing tests don't.                                                                                                                                                                                                                                         |
+| D3  | Do not add a full RN-hook-level integration test wiring real `bakePNG` output through `useBadgeExport`'s `Sharing`/`FileSystem` mocks | Build an end-to-end integration test spanning both hooks | `useBadgeExport` never parses or touches PNG bytes — `exportImage`/`exportVerifiableBadge` treat `imageUri` as an opaque path and hand it to `Sharing.shareAsync` / `FileSystem` verbatim. An integration test there would only re-prove plumbing already covered by `BadgeDetailScreen.test.tsx`'s existing `it.each` regression test (forwards baked `imageUri` regardless of `design`) and `useBadgeExport.test.ts`'s exact-string `exportJSON` assertion. Lower value than the byte-level and identity checks below. |
+
+## Affected Areas
+
+- `apps/native-rd/src/badges/__tests__/pngBaking.test.ts`: new assertions pinning the literal
+  `openbadgecredential` keyword and uncompressed flag on real `bakePNG` output.
+- `apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts`: strengthen existing bake/re-bake
+  tests to assert `bakePNG`'s credential argument is byte-identical to the persisted
+  `credential` field, not just `expect.any(String)`.
+
+## Implementation Plan
+
+### Step 1: Pin the literal iTXt keyword and uncompressed flag on real baked bytes
+
+**Files**: `apps/native-rd/src/badges/__tests__/pngBaking.test.ts`
+**Commit**: `test(native-rd): pin OB3 iTXt openbadgecredential keyword + uncompressed flag`
+**Changes**:
+
+- [ ] Import `extractChunks`, `findiTXtChunk` from `../png-chunk-utils`.
+- [ ] New test: bake `CREDENTIAL_STUB` into a generated PNG, call `extractChunks` +
+      `findiTXtChunk(chunks, "openbadgecredential")` directly (not via `unbakePNG`), assert the
+      chunk is found. Use the literal string, not the module's `OB3_KEYWORD` export (it isn't
+      exported — that's intentional; re-importing the constant would make the test tautological).
+- [ ] New test: from the same chunk, walk past the null-terminated keyword and assert the
+      compression-flag byte is `0`.
+
+### Step 2: Pin baked-bytes/persisted-credential identity in `useCreateBadge`
+
+**Files**: `apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts`
+**Commit**: `test(native-rd): assert baked PNG credential matches persisted badge.credential`
+**Changes**:
+
+- [ ] In the existing "creates badge" happy-path test (`WITH_PNG`), capture
+      `mockBadges.bakePNG.mock.calls[0][1]` and `mockCreateBadge.mock.calls[0][0].credential`;
+      assert strict equality (`toBe`), replacing/augmenting the current `expect.any(String)`
+      shape.
+- [ ] Do the same in the re-bake tests (`freshCapturedPng` path → `mockUpdateBadge`, and
+      `readBadgePNG`-of-existing-imageUri path → `mockUpdateBadge`): `bakePNG`'s credential
+      argument must equal the `credential` field passed to `updateBadge`.
+
+## Testing Strategy
+
+- [ ] `bun run test --testPathPatterns "pngBaking|useCreateBadge"` — scoped run for the touched
+      suites (Jest 30, run via `scripts/jest-node.sh`, never plain `jest`/`bun test`).
+- [ ] `bun run test` — full suite, confirm no regressions elsewhere.
+- [ ] `bun run type-check` and `bun run lint`.
+- [ ] No manual device testing needed — test-only change, no runtime code touched.
+
+## Not in Scope
+
+| Item                                                                       | Reason                                                                                                         | Follow-up |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------- |
+| Re-fixing the `design ?` export branch                                     | Already fixed on `main` by #96; verified via grep, no `exportDesignImage` remains                              | none      |
+| Messenger transcode handling (Telegram photo mode strips iTXt)             | Explicitly out of scope per issue; receiver-side, no in-app fix exists                                         | none      |
+| Hosted verification link / Tier 3 (OB 3.0 §5.2 web resource)               | Separate architectural work, tracked under the parent epic                                                     | #595      |
+| Full RN-hook integration test spanning `useCreateBadge` → `useBadgeExport` | `useBadgeExport` never touches PNG bytes; existing wiring + exact-string tests already cover the seam (see D3) | none      |
+
+## Discovery Log
+
+- [2026-09-03] Confirmed via `git log --oneline main..HEAD` (empty) and grep for
+  `exportDesignImage` (zero results in `apps/native-rd/src`) that the production bug described
+  in this issue was already fixed by PR #96 (`6d65787a`, merged 2026-05-18) before the issue was
+  filed (2026-08-23). Scope narrowed from "fix the export path" to "close the regression-test gap
+  the issue's own 'Done when' line calls out."

--- a/apps/native-rd/src/badges/__tests__/pngBaking.test.ts
+++ b/apps/native-rd/src/badges/__tests__/pngBaking.test.ts
@@ -153,15 +153,16 @@ describe("baked iTXt chunk — OB 3.0 wire format (#599)", () => {
     return parsed.filter((c) => c.keyword === OB3_KEYWORD);
   }
 
+  const baked = bakePNG(
+    Buffer.from(generateBadgeImagePNG("#FF5733")),
+    JSON.stringify(CREDENTIAL_STUB),
+  );
+
   it("writes exactly one iTXt chunk keyed `openbadgecredential`", () => {
-    const png = generateBadgeImagePNG("#FF5733");
-    const baked = bakePNG(Buffer.from(png), JSON.stringify(CREDENTIAL_STUB));
     expect(findOb3Chunk(baked)).toHaveLength(1);
   });
 
   it("stores the credential uncompressed (flag 0, method 0)", () => {
-    const png = generateBadgeImagePNG("#FF5733");
-    const baked = bakePNG(Buffer.from(png), JSON.stringify(CREDENTIAL_STUB));
     const [chunk] = findOb3Chunk(baked);
     expect(chunk?.compressionFlag).toBe(0);
     expect(chunk?.compressionMethod).toBe(0);

--- a/apps/native-rd/src/badges/__tests__/pngBaking.test.ts
+++ b/apps/native-rd/src/badges/__tests__/pngBaking.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_BADGE_COLOR,
 } from "../badgeImageGenerator";
 import { bakePNG, unbakePNG, isPNG } from "../png-baking";
+import { extractChunks } from "../png-chunk-utils";
 
 // The OB3 credential stub we bake into test images
 const CREDENTIAL_STUB = {
@@ -121,6 +122,58 @@ describe("bakePNG / unbakePNG roundtrip", () => {
     // JWS path returns the raw string, not a parsed object
     expect(typeof recovered).toBe("string");
     expect(recovered).toBe(jws);
+  });
+});
+
+/**
+ * Regression guard for #599: the bytes that leave the app must carry the
+ * credential in the OB 3.0 shape. Parsed straight from the chunk stream with
+ * a literal keyword so a symmetric typo in the module's own constant (which
+ * both bakePNG and unbakePNG read) cannot round-trip green.
+ */
+describe("baked iTXt chunk — OB 3.0 wire format (#599)", () => {
+  const OB3_KEYWORD = "openbadgecredential";
+
+  function findOb3Chunk(baked: Buffer) {
+    const iTXtChunks = extractChunks(baked).filter((c) => c.name === "iTXt");
+    const parsed = iTXtChunks.map((c) => {
+      const data = Buffer.from(c.data);
+      const keywordEnd = data.indexOf(0);
+      const keyword = data.subarray(0, keywordEnd).toString("latin1");
+      // iTXt layout after the keyword's null terminator:
+      // compression flag (1) | compression method (1) |
+      // language tag \0 | translated keyword \0 | text
+      const compressionFlag = data[keywordEnd + 1];
+      const compressionMethod = data[keywordEnd + 2];
+      const langEnd = data.indexOf(0, keywordEnd + 3);
+      const translatedEnd = data.indexOf(0, langEnd + 1);
+      const text = data.subarray(translatedEnd + 1).toString("utf8");
+      return { keyword, compressionFlag, compressionMethod, text };
+    });
+    return parsed.filter((c) => c.keyword === OB3_KEYWORD);
+  }
+
+  it("writes exactly one iTXt chunk keyed `openbadgecredential`", () => {
+    const png = generateBadgeImagePNG("#FF5733");
+    const baked = bakePNG(Buffer.from(png), JSON.stringify(CREDENTIAL_STUB));
+    expect(findOb3Chunk(baked)).toHaveLength(1);
+  });
+
+  it("stores the credential uncompressed (flag 0, method 0)", () => {
+    const png = generateBadgeImagePNG("#FF5733");
+    const baked = bakePNG(Buffer.from(png), JSON.stringify(CREDENTIAL_STUB));
+    const [chunk] = findOb3Chunk(baked);
+    expect(chunk?.compressionFlag).toBe(0);
+    expect(chunk?.compressionMethod).toBe(0);
+  });
+
+  it("the chunk text is byte-identical to the credential string handed to bakePNG", () => {
+    const png = generateBadgeImagePNG("#FF5733");
+    const jws =
+      "eyJhbGciOiJFUzI1NiJ9.eyJ2YyI6eyJpZCI6InVybjp1dWlkOjU5OSJ9fQ.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const baked = bakePNG(Buffer.from(png), jws);
+    const [chunk] = findOb3Chunk(baked);
+    expect(chunk?.text).toBe(jws);
   });
 });
 

--- a/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
@@ -163,8 +163,12 @@ beforeEach(() => {
  * carry the same signed credential.
  */
 function bakedCredentialArg(): string {
-  const call = mockBadges.bakePNG.mock.calls[0] as unknown as [Buffer, string];
-  return call[1];
+  return mockBadges.bakePNG.mock.calls[0][1] as string;
+}
+
+/** Credential field of the record handed to updateBadge (re-bake paths). */
+function updatedCredentialArg(): string {
+  return mockUpdateBadge.mock.calls[0][1].credential as string;
 }
 
 describe("useCreateBadge", () => {
@@ -249,11 +253,7 @@ describe("useCreateBadge", () => {
         expect.any(String),
       );
       // #599: the re-baked PNG carries the same credential updateBadge persists
-      const [, updated] = mockUpdateBadge.mock.calls[0] as [
-        string,
-        { credential: string },
-      ];
-      expect(updated.credential).toBe(bakedCredentialArg());
+      expect(updatedCredentialArg()).toBe(bakedCredentialArg());
     });
 
     it("re-bakes using readBadgePNG of the existing imageUri when no freshCapturedPng is provided", async () => {
@@ -288,11 +288,7 @@ describe("useCreateBadge", () => {
       );
       expect(mockUpdateBadge).toHaveBeenCalled();
       expect(mockCreateBadge).not.toHaveBeenCalled();
-      const [, updated] = mockUpdateBadge.mock.calls[0] as [
-        string,
-        { credential: string },
-      ];
-      expect(updated.credential).toBe(bakedCredentialArg());
+      expect(updatedCredentialArg()).toBe(bakedCredentialArg());
     });
 
     it("fails loud when readBadgePNG throws on re-completion (does not silently fall back)", async () => {
@@ -418,8 +414,23 @@ describe("useCreateBadge", () => {
       const { credential } = mockCreateBadge.mock.calls[0][0] as {
         credential: string;
       };
+      // Guards the toBe below against a vacuous undefined === undefined.
       expect(credential).toMatch(JWS_PATTERN);
       expect(bakedCredentialArg()).toBe(credential);
+    });
+
+    it("saves the baked bytes, not the raw capture (#599 bug shape)", async () => {
+      // Distinguishable from the input so "saved the raw capture" cannot pass.
+      const BAKED = Buffer.concat([VALID_PNG, Buffer.from("iTXt")]);
+      mockBadges.bakePNG.mockReturnValueOnce(BAKED);
+
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
+      await act(async () => {});
+
+      expect(mockBadges.saveBadgePNG).toHaveBeenCalledWith(
+        BAKED,
+        expect.any(String),
+      );
     });
 
     it("reaches status: done after successful creation", async () => {

--- a/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
@@ -157,6 +157,16 @@ beforeEach(() => {
   });
 });
 
+/**
+ * #599: the string baked into the PNG must be the very string persisted as
+ * badge.credential — that is what exportJSON ships, so PNG and JSON exports
+ * carry the same signed credential.
+ */
+function bakedCredentialArg(): string {
+  const call = mockBadges.bakePNG.mock.calls[0] as unknown as [Buffer, string];
+  return call[1];
+}
+
 describe("useCreateBadge", () => {
   describe("when key is not ready (isReady: false)", () => {
     it("returns status: loading — transient, key is still initialising", () => {
@@ -238,6 +248,12 @@ describe("useCreateBadge", () => {
         FRESH,
         expect.any(String),
       );
+      // #599: the re-baked PNG carries the same credential updateBadge persists
+      const [, updated] = mockUpdateBadge.mock.calls[0] as [
+        string,
+        { credential: string },
+      ];
+      expect(updated.credential).toBe(bakedCredentialArg());
     });
 
     it("re-bakes using readBadgePNG of the existing imageUri when no freshCapturedPng is provided", async () => {
@@ -272,6 +288,11 @@ describe("useCreateBadge", () => {
       );
       expect(mockUpdateBadge).toHaveBeenCalled();
       expect(mockCreateBadge).not.toHaveBeenCalled();
+      const [, updated] = mockUpdateBadge.mock.calls[0] as [
+        string,
+        { credential: string },
+      ];
+      expect(updated.credential).toBe(bakedCredentialArg());
     });
 
     it("fails loud when readBadgePNG throws on re-completion (does not silently fall back)", async () => {
@@ -388,6 +409,17 @@ describe("useCreateBadge", () => {
       expect(decodeJwsPayload(credential)["vc"]).toMatchObject({
         type: ["VerifiableCredential"],
       });
+    });
+
+    it("bakes the exact credential string it persists (PNG and JSON exports agree, #599)", async () => {
+      renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
+      await act(async () => {});
+
+      const { credential } = mockCreateBadge.mock.calls[0][0] as {
+        credential: string;
+      };
+      expect(credential).toMatch(JWS_PATTERN);
+      expect(bakedCredentialArg()).toBe(credential);
     });
 
     it("reaches status: done after successful creation", async () => {


### PR DESCRIPTION
## Summary

- The bug as filed in #599 (`design ? exportDesignImage(...)` skipping `bakePNG`) **no longer exists on `main`** — it was fixed by #96 (`6d65787a`, 2026-05-18), three months before the issue was filed from the same-day research doc. `exportDesignImage` is gone; both share rows forward the on-disk baked `imageUri`; `BadgeDetailScreen.test.tsx` already pins that wiring.
- What was missing is the issue's own "Done when" line: a regression test that **pins the chunk**. Every existing test either round-tripped `bakePNG`/`unbakePNG` through the same module constant, or mocked `bakePNG` and checked only `expect.any(String)`.
- This PR is test-only. No production code changes.

## Changes

- `pngBaking.test.ts`: parses `bakePNG` output straight from the chunk stream with the literal keyword `openbadgecredential`; asserts exactly one such iTXt chunk, compression flag/method `0`, and chunk text byte-identical to the credential string passed in.
- `useCreateBadge.test.ts`: asserts the string handed to `bakePNG` is the very string persisted as `badge.credential` (what `exportJSON` ships), on the initial bake and both re-bake paths; asserts `saveBadgePNG` receives `bakePNG`'s output, not the raw capture.
- Every new assertion was mutation-checked: keyword typo → 3 failures; persisting `signedCredential + "x"` → 4 failures; saving `pngBuffer` instead of `bakedPng` → 1 failure.

## Intent Verification

- [x] A test parses a real `bakePNG(...)` output and fails if the keyword byte sequence is anything other than the literal string `"openbadgecredential"` — independent of `unbakePNG`'s own keyword search.
- [x] A test fails if the iTXt chunk's compression flag byte is non-zero.
- [x] A test fails if `useCreateBadge`'s `bakePNG(...)` second argument ever diverges from the `credential` field persisted via `createBadge`/`updateBadge`, for both the initial-bake and re-bake code paths.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Test-only PR; no production code changes | `exportDesignImage` is gone and both export paths already forward `imageUri` unconditionally; wiring regression test already exists. |
| Assert the iTXt keyword via a fresh chunk-stream parse rather than trusting `unbakePNG`'s round-trip | Bake and unbake read the same module constant — a symmetric typo would still round-trip green. |
| No full RN-hook integration test spanning `useCreateBadge` → `useBadgeExport` | `useBadgeExport` never touches PNG bytes; existing wiring + exact-string `exportJSON` tests cover that seam. |

## Discovery Log

- [2026-09-03] Confirmed via grep for `exportDesignImage` (zero results) and `git log` that the production bug was already fixed by PR #96 before the issue was filed. Scope narrowed to closing the regression-test gap.

## Test Plan

- [x] Type-check passes
- [x] Lint passes
- [x] Tests pass (217 suites, 10394 tests)
- [x] Build script (no-op for native-rd) returns successfully

---

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8X5mdG9sLzTJCxQLBdvfz