### PR TITLE
docs: add root LICENSE and fix the three license contradictions (#602)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,663 @@
+This repository is multi-licensed; see LICENSING.md for the per-package map.
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-This repository is multi-licensed; see LICENSING.md for the per-package map.
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
@@ -661,3 +659,5 @@ specific requirements.
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
+
+This repository is multi-licensed; see LICENSING.md for the per-package map.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -10,7 +10,7 @@ This repository is a multi-package workspace. Different packages are licensed di
 | `packages/design-tokens`   | **MIT**           | [`packages/design-tokens/LICENSE`](packages/design-tokens/LICENSE)     | Design tokens. Maximally permissive.                                                         |
 | `apps/native-rd`           | **AGPL-3.0-only** | [`apps/native-rd/LICENSE`](apps/native-rd/LICENSE)                     | Differentiated product. Strong copyleft: any commercial fork or SaaS clone must remain open. |
 
-The root `package.json` is a private workspace meta-package — it is not published and has no per-se license; see this file.
+The root `package.json` is a private, unpublished workspace meta-package. Its `license` field points to this file rather than naming a single SPDX id, because the repo is licensed per package as above. The root [`LICENSE`](LICENSE) file carries the AGPL-3.0-only text (the dominant product license) so GitHub's license detector can populate the repository's license metadata; it does not change any package's license.
 
 ## Copyright
 
@@ -40,14 +40,14 @@ Forks may use the code under the applicable license. Forks **may not** publish t
 
 ## SPDX identifiers
 
-New source files should include an SPDX identifier in a header comment, e.g.:
+Source files may include an SPDX identifier in a header comment, e.g.:
 
 ```ts
 // SPDX-FileCopyrightText: 2026 Joe Czarnecki
 // SPDX-License-Identifier: AGPL-3.0-only
 ```
 
-Existing files will be backfilled progressively; lack of an SPDX header in an older file does not change which license applies (the package's LICENSE file is authoritative).
+SPDX headers are optional, not required. The package's LICENSE file is authoritative regardless of whether a given source file carries a header.
 
 ## Future-state notes
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -10,7 +10,7 @@ This repository is a multi-package workspace. Different packages are licensed di
 | `packages/design-tokens`   | **MIT**           | [`packages/design-tokens/LICENSE`](packages/design-tokens/LICENSE)     | Design tokens. Maximally permissive.                                                         |
 | `apps/native-rd`           | **AGPL-3.0-only** | [`apps/native-rd/LICENSE`](apps/native-rd/LICENSE)                     | Differentiated product. Strong copyleft: any commercial fork or SaaS clone must remain open. |
 
-The root `package.json` is a private, unpublished workspace meta-package. Its `license` field points to this file rather than naming a single SPDX id, because the repo is licensed per package as above. The root [`LICENSE`](LICENSE) file carries the AGPL-3.0-only text (the dominant product license) so GitHub's license detector can populate the repository's license metadata; it does not change any package's license.
+The root `package.json` is a private, unpublished workspace meta-package. Its `license` field and the root [`LICENSE`](LICENSE) file both say **AGPL-3.0-only** (the dominant product license) so GitHub's license detector can populate the repository's license metadata. That root declaration does not change any package's license: the per-package `LICENSE` files above are authoritative for the code they cover.
 
 ## Copyright
 

--- a/apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md
+++ b/apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md
@@ -116,7 +116,8 @@ Concrete artifacts required before App Store submission:
    - `packages/openbadges-core`: `"license": "Apache-2.0"`
    - `packages/design-tokens`: `"license": "MIT"`
    - `apps/native-rd`: `"license": "AGPL-3.0-only"`
-5. Root `package.json` `license` field set to `"SEE LICENSE IN ./LICENSING.md"`. Keep `"private": true` for the root meta-package (it's never published).
+5. Root `package.json` `license` field set to `"SEE LICENSE IN LICENSING.md"` (no leading `./` — npm and GitHub's licensee expect a bare path). Keep `"private": true` for the root meta-package (it's never published).
+   A root `LICENSE` carrying the AGPL-3.0-only text (the dominant product license) exists so GitHub's license detector populates the repository metadata; it does not override the per-package licenses (#602).
 6. Top-level `LICENSING.md` explaining the per-package model and the CLA/DCO posture.
 7. SPDX headers on source files (optional but recommended; tools like `reuse` automate this).
 8. **DCO enforcement** via a GitHub Action that requires `Signed-off-by:` lines on all PRs (or a CLA bot if a full CLA is preferred later).

--- a/apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md
+++ b/apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-The repo currently has no LICENSE file and `package.json` declares `private: true`. By default that means **all rights reserved** — nobody but the copyright holder may legally use, modify, or redistribute the code. Before the App Store launch (`docs/launch/app-store-launch-plan.md`), and before any public OSS announcement, a deliberate licensing posture is needed.
+At the time of writing the repo had no LICENSE file and `package.json` declared `private: true` (per-package LICENSE files and a root LICENSE were added later; see Implementation notes). By default that means **all rights reserved** — nobody but the copyright holder may legally use, modify, or redistribute the code. Before the App Store launch (`docs/launch/app-store-launch-plan.md`), and before any public OSS announcement, a deliberate licensing posture is needed.
 
 The project has **two distinct surfaces** with different strategic value:
 

--- a/apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md
+++ b/apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md
@@ -116,8 +116,7 @@ Concrete artifacts required before App Store submission:
    - `packages/openbadges-core`: `"license": "Apache-2.0"`
    - `packages/design-tokens`: `"license": "MIT"`
    - `apps/native-rd`: `"license": "AGPL-3.0-only"`
-5. Root `package.json` `license` field set to `"SEE LICENSE IN LICENSING.md"` (no leading `./` — npm and GitHub's licensee expect a bare path). Keep `"private": true` for the root meta-package (it's never published).
-   A root `LICENSE` carrying the AGPL-3.0-only text (the dominant product license) exists so GitHub's license detector populates the repository metadata; it does not override the per-package licenses (#602).
+5. Root `package.json` `license` field set to `"AGPL-3.0-only"`, matching a root `LICENSE` that carries the verbatim AGPL-3.0-only text (the dominant product license). Both exist so GitHub's license detector populates the repository metadata; a `SEE LICENSE IN …` value or any preamble in the LICENSE file makes licensee report NOASSERTION (#602). Keep `"private": true` for the root meta-package (it's never published). The root declaration does not override the per-package licenses.
 6. Top-level `LICENSING.md` explaining the per-package model and the CLA/DCO posture.
 7. SPDX headers on source files (optional but recommended; tools like `reuse` automate this).
 8. **DCO enforcement** via a GitHub Action that requires `Signed-off-by:` lines on all PRs (or a CLA bot if a full CLA is preferred later).

--- a/apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md
@@ -1,0 +1,121 @@
+# Development Plan: Issue #602
+
+## Issue Summary
+
+**Title**: Add a root LICENSE and fix the three license contradictions
+**Type**: documentation
+**Complexity**: TRIVIAL
+**Estimated Lines**: ~680 lines (mostly the copied AGPL license text; hand-authored diff is ~15 lines)
+
+## Intent Verification
+
+- [x] `/LICENSE` exists at repo root, containing the full AGPL-3.0-only text (verbatim copy of `apps/native-rd/LICENSE`) with a one-line preamble above it
+- [ ] After merge, `gh repo view --json licenseInfo` returns a non-null AGPL-3.0 result and the GitHub About sidebar shows a license chip
+- [x] `packages/openbadges-core/README.md` License section reads `Apache-2.0 — see [LICENSE](./LICENSE).` and matches `package.json:61` (`"license": "Apache-2.0"`)
+- [x] Root `package.json` `license` field has no leading `./` (either `SEE LICENSE IN LICENSING.md` or `AGPL-3.0-only`)
+- [x] `LICENSING.md`'s "no per-se license" sentence is reworded to match the new root LICENSE's existence
+- [x] `LICENSING.md`'s SPDX section no longer claims headers "will be backfilled progressively" as a commitment; it states they are optional and the package LICENSE file is authoritative
+- [x] `grep -rniE '^(MIT|Apache|AGPL)' --include='*.md' . --exclude-dir=node_modules` returns no result that contradicts its package's `package.json` license
+
+## Dependencies
+
+| Issue | Title                                   | Status  | Type                          |
+| ----- | --------------------------------------- | ------- | ----------------------------- |
+| #601  | Epic: Prototype Fund readiness (parent) | 🟡 Open | Parent tracker, not a blocker |
+
+**Status**: ✅ All dependencies met. #601 is referenced with "Part of #601" (parent epic), not "Blocked by"/"Depends on"/"After" — no hard or soft dependency marker. #602 is independently mergeable.
+
+## Objective
+
+Add a root `/LICENSE` file (AGPL-3.0-only text, matching `apps/native-rd/LICENSE`, the dominant product license) so GitHub's licensee detector populates `licenseInfo` and the About-sidebar license chip. Fix the three license self-contradictions the issue identifies: the MIT/Apache-2.0 mismatch in `packages/openbadges-core/README.md`, the `./`-prefixed root `package.json` license field that licensee ignores, and the stale/aspirational SPDX-backfill and "no per-se license" language in `LICENSING.md`.
+
+## Decisions
+
+| ID  | Decision                                                                                                                                                                                       | Alternatives Considered                                                                                         | Rationale                                                                                                                                                                                                                                                                                                                                |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Root `/LICENSE` = verbatim copy of `apps/native-rd/LICENSE` (AGPL-3.0-only) with a one-line preamble pointing to `LICENSING.md`                                                                | (a) `SEE LICENSE IN LICENSING.md` stub with no license text at root; (b) a custom multi-license disclaimer file | Issue explicitly directs this. Licensee only scans root `LICENSE`; a stub or custom text either fails detection or detects the wrong license. A single short preamble line does not break licensee's fuzzy match (see Verification).                                                                                                     |
+| D2  | Root `package.json` license field: change `SEE LICENSE IN ./LICENSING.md` → `SEE LICENSE IN LICENSING.md` (drop `./`), not `AGPL-3.0-only`                                                     | Setting it to `AGPL-3.0-only`                                                                                   | The root package is a private, unpublished multi-license workspace meta-package (per `LICENSING.md`); claiming a single SPDX license on it would itself be a new contradiction. The issue offers this as the primary option; dropping `./` is the minimal fix and is what npm/SPDX tooling expects for the `SEE LICENSE IN <file>` form. |
+| D3  | `LICENSING.md` "no per-se license" sentence (line 13) rewritten to state the root package.json license field points to this file, now that a root LICENSE exists for GitHub detection purposes | Delete the sentence entirely                                                                                    | The underlying fact (root workspace package has no single SPDX license) is still true and worth keeping; only the "no per-se license" framing needs updating now that a root `LICENSE` file exists (for licensee) even though no single SPDX id applies to the workspace root package.                                                   |
+
+## Affected Areas
+
+- `LICENSE` (new): root LICENSE file, AGPL-3.0-only text + one-line preamble
+- `packages/openbadges-core/README.md`: fix License section (MIT → Apache-2.0)
+- `package.json`: fix `license` field (drop `./`)
+- `LICENSING.md`: reword "no per-se license" sentence; soften SPDX-backfill claim
+
+## Implementation Plan
+
+### Step 1: Add root LICENSE
+
+**Files**: `LICENSE` (new)
+**Commit**: `docs: add root LICENSE (AGPL-3.0-only) for GitHub license detection`
+**Changes**:
+
+- [x] Create `/LICENSE` at repo root
+- [x] First line: `This repository is multi-licensed; see LICENSING.md for the per-package map.` followed by a blank line
+- [x] Below that, the full, unmodified AGPL-3.0-only text from `apps/native-rd/LICENSE` (661 lines) — copy verbatim, do not touch copyright/FSF boilerplate
+- [x] Do not remove or alter `apps/native-rd/LICENSE`, `packages/openbadges-core/LICENSE`, or `packages/design-tokens/LICENSE` — all three per-package files stay as-is
+
+### Step 2: Fix openbadges-core README license contradiction
+
+**Files**: `packages/openbadges-core/README.md`
+**Commit**: `docs(openbadges-core): fix README License section to match Apache-2.0 package.json`
+**Changes**:
+
+- [x] Line 203: replace bare `MIT` under the `## License` heading with `Apache-2.0 — see [LICENSE](./LICENSE).`
+
+### Step 3: Fix root package.json license field
+
+**Files**: `package.json`
+**Commit**: `fix: drop leading ./ from root package.json license field (licensee-ignored)`
+**Changes**:
+
+- [x] Line 7: `"license": "SEE LICENSE IN ./LICENSING.md"` → `"license": "SEE LICENSE IN LICENSING.md"`
+
+### Step 4: Reword LICENSING.md stale/aspirational claims
+
+**Files**: `LICENSING.md`
+**Commit**: `docs: reword LICENSING.md no-per-se-license and SPDX-backfill claims`
+**Changes**:
+
+- [x] Line 13 ("The root `package.json` is a private workspace meta-package — it is not published and has no per-se license; see this file.") — reword to something like: "The root `package.json` is a private, unpublished workspace meta-package; its `license` field points here rather than naming a single SPDX id, since the repo is multi-licensed per package (below). The root `LICENSE` file (AGPL-3.0-only, the dominant product license) exists solely so GitHub's license detector can populate the repository's license metadata."
+- [x] Line 50 ("Existing files will be backfilled progressively; lack of an SPDX header in an older file does not change which license applies (the package's LICENSE file is authoritative).") — reword to drop the "will be backfilled progressively" commitment, e.g.: "SPDX headers are optional, not required — the package's LICENSE file is authoritative regardless of whether a given source file carries a header." (Also adjust line 43's "New source files should include" if it reads as a hard requirement; soften to "may include".)
+
+### Step 5: Sweep fixes (contingency — none found in current sweep)
+
+**Files**: none expected
+**Commit**: `docs: fix remaining stale license claims found in sweep` (only if sweep turns up new hits)
+**Changes**:
+
+- [x] Re-run `grep -rniE '^(MIT|Apache|AGPL)' --include='*.md' . --exclude-dir=node_modules` and `grep -rln -i '## license' --include='*.md' . --exclude-dir=node_modules` at implementation time (docs may have changed since research) and fix any stale hit found beyond the one in Step 2
+- [x] This step is a no-op / skip if the sweep is clean, which it was as of research (see Discovery Log)
+
+## Testing Strategy
+
+- [ ] Not applicable — documentation/metadata-only change, no runtime code touched
+- [ ] Manual verification: `cat LICENSE` shows preamble + full AGPL-3.0-only text; `git diff` for each commit touches only the file(s) named in that step
+- [ ] Manual verification: `node -e "console.log(require('./package.json').license)"` prints `SEE LICENSE IN LICENSING.md`
+- [ ] Manual verification: `grep -A2 '## License' packages/openbadges-core/README.md` shows `Apache-2.0`
+- [ ] Post-merge verification: `gh repo view --json licenseInfo` on `main` returns AGPL-3.0 (GitHub's licensee scan runs server-side after the LICENSE file lands on the default branch; there is no local licensee gem in this repo/CI to run it pre-merge — note as a known gap, not a blocker)
+
+## Not in Scope
+
+| Item                                                              | Reason                                                                | Follow-up                                     |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------- |
+| Backfilling SPDX headers across `apps/native-rd/src` (0/729)      | Issue explicitly defers this ("not this month's work")                | none                                          |
+| Changing any package's actual license (AGPL/Apache/MIT)           | Issue confirms AGPL-3.0-only qualifies for PTF; no relicensing needed | none                                          |
+| Adding CI/lint to enforce license-field consistency going forward | Not requested by issue; would be a separate scoped change             | possible future issue if contradictions recur |
+
+_All other items: no items deferred beyond the above._
+
+## Discovery Log
+
+- [2026-09-03 impl] Sweep at implementation time found one extra stale claim beyond the plan: `apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md:119` still listed the `./`-prefixed license field and predated the root LICENSE. Fixed in a fifth commit. The `license: MIT` hits in `apps/native-rd/.agents/skills/vercel-*/SKILL.md` and the relay mention in `docs/architecture/local-first-sync.md` describe third-party software, not this repo's packages — left alone.
+
+- [2026-09-03] Full-repo sweep (`grep -rniE '^(MIT|Apache|AGPL)' --include='*.md' . --exclude-dir=node_modules`) found exactly one contradiction: `packages/openbadges-core/README.md:203` (`MIT`, should be `Apache-2.0`). The five other grep hits (`apps/native-rd/docs/research/web-privacy-local-first.md`, matching "Mitigation(s)") are false positives from the case-insensitive `^AGPL` alternation catching "Mit..." at line start — not license claims.
+- [2026-09-03] `grep -rln -i '## license' --include='*.md' . --exclude-dir=node_modules` found only one file with a `## License` heading in the whole repo: `packages/openbadges-core/README.md`. `packages/design-tokens/README.md`, `apps/native-rd/README.md`, and the root `README.md` either don't exist or have no License section — nothing to reconcile there.
+- [2026-09-03] `apps/native-rd/package.json:5` already correctly reads `"license": "AGPL-3.0-only"` — no change needed. `packages/design-tokens/package.json` already correctly reads `"license": "MIT"` — no change needed. Only the root `package.json` (line 7) and `openbadges-core/README.md` (line 203) needed fixes, confirming the issue's own three-contradiction count (README, root package.json `./`, LICENSING.md wording) exactly.
+- [2026-09-03] No CI workflow in `.github/workflows/` validates `package.json` license fields or lints markdown License sections — confirmed by scanning all 14 workflow files for "license" references (none found) and for markdown-lint-named workflows (none found). This PR's correctness rests on manual grep verification, not an automated gate.
+- [2026-09-03] Licensee (GitHub's detection library) uses Dice-Sørensen fuzzy text matching against canonical SPDX license texts, with a confidence threshold around 98%. A single short preamble line ("This repository is multi-licensed; see LICENSING.md...") prepended above ~661 lines of otherwise-verbatim AGPL-3.0 text changes the similarity by a fraction of a percent — well within the fuzzy-match tolerance licensee is designed for (it already tolerates copyright-line substitutions, trailing whitespace, etc.). No local licensee gem is installed in this repo to empirically confirm; this is based on documented licensee matching behavior, and the real confirmation is the post-merge `gh repo view --json licenseInfo` check in Testing Strategy.
+- [2026-09-03] No open "Blocked by"/"Depends on"/"After" marker found in the issue body. "Part of #601" is a parent-epic reference only; #601 (open) does not block this issue's independent mergeability.

--- a/apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md
@@ -68,7 +68,7 @@ Add a root `/LICENSE` file (AGPL-3.0-only text, matching `apps/native-rd/LICENSE
 ### Step 3: Fix root package.json license field
 
 **Files**: `package.json`
-**Commit**: `fix: drop leading ./ from root package.json license field (licensee-ignored)`
+**Commit**: `fix: drop leading ./ from root package.json license field`
 **Changes**:
 
 - [x] Line 7: `"license": "SEE LICENSE IN ./LICENSING.md"` → `"license": "SEE LICENSE IN LICENSING.md"`

--- a/apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md
@@ -53,7 +53,7 @@ Add a root `/LICENSE` file (AGPL-3.0-only text, matching `apps/native-rd/LICENSE
 **Changes**:
 
 - [x] Create `/LICENSE` at repo root
-- [x] First line: `This repository is multi-licensed; see LICENSING.md for the per-package map.` followed by a blank line
+- [x] Pointer line `This repository is multi-licensed; see LICENSING.md for the per-package map.` — appended after the license text (moved from the top; see Discovery Log)
 - [x] Below that, the full, unmodified AGPL-3.0-only text from `apps/native-rd/LICENSE` (661 lines) — copy verbatim, do not touch copyright/FSF boilerplate
 - [x] Do not remove or alter `apps/native-rd/LICENSE`, `packages/openbadges-core/LICENSE`, or `packages/design-tokens/LICENSE` — all three per-package files stay as-is
 
@@ -71,7 +71,7 @@ Add a root `/LICENSE` file (AGPL-3.0-only text, matching `apps/native-rd/LICENSE
 **Commit**: `fix: drop leading ./ from root package.json license field`
 **Changes**:
 
-- [x] Line 7: `"license": "SEE LICENSE IN ./LICENSING.md"` → `"license": "SEE LICENSE IN LICENSING.md"`
+- [x] Line 7: `"license": "SEE LICENSE IN ./LICENSING.md"` → `"license": "AGPL-3.0-only"` (revised from the bare `SEE LICENSE IN` form; see Discovery Log)
 
 ### Step 4: Reword LICENSING.md stale/aspirational claims
 
@@ -97,6 +97,7 @@ Add a root `/LICENSE` file (AGPL-3.0-only text, matching `apps/native-rd/LICENSE
 - [ ] Manual verification: `cat LICENSE` shows preamble + full AGPL-3.0-only text; `git diff` for each commit touches only the file(s) named in that step
 - [ ] Manual verification: `node -e "console.log(require('./package.json').license)"` prints `SEE LICENSE IN LICENSING.md`
 - [ ] Manual verification: `grep -A2 '## License' packages/openbadges-core/README.md` shows `Apache-2.0`
+- [x] Pre-merge verification: `licensee detect .` (licensee 10.1.0 via Homebrew Ruby 4.0.6, gem installed to scratchpad) reports `License: AGPL-3.0`, LICENSE matcher Exact 100%, package.json matcher NpmBower AGPL-3.0.
 - [ ] Post-merge verification: `gh repo view --json licenseInfo` on `main` returns AGPL-3.0 (GitHub's licensee scan runs server-side after the LICENSE file lands on the default branch; there is no local licensee gem in this repo/CI to run it pre-merge — note as a known gap, not a blocker)
 
 ## Not in Scope
@@ -110,6 +111,8 @@ Add a root `/LICENSE` file (AGPL-3.0-only text, matching `apps/native-rd/LICENSE
 _All other items: no items deferred beyond the above._
 
 ## Discovery Log
+
+- [2026-09-03 review] Empirical `licensee detect` (v10.1.0) contradicted the research estimate: a one-line preamble above the AGPL text gives 96.71% similarity, below licensee's 98% threshold, so the repo reports NOASSERTION. Appending the same line after the text keeps an Exact 100% match. Separately, a root `package.json` value of `SEE LICENSE IN LICENSING.md` resolves to NOASSERTION in licensee's npm matcher and vetoes the repo-level verdict even when LICENSE matches; `AGPL-3.0-only` (the issue's alternative) makes both matchers agree. Both changes applied in follow-up commits; LICENSING.md and ADR-0005 wording updated to match.
 
 - [2026-09-03 impl] Sweep at implementation time found one extra stale claim beyond the plan: `apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md:119` still listed the `./`-prefixed license field and predated the root LICENSE. Fixed in a fifth commit. The `license: MIT` hits in `apps/native-rd/.agents/skills/vercel-*/SKILL.md` and the relay mention in `docs/architecture/local-first-sync.md` describe third-party software, not this repo's packages — left alone.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "description": "Mobile app and shared badge packages for Rollercoaster.dev",
-  "license": "SEE LICENSE IN ./LICENSING.md",
+  "license": "SEE LICENSE IN LICENSING.md",
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "description": "Mobile app and shared badge packages for Rollercoaster.dev",
-  "license": "SEE LICENSE IN LICENSING.md",
+  "license": "AGPL-3.0-only",
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/packages/openbadges-core/README.md
+++ b/packages/openbadges-core/README.md
@@ -200,7 +200,7 @@ src/
 
 ## License
 
-MIT
+Apache-2.0 — see [LICENSE](./LICENSE).
 
 ## Links
 


### PR DESCRIPTION
## Summary

- Add a root `LICENSE` (verbatim AGPL-3.0-only, the dominant product license) so GitHub's licensee populates `licenseInfo` and the About sidebar shows a license chip.
- Fix the three self-contradictions from #602: `openbadges-core` README said MIT (package is Apache-2.0), root `package.json` used a `./`-prefixed `SEE LICENSE IN`, and `LICENSING.md` carried a stale "no per-se license" sentence plus an SPDX-backfill promise.
- Verified locally with `licensee detect .` (v10.1.0): `License: AGPL-3.0`, LICENSE matcher Exact 100%, package.json matcher AGPL-3.0.

## Changes

- `LICENSE` (new): verbatim copy of `apps/native-rd/LICENSE`, with the one-line pointer to `LICENSING.md` **appended after** the text. A preamble above the text drops similarity to 96.71% (under licensee's 98% threshold) and yields NOASSERTION.
- `package.json`: `license` → `AGPL-3.0-only`. The issue's first option, `SEE LICENSE IN LICENSING.md`, resolves to NOASSERTION in licensee's npm matcher and vetoes the repo-level verdict even when LICENSE matches. The issue offered `AGPL-3.0-only` as the alternative.
- `packages/openbadges-core/README.md`: License section → `Apache-2.0 — see [LICENSE](./LICENSE).`
- `LICENSING.md`: root declaration explained (AGPL-3.0-only for detection; per-package LICENSE files authoritative); SPDX headers now "optional", backfill commitment dropped.
- `apps/native-rd/docs/decisions/ADR-0005-licensing-and-trademark.md`: implementation checklist and Context tense updated to match (sweep hits).
- Dev plan: `apps/native-rd/docs/plans/dev-plans/issue-602-root-license.md`.

Sweep (`grep -rniE '^(MIT|Apache|AGPL)' --include='*.md'` plus `## License` headings) found no other claims contradicting a package's `package.json`. Remaining `MIT`/`Apache` mentions describe third-party software.

## Intent Verification

- [x] `/LICENSE` exists at repo root, containing the full AGPL-3.0-only text (verbatim copy of `apps/native-rd/LICENSE`) with a one-line pointer to LICENSING.md
- [ ] After merge, `gh repo view --json licenseInfo` returns a non-null AGPL-3.0 result and the GitHub About sidebar shows a license chip (server-side; local `licensee detect .` already returns AGPL-3.0)
- [x] `packages/openbadges-core/README.md` License section reads `Apache-2.0 — see [LICENSE](./LICENSE).` and matches `package.json`
- [x] Root `package.json` `license` field has no leading `./` (now `AGPL-3.0-only`)
- [x] `LICENSING.md`'s "no per-se license" sentence is reworded to match the new root LICENSE
- [x] `LICENSING.md`'s SPDX section states headers are optional and the package LICENSE file is authoritative
- [x] Sweep returns no result that contradicts its package's `package.json` license

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| Pointer line appended after the AGPL text, not as a preamble | Empirical licensee run: preamble → 96.71% similarity → NOASSERTION; trailing line → Exact 100%. |
| Root `package.json` license `AGPL-3.0-only`, not `SEE LICENSE IN LICENSING.md` | `SEE LICENSE IN` resolves to NOASSERTION in licensee's npm matcher and vetoes the repo verdict. Issue offered `AGPL-3.0-only` as the alternative. |
| Keep the fact that the root is a private multi-license meta-package in LICENSING.md | Still true; the root declaration exists for detection and does not override per-package licenses. |

## Discovery Log

- [2026-09-03] Research estimated a preamble would survive licensee's fuzzy match; the empirical run (licensee 10.1.0 via Homebrew Ruby 4.0.6) contradicted that. Fixed in follow-up commits and recorded in the plan.
- [2026-09-03] Sweep found one extra stale claim beyond the plan: ADR-0005's implementation checklist still named the `./`-prefixed field. Fixed.

## Test Plan

- [x] Type-check passes
- [x] Lint passes
- [x] Tests pass (217 suites, 10389 tests)
- [x] Build script (no-op for native-rd) returns successfully
- [x] `licensee detect .` → `AGPL-3.0`
- [ ] Post-merge: `gh repo view --json licenseInfo` returns AGPL-3.0

---

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Re5nChYVeJyRjAokReVbT