### PR TITLE
test(native-rd): follow-up to #649 — drop a renders-only frame test, restore the Keyboard.dismiss spy

### DIFF
--- a/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
+++ b/apps/native-rd/src/components/EditGoalView/__tests__/EditGoalView.test.tsx
@@ -259,6 +259,7 @@ describe("EditGoalView", () => {
       fireEvent(input, "submitEditing");
       expect(onAddStep).not.toHaveBeenCalled();
       expect(dismiss).toHaveBeenCalledTimes(1);
+      dismiss.mockRestore();
     });
 
     it("renders each date/dependency chip when present", () => {

--- a/apps/native-rd/src/components/KeyboardAvoidingFrame/__tests__/KeyboardAvoidingFrame.test.tsx
+++ b/apps/native-rd/src/components/KeyboardAvoidingFrame/__tests__/KeyboardAvoidingFrame.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { View } from "react-native";
 import { act, render, screen } from "@testing-library/react-native";
 import { KeyboardControllerNative } from "react-native-keyboard-controller";
 import { KeyboardAvoidingFrame } from "../KeyboardAvoidingFrame";
@@ -8,16 +8,6 @@ const viewPositionInWindow =
   KeyboardControllerNative.viewPositionInWindow as jest.Mock;
 
 describe("KeyboardAvoidingFrame", () => {
-  it("renders its children inside the frame", () => {
-    render(
-      <KeyboardAvoidingFrame testID="frame">
-        <Text>footer</Text>
-      </KeyboardAvoidingFrame>,
-    );
-    expect(screen.getByTestId("frame")).toBeTruthy();
-    expect(screen.getByText("footer")).toBeTruthy();
-  });
-
   it("forwards the caller's onLayout", () => {
     const onLayout = jest.fn();
     render(<KeyboardAvoidingFrame testID="frame" onLayout={onLayout} />);


### PR DESCRIPTION
Review follow-up to #649, which merged while the fix was being prepared.

- `KeyboardAvoidingFrame.test.tsx`: the "renders its children" case asserted nothing a regression could break; the three offset cases next to it pin the real behaviour. Dropped per `.claude/rules/no-unfalsifiable-assertions.md`.
- `EditGoalView.test.tsx`: the `Keyboard.dismiss` spy was the only spy in the file left unrestored (jest config has no `restoreMocks`).

Not changed, noted from the same review: `prototypes/screen-redesign/uploads/FocusModeScreen.tsx` still imports the removed `KEYBOARD_AVOIDING_PROPS` (a frozen upload snapshot outside the app tsconfig, not compiled); the frame's window offset is not clamped at 0 for the zero-position web/jest fallback (inert there, and a clamp would break the math for a partially offscreen parent); Android keyboard behaviour is still unverified on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgoTTQyb89UZP7xGHMtkDe