### PR TITLE
fix(native-rd): make the no-key bake state reachable on a real key failure (#566)

### DIFF
--- a/apps/native-rd/e2e/README.md
+++ b/apps/native-rd/e2e/README.md
@@ -174,7 +174,7 @@ Compensating coverage, all pure-Jest plus Storybook stories:
 
 **The bake-failure error alert and its retry.** `finish-baking-error-alert` / `finish-baking-retry-button` have no E2E coverage since #635. The only UI-reachable deterministic bake failure was the no-evidence gate, and that is now blocked upstream at the Bake CTA (`evidence-gate.yaml` asserts the block instead) — every remaining failure mode (`bakePNG` corruption, `saveBadgePNG`/`readBadgePNG` FS errors, `keyProvider.sign`) needs code-level fault injection Maestro cannot do. Covered at component level in `FinishBakingStage.test.tsx` and `CompletionFlowScreen.test.tsx`.
 
-**The `no-key` bake branch.** Logically unreachable: the hook sets it only when `isReady && !keyId`, but `isReady` already implies a `keyId`. The real no-key failure mode is an unbounded spinner with no alert, retry or exit — filed as a bug rather than asserted.
+**The `no-key` bake branch.** Reachable since #566 — the hook lands on it whenever `useUserKey` reports an error (SecureStore unavailable, keypair generation threw, verification failed). No E2E coverage because every trigger is a native-keystore fault Maestro cannot inject; covered in `useCreateBadge.test.ts`, `FinishBakingStage.test.tsx` and `CompletionFlowScreen.test.tsx`.
 
 ## The pre-merge gate
 

--- a/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
@@ -527,10 +527,9 @@ describe("useCreateBadge", () => {
       expect(result.current.error).toBe(
         "Secure storage is unavailable on this device",
       );
-      expect(mockCreateBadge).not.toHaveBeenCalled();
     });
 
-    it("prefers no-key over the idempotent done only when no badge exists yet", () => {
+    it("idempotent done still wins over no-key when a badge already exists", () => {
       mockUseUserKey.mockReturnValue({
         keyId: "key-001",
         isReady: false,

--- a/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useCreateBadge.test.ts
@@ -507,12 +507,15 @@ describe("useCreateBadge", () => {
     });
   });
 
-  describe("when key is ready but keyId is null", () => {
-    it("returns status: no-key", () => {
+  describe("when useUserKey reports an error (#566)", () => {
+    // `isReady` implies a non-null keyId, so `{ keyId: null, isReady: true }`
+    // is a state useUserKey cannot produce. The real permanent-failure shape
+    // is `error` set with `isReady: false` — which must NOT read as "loading".
+    it("returns status: no-key and surfaces the key error, not an unbounded loading", () => {
       mockUseUserKey.mockReturnValue({
         keyId: null,
-        isReady: true,
-        error: null,
+        isReady: false,
+        error: "Secure storage is unavailable on this device",
       });
       mockUseQuery.mockImplementation((query: string) => {
         if (query === "mock-badge-query") return [];
@@ -521,6 +524,30 @@ describe("useCreateBadge", () => {
 
       const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
       expect(result.current.status).toBe("no-key");
+      expect(result.current.error).toBe(
+        "Secure storage is unavailable on this device",
+      );
+      expect(mockCreateBadge).not.toHaveBeenCalled();
+    });
+
+    it("prefers no-key over the idempotent done only when no badge exists yet", () => {
+      mockUseUserKey.mockReturnValue({
+        keyId: "key-001",
+        isReady: false,
+        error: "Key verification failed: boom",
+      });
+      mockUseQuery.mockImplementation((query: string) => {
+        if (query === "mock-goals-query")
+          return [{ ...MOCK_GOAL, status: GoalStatus.completed }];
+        if (query === "mock-badge-query")
+          return [
+            { id: "badge-01", goalId: GOAL_ID, imageUri: "file:///old.png" },
+          ];
+        return [];
+      });
+
+      const { result } = renderHook(() => useCreateBadge(GOAL_ID, WITH_PNG));
+      expect(result.current.status).toBe("done");
     });
   });
 

--- a/apps/native-rd/src/hooks/useCreateBadge.ts
+++ b/apps/native-rd/src/hooks/useCreateBadge.ts
@@ -94,7 +94,7 @@ export type BadgeCreationStatus =
   | "storing"
   | "done"
   | "error"
-  | "no-key"; // key is ready but absent (permanent failure)
+  | "no-key"; // key is unusable — useUserKey reported an error (permanent failure)
 
 export interface UseCreateBadgeResult {
   status: BadgeCreationStatus;
@@ -133,7 +133,7 @@ export function useCreateBadge(
   options?: UseCreateBadgeOptions,
 ): UseCreateBadgeResult {
   const enabled = options?.enabled !== false;
-  const { keyId, isReady } = useUserKey();
+  const { keyId, isReady, error: keyError } = useUserKey();
   // Narrative is localized at bake time in the active UI language and frozen
   // into the signed credential — single language, by design. See docs/i18n.md.
   const { t } = useTranslation("badges");
@@ -182,14 +182,22 @@ export function useCreateBadge(
       return;
     }
 
-    if (!isReady) {
-      setStatus("loading");
+    // Key unusable → permanent failure (#566). useUserKey sets `error` when
+    // SecureStore is unavailable, keypair generation threw, or verification
+    // failed for a non-orphan reason, and never clears it within a session, so
+    // `isReady` stays false forever. Without this branch that lands on
+    // "loading" — an unbounded "Baking your badge…" spinner with no alert,
+    // retry, or exit. "no-key" renders the alert + "Continue without a badge".
+    if (keyError !== null) {
+      setStatus("no-key");
+      setError(keyError);
       return;
     }
 
-    // Key ready but absent → permanent failure (generation failed).
-    if (!keyId) {
-      setStatus("no-key");
+    // Key still initialising. `isReady` implies a non-null `keyId`, so the
+    // second check only narrows the type for the signing calls below.
+    if (!isReady || !keyId) {
+      setStatus("loading");
       return;
     }
 
@@ -435,7 +443,16 @@ export function useCreateBadge(
       }
       // No finally reset — hasTriggered.current stays true permanently
     })();
-  }, [existingBadge, isReady, keyId, goal, goalId, enabled, retryNonce]); // evidence read via ref, not deps
+  }, [
+    existingBadge,
+    isReady,
+    keyId,
+    keyError,
+    goal,
+    goalId,
+    enabled,
+    retryNonce,
+  ]); // evidence read via ref, not deps
 
   // Recovery from the terminal "error" state: clear the never-reset guard and
   // return to "idle" so the guarded effect can re-run on the next render.


### PR DESCRIPTION
## Summary

Fixes #566.

`useCreateBadge`'s `"no-key"` status was dead code: it required `isReady && !keyId`, but `useUserKey.isReady` already implies a non-null `keyId`. Every real key failure (SecureStore unavailable, keypair generation threw, verification failed) sets `useUserKey.error`, keeps `isReady` false permanently, and fell through to `"loading"` — an unbounded "Baking your badge…" spinner with no alert, no retry, no exit.

## Change

- `useCreateBadge` now reads `error` from `useUserKey`. When set, status becomes `"no-key"` and the diagnostic is surfaced through the hook's `error`. The existing `FinishBakingStage` no-key branch (alert + "Continue without a badge", wired to `popToTop`) is now reachable.
- The `!keyId` check is folded into the loading guard as type narrowing only, with a comment saying so.
- Test: replaced the impossible `{ keyId: null, isReady: true }` mock with the real failure shape (`isReady: false, error: "…"`) and asserted `no-key` + surfaced message + no `createBadge` call. Added a case pinning that the idempotent `done` guard still wins for a completed goal with a badge.
- `e2e/README.md`: no-key branch is no longer documented as unreachable; still not E2E-asserted because its triggers are native keystore faults.

Options (b) bounded wait and (c) unfolding `loading` from `building` from the issue are not in this PR — (a) was the minimum and the only one that makes the existing UI reachable.

## Verification

- `bunx jest src/hooks/__tests__/useCreateBadge.test.ts` — 49 passed
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgoTTQyb89UZP7xGHMtkDe
