### PR TITLE
fix(scripts): verify patches only in store copies something actually links to

### DIFF
--- a/scripts/check-patches.ts
+++ b/scripts/check-patches.ts
@@ -14,8 +14,14 @@
  * in node_modules rather than trusting the bookkeeping.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { basename, join, resolve, sep } from "node:path";
 
 type Manifest = {
   patchedDependencies?: Record<string, string>;
@@ -153,28 +159,69 @@ function allVersions(lock: BunLock, name: string): string[] {
   return [...versions].sort();
 }
 
-/** Where `name@version` is installed. Bun's store dir may carry a peer hash. */
-function installDirs(name: string, version: string): string[] {
-  const dirs: string[] = [];
+/**
+ * Where `name@version` is actually reachable from. Bun's store keeps one dir per
+ * peer-hash variant (`<name>@<version>+<hash>`) and never prunes the ones a
+ * re-resolve leaves behind, so scanning the store would report unpatched
+ * orphans that no import can reach. Instead, follow every link that can lead
+ * to the package — the hoisted root copy, each workspace's copy, and each
+ * *other* store package's nested `node_modules/<name>` — and verify only those
+ * targets. Orphans are reported separately so they can be cleaned up.
+ */
+function installDirs(
+  name: string,
+  version: string,
+): { live: string[]; orphans: string[] } {
   const store = join(repoRoot, "node_modules", ".bun");
+  const segments = name.split("/");
   const escaped = name.replace(/\//g, "+");
+  const ownStoreDirs: string[] = [];
+  const candidates: string[] = [join(repoRoot, "node_modules", ...segments)];
 
-  if (existsSync(store)) {
-    for (const dir of readdirSync(store)) {
-      if (
-        dir !== `${escaped}@${version}` &&
-        !dir.startsWith(`${escaped}@${version}+`)
-      )
-        continue;
-      const candidate = join(store, dir, "node_modules", ...name.split("/"));
-      if (existsSync(candidate)) dirs.push(candidate);
+  for (const workspaceRoot of workspaceRoots) {
+    const dir = join(repoRoot, workspaceRoot);
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      candidates.push(join(dir, entry.name, "node_modules", ...segments));
     }
   }
 
-  const hoisted = join(repoRoot, "node_modules", ...name.split("/"));
-  if (existsSync(hoisted)) dirs.push(hoisted);
+  if (existsSync(store)) {
+    for (const dir of readdirSync(store)) {
+      const isOwn =
+        dir === `${escaped}@${version}` ||
+        dir.startsWith(`${escaped}@${version}+`);
+      // A store dir's own `node_modules/<name>` is the package itself, not a
+      // link to it — counting it would make every orphan look reachable.
+      if (isOwn)
+        ownStoreDirs.push(join(store, dir, "node_modules", ...segments));
+      else candidates.push(join(store, dir, "node_modules", ...segments));
+    }
+  }
 
-  return dirs;
+  const live = new Set<string>();
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    let manifest: { version?: string };
+    try {
+      manifest = JSON.parse(
+        readFileSync(join(candidate, "package.json"), "utf8"),
+      ) as { version?: string };
+    } catch {
+      continue;
+    }
+    if (manifest.version === version) live.add(realpathSync(candidate));
+  }
+
+  // Report the store dir itself — that is the thing to `rm -rf`.
+  const orphans = ownStoreDirs
+    .filter((dir) => existsSync(dir) && !live.has(realpathSync(dir)))
+    .map((dir) =>
+      dir.slice(0, dir.indexOf(`${sep}node_modules${sep}`, store.length)),
+    );
+
+  return { live: [...live].sort(), orphans };
 }
 
 type Hunk = {
@@ -250,7 +297,15 @@ function containsSequence(haystack: string[], needle: string[]): boolean {
 
 /** Verify the patch's effect is present in the installed package. */
 function checkApplied(entry: PatchEntry, patchText: string): void {
-  const dirs = installDirs(entry.name, entry.version);
+  const { live: dirs, orphans } = installDirs(entry.name, entry.version);
+
+  for (const orphan of orphans) {
+    const relative = orphan.slice(repoRoot.length + 1);
+    notes.push(
+      `- ${entry.key}: ${relative} is a store copy nothing links to (left by an earlier install), so it is not verified.\n` +
+        `  Cleanup: \`rm -rf ${relative}\``,
+    );
+  }
 
   if (dirs.length === 0) {
     errors.push(


### PR DESCRIPTION
Bun keeps one store dir per peer-hash variant (`<name>@<version>+<hash>`)
and never prunes the ones a re-resolve orphans. check-patches scanned
every matching store dir, so two stale unistyles copies from earlier
installs (unreachable by any import, untouched by `bun install`) failed
the check on a machine whose live copy was fully patched.

installDirs() now follows the links instead: the hoisted root copy, each
workspace's node_modules/<name>, and every other store package's nested
node_modules/<name>, deduped by realpath. Only those are verified.
Orphaned store dirs are surfaced as a warning with the `rm -rf` to run,
so they stay visible without masquerading as patch drift. A live copy
with a missing hunk still fails as before.

## Verified locally
- Clean tree: passes (2 patches).
- Simulated orphan store dir with a reverted hunk: warning + `rm -rf` hint, exit 0.
- Reverted a hunk in the live copy: fails as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAmKeXevFiGHzvgCcLi5H6