### PR TITLE
fix(native-rd): make CaptureLinkScreen scroll and label its URL return key honestly (#565)

### DIFF
--- a/apps/native-rd/docs/plans/dev-plans/issue-565-capture-link-scroll-keyboard.md
+++ b/apps/native-rd/docs/plans/dev-plans/issue-565-capture-link-scroll-keyboard.md
@@ -1,0 +1,37 @@
+# Issue #565 — CaptureLinkScreen: scroll container, return-key label, e2e comments
+
+**Branch:** `fix/issue-565-capture-link-keyboard`
+
+## State on main when this started
+
+- Suggested fix (1) — keyboard avoidance — already landed in #649 (`f4e50b44`):
+  `CaptureLinkScreen` wraps its body in the shared `KeyboardAvoidingFrame`
+  (the successor to `KEYBOARD_AVOIDING_PROPS`, which no longer exists in
+  `src/utils/keyboard.ts`). `FocusModeScreen` uses the same frame. Nothing to
+  redo there.
+- Still open: no `ScrollView` (actions unreachable at large text), no
+  `useTabScreenContentInset`, URL input labelled `returnKeyType="next"` with
+  nothing wired to advance focus, and e2e comments/README still describing the
+  `"next"` label.
+
+## Commits
+
+1. `fix(native-rd): make CaptureLinkScreen scroll and label its URL return key honestly (#565)`
+   - `CaptureLinkScreen.tsx`: body becomes `ScrollView`
+     (`keyboardShouldPersistTaps="handled"`, `testID="capture-link-scroll"`,
+     `contentContainerStyle=[styles.content, tabInset]`) inside the existing
+     `KeyboardAvoidingFrame`; URL input `returnKeyType="done"`.
+   - `CaptureLinkScreen.styles.ts`: `content` drops `flex: 1` (a
+     contentContainer with `flex: 1` cannot scroll); add `scroll: { flex: 1 }`.
+   - Test: scroll container carries `keyboardShouldPersistTaps="handled"` and a
+     positive bottom inset; Save and Cancel render inside it; URL input's
+     `returnKeyType` is `"done"`.
+2. `docs(e2e): stop describing the Capture Link URL key as "next" (#565)`
+   - `e2e/README.md`, `e2e/flows/full-ride.yaml`, `e2e/flows/evidence-viewer.yaml`.
+   - `pressKey: Enter` steps stay (they still work).
+
+## Out of scope
+
+- `forwardRef` on `Input` / real focus advancement.
+- The historical #502 plan doc (`issue-502-e2e-canonical-full-ride.md`) is a
+  record of that work, not live guidance; left as is.

--- a/apps/native-rd/e2e/README.md
+++ b/apps/native-rd/e2e/README.md
@@ -142,7 +142,7 @@ This is verifiable, and should be verified, with `maestro hierarchy` — VoiceOv
 
 Every screen with a text input above a pinned footer CTA now lifts that footer above the keyboard: `CaptureTextNote` via `useReanimatedKeyboardAnimation`, and `NewGoalWizard`, `EditGoalView`, `CaptureLinkScreen`, `VoiceMemoScreen`, `FinishCelebrateStage` and `FinishDesignStage` via the shared `KeyboardAvoidingFrame` (keyboard-controller's view plus a self-measured window offset). `keyboard-cta-reachable.yaml` pins this for the two screens whose add-step input keeps the keyboard up between adds (`blurOnSubmit={false}`): it taps the footer CTA with the keyboard still showing and asserts arrival. Do not add a dismissal step before those taps.
 
-Older flows still dismiss before tapping `capture-link-save` (tap `capture-link-caption`, `pressKey: Enter`). That is now belt and braces, not load-bearing. If you do dismiss from Capture Link, do it from the caption: the URL input is labelled `returnKeyType="next"` but wires no `onSubmitEditing`/ref, so that key advances no focus.
+Older flows still dismiss before tapping `capture-link-save` (tap `capture-link-caption`, `pressKey: Enter`). That is now belt and braces, not load-bearing. Both Capture Link inputs carry `returnKeyType="done"` (#565), so Enter on either one blurs and dismisses; the screen's body is also a `ScrollView` with `keyboardShouldPersistTaps="handled"`, so a tap on Save with the keyboard still up reaches the button.
 
 ### Flow structure
 

--- a/apps/native-rd/e2e/flows/evidence-viewer.yaml
+++ b/apps/native-rd/e2e/flows/evidence-viewer.yaml
@@ -85,11 +85,9 @@ env:
     id: "new-goal-start-working-button"
 
 # --- Capture the link first (older) -----------------------------------------
-# Per-type invites replace the old FAB → FABMenu path. `pressKey: Enter` after
-# the caption fires the keyboard's blue check (returnKeyType="done") to dismiss
-# the soft keyboard. Since #649/#565 that is belt and braces: CaptureLinkScreen
-# lifts Save above the keyboard (KeyboardAvoidingFrame) and its ScrollView keeps
-# taps alive with the keyboard up. Both inputs are returnKeyType="done".
+# Per-type invites replace the old FAB → FABMenu path. The `pressKey: Enter`
+# before Save is belt and braces, not load-bearing; both inputs are
+# returnKeyType="done" (#565). See README.md → "Soft keyboard occlusion".
 - extendedWaitUntil:
     visible:
       id: "focus-current-task-add-link"

--- a/apps/native-rd/e2e/flows/evidence-viewer.yaml
+++ b/apps/native-rd/e2e/flows/evidence-viewer.yaml
@@ -87,9 +87,9 @@ env:
 # --- Capture the link first (older) -----------------------------------------
 # Per-type invites replace the old FAB → FABMenu path. `pressKey: Enter` after
 # the caption fires the keyboard's blue check (returnKeyType="done") to dismiss
-# the soft keyboard so Save is tappable — CaptureLinkScreen has no
-# KeyboardAvoidingView, so without dismissing first the Save tap lands on the
-# keyboard. Enter on the URL field does not help: it is returnKeyType="next".
+# the soft keyboard. Since #649/#565 that is belt and braces: CaptureLinkScreen
+# lifts Save above the keyboard (KeyboardAvoidingFrame) and its ScrollView keeps
+# taps alive with the keyboard up. Both inputs are returnKeyType="done".
 - extendedWaitUntil:
     visible:
       id: "focus-current-task-add-link"

--- a/apps/native-rd/e2e/flows/full-ride.yaml
+++ b/apps/native-rd/e2e/flows/full-ride.yaml
@@ -341,12 +341,11 @@ env:
 - assertNotVisible:
     id: "focus-current-task-mark-complete"
 
-# 21. Capture the Link. CaptureLinkScreen now wraps its content in a
-#     KeyboardAvoidingView, so Save sits above the keyboard and the dismissal
-#     below is belt and braces, not load-bearing. It dismisses from the caption
-#     input (returnKeyType="done"); the URL input is labelled
-#     returnKeyType="next" but wires no onSubmitEditing/ref, so that key
-#     advances no focus.
+# 21. Capture the Link. CaptureLinkScreen wraps its body in a
+#     KeyboardAvoidingFrame and a ScrollView (keyboardShouldPersistTaps=
+#     "handled"), so Save sits above the keyboard and the dismissal below is
+#     belt and braces, not load-bearing. Both inputs carry returnKeyType="done"
+#     (#565): Enter on either blurs and dismisses.
 - tapOn:
     id: "focus-current-task-add-link"
 - tapOn:

--- a/apps/native-rd/e2e/flows/full-ride.yaml
+++ b/apps/native-rd/e2e/flows/full-ride.yaml
@@ -341,11 +341,9 @@ env:
 - assertNotVisible:
     id: "focus-current-task-mark-complete"
 
-# 21. Capture the Link. CaptureLinkScreen wraps its body in a
-#     KeyboardAvoidingFrame and a ScrollView (keyboardShouldPersistTaps=
-#     "handled"), so Save sits above the keyboard and the dismissal below is
-#     belt and braces, not load-bearing. Both inputs carry returnKeyType="done"
-#     (#565): Enter on either blurs and dismisses.
+# 21. Capture the Link. The Enter before Save is belt and braces, not
+#     load-bearing; both inputs are returnKeyType="done" (#565). See
+#     README.md → "Soft keyboard occlusion".
 - tapOn:
     id: "focus-current-task-add-link"
 - tapOn:

--- a/apps/native-rd/src/screens/CaptureLinkScreen/CaptureLinkScreen.styles.ts
+++ b/apps/native-rd/src/screens/CaptureLinkScreen/CaptureLinkScreen.styles.ts
@@ -11,8 +11,13 @@ export const styles = StyleSheet.create((theme) => ({
   keyboardFrame: {
     flex: 1,
   },
-  content: {
+  scroll: {
     flex: 1,
+  },
+  // ScrollView content container: no `flex: 1` here, or the content would
+  // shrink to the viewport instead of overflowing into a scroll. The tab-bar
+  // inset is merged in at the call site and wins on paddingBottom.
+  content: {
     padding: theme.space[4],
     gap: theme.space[4],
   },

--- a/apps/native-rd/src/screens/CaptureLinkScreen/CaptureLinkScreen.tsx
+++ b/apps/native-rd/src/screens/CaptureLinkScreen/CaptureLinkScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { View, Alert } from "react-native";
+import { View, Alert, ScrollView } from "react-native";
 import { KeyboardAvoidingFrame } from "../../components/KeyboardAvoidingFrame";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
@@ -12,6 +12,7 @@ import { createEvidence, EvidenceType } from "../../db";
 import type { GoalId, StepId } from "../../db";
 import { reportError } from "../../services/sentry-report";
 import { useEvidenceStartBreadcrumb } from "../../hooks/useEvidenceStartBreadcrumb";
+import { useTabScreenContentInset } from "../../navigation/useTabScreenContentInset";
 import type { CaptureLinkScreenProps } from "../../navigation/types";
 import { isValidUrl, normalizeUrl } from "../../utils/url";
 import { styles } from "./CaptureLinkScreen.styles";
@@ -20,6 +21,7 @@ export function CaptureLinkScreen({ route }: CaptureLinkScreenProps) {
   const navigation = useNavigation();
   const { t } = useTranslation(["captureLink", "common"]);
   const { goalId, stepId } = route.params;
+  const tabInset = useTabScreenContentInset();
 
   const [url, setUrl] = useState("");
   const [caption, setCaption] = useState("");
@@ -87,9 +89,18 @@ export function CaptureLinkScreen({ route }: CaptureLinkScreenProps) {
       />
 
       {/* Keeps the Save/Cancel row above the keyboard while the URL or caption
-          has focus; header stays outside so no vertical offset is needed. */}
+          has focus; header stays outside so no vertical offset is needed.
+          The body scrolls so the actions stay reachable at large text sizes,
+          where inputs + preview card + buttons outgrow the viewport; the
+          bottom inset clears the floating tab bar like the sibling capture
+          screens. */}
       <KeyboardAvoidingFrame style={styles.keyboardFrame}>
-        <View style={styles.content}>
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={[styles.content, tabInset]}
+          keyboardShouldPersistTaps="handled"
+          testID="capture-link-scroll"
+        >
           <View style={styles.inputSection}>
             <Input
               label={t("captureLink:urlInput.label")}
@@ -100,7 +111,9 @@ export function CaptureLinkScreen({ route }: CaptureLinkScreenProps) {
               autoCapitalize="none"
               autoCorrect={false}
               keyboardType="url"
-              returnKeyType="next"
+              // "done", not "next": nothing is wired to advance focus to the
+              // caption (Input exposes no ref), so the key blurs and dismisses.
+              returnKeyType="done"
               textContentType="URL"
               testID="capture-link-url"
             />
@@ -155,7 +168,7 @@ export function CaptureLinkScreen({ route }: CaptureLinkScreenProps) {
               disabled={saving}
             />
           </View>
-        </View>
+        </ScrollView>
       </KeyboardAvoidingFrame>
     </View>
   );

--- a/apps/native-rd/src/screens/CaptureLinkScreen/CaptureLinkScreen.tsx
+++ b/apps/native-rd/src/screens/CaptureLinkScreen/CaptureLinkScreen.tsx
@@ -88,12 +88,10 @@ export function CaptureLinkScreen({ route }: CaptureLinkScreenProps) {
         onBack={() => navigation.goBack()}
       />
 
-      {/* Keeps the Save/Cancel row above the keyboard while the URL or caption
-          has focus; header stays outside so no vertical offset is needed.
-          The body scrolls so the actions stay reachable at large text sizes,
-          where inputs + preview card + buttons outgrow the viewport; the
-          bottom inset clears the floating tab bar like the sibling capture
-          screens. */}
+      {/* The frame shrinks the scroll viewport to the space above the keyboard;
+          header stays outside so no vertical offset is needed. Save/Cancel
+          scroll with the body (not a pinned footer), so they are reachable at
+          any text size, and taps on them survive an open keyboard. */}
       <KeyboardAvoidingFrame style={styles.keyboardFrame}>
         <ScrollView
           style={styles.scroll}

--- a/apps/native-rd/src/screens/CaptureLinkScreen/__tests__/CaptureLinkScreen.test.tsx
+++ b/apps/native-rd/src/screens/CaptureLinkScreen/__tests__/CaptureLinkScreen.test.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { StyleSheet } from "react-native";
 import {
   renderWithProviders,
   screen,
   fireEvent,
   waitFor,
+  within,
 } from "../../../__tests__/test-utils";
 import { i18n } from "../../../i18n";
 import { CaptureLinkScreen } from "../CaptureLinkScreen";
@@ -69,6 +71,33 @@ describe("CaptureLinkScreen", () => {
     ).toBeTruthy();
     expect(screen.getByText(i18n.t("captureLink:actions.save"))).toBeTruthy();
     expect(screen.getByText(i18n.t("common:actions.cancel"))).toBeTruthy();
+  });
+
+  // #565: at large Dynamic Type the inputs + preview card + buttons outgrow
+  // the viewport. The actions must live inside a scroll container that keeps
+  // taps alive with the keyboard up and clears the floating tab bar.
+  it("renders Save and Cancel inside a tap-persisting, tab-bar-inset scroll container", () => {
+    renderScreen();
+
+    const scroll = screen.getByTestId("capture-link-scroll");
+    expect(scroll.props.keyboardShouldPersistTaps).toBe("handled");
+
+    const content = StyleSheet.flatten(scroll.props.contentContainerStyle);
+    expect(content.paddingBottom).toBeGreaterThan(0);
+
+    const inside = within(scroll);
+    expect(inside.getByTestId("capture-link-save")).toBeOnTheScreen();
+    expect(inside.getByText(i18n.t("common:actions.cancel"))).toBeOnTheScreen();
+  });
+
+  // #565: the URL input wires no onSubmitEditing/ref, so its return key can
+  // only blur. Labelling it "next" promised focus advancement that never came.
+  it("labels the URL input's return key as done", () => {
+    renderScreen();
+
+    expect(screen.getByTestId("capture-link-url").props.returnKeyType).toBe(
+      "done",
+    );
   });
 
   it("shows validation error for empty URL on save", () => {

--- a/apps/native-rd/src/screens/CaptureLinkScreen/__tests__/CaptureLinkScreen.test.tsx
+++ b/apps/native-rd/src/screens/CaptureLinkScreen/__tests__/CaptureLinkScreen.test.tsx
@@ -4,7 +4,6 @@ import {
   renderWithProviders,
   screen,
   fireEvent,
-  waitFor,
   within,
 } from "../../../__tests__/test-utils";
 import { i18n } from "../../../i18n";
@@ -33,6 +32,13 @@ jest.mock("../../../db", () => {
     createEvidence: jest.fn(),
   };
 });
+
+// Pin a distinctive inset so the test proves the screen merges the hook's
+// value into the scroll content, not just that some padding exists.
+const TAB_INSET = 123;
+jest.mock("../../../navigation/useTabScreenContentInset", () => ({
+  useTabScreenContentInset: () => ({ paddingBottom: TAB_INSET }),
+}));
 
 const mockCreateEvidence = createEvidence as jest.MockedFunction<
   typeof createEvidence
@@ -75,19 +81,25 @@ describe("CaptureLinkScreen", () => {
 
   // #565: at large Dynamic Type the inputs + preview card + buttons outgrow
   // the viewport. The actions must live inside a scroll container that keeps
-  // taps alive with the keyboard up and clears the floating tab bar.
-  it("renders Save and Cancel inside a tap-persisting, tab-bar-inset scroll container", () => {
+  // taps alive with the keyboard up.
+  it("renders Save and Cancel inside a scroll container that persists taps", () => {
     renderScreen();
 
     const scroll = screen.getByTestId("capture-link-scroll");
     expect(scroll.props.keyboardShouldPersistTaps).toBe("handled");
 
-    const content = StyleSheet.flatten(scroll.props.contentContainerStyle);
-    expect(content.paddingBottom).toBeGreaterThan(0);
-
     const inside = within(scroll);
     expect(inside.getByTestId("capture-link-save")).toBeOnTheScreen();
     expect(inside.getByText(i18n.t("common:actions.cancel"))).toBeOnTheScreen();
+  });
+
+  it("pads the scroll content by the floating tab-bar inset", () => {
+    renderScreen();
+
+    const content = StyleSheet.flatten(
+      screen.getByTestId("capture-link-scroll").props.contentContainerStyle,
+    );
+    expect(content.paddingBottom).toBe(TAB_INSET);
   });
 
   // #565: the URL input wires no onSubmitEditing/ref, so its return key can


### PR DESCRIPTION
## Summary

Closes the half of #565 that #649 left open. That PR gave `CaptureLinkScreen` the shared `KeyboardAvoidingFrame` (suggested fix 1). What remained: the body was a fixed `flex: 1` `View`, so at large Dynamic Type or under the `largeText` / `lowVision` variants the inputs + preview card + buttons outgrew the viewport and Save/Cancel fell off-screen with no way to scroll them back; the screen skipped the floating tab-bar inset its sibling capture screens pay; and the URL input's return key was labelled `next` with nothing wired to advance focus.

## Changes

- `CaptureLinkScreen`: body is now a `ScrollView` (`keyboardShouldPersistTaps="handled"`, `testID="capture-link-scroll"`) inside the existing `KeyboardAvoidingFrame`, with `useTabScreenContentInset()` merged into the content container so the actions clear the `FocusPillTabBar` — same shape as `EditGoalView` / `FinishDesignStage`, same inset pattern as `CaptureVideoScreen`.
- `CaptureLinkScreen.styles.ts`: `content` drops `flex: 1` (a content container that flexes cannot overflow into a scroll); new `scroll: { flex: 1 }`.
- URL input `returnKeyType` `"next"` → `"done"`. `Input` exposes no ref and the screen passes no `onSubmitEditing`, so the key only ever blurred. `Input` itself is untouched (no `forwardRef` work — out of scope per the issue).
- `e2e/README.md`, `full-ride.yaml`, `evidence-viewer.yaml`: no longer claim the URL key is `next` / "advances no focus"; the flows' `pressKey: Enter` steps stay as belt and braces.
- Tests: scroll container persists taps and contains Save + Cancel; content container carries exactly the tab-bar inset (hook mocked to a distinctive value); URL key label is `done`.

## Dependencies

- [x] None (#649 already merged)

## Test Plan

- [x] `bun run test --testPathPatterns CaptureLinkScreen` — 19/19
- [x] Sibling suites (`CaptureTextNote`, `CaptureVideoScreen`, `FocusPillTabBar`) — 68/68 across 4 suites
- [x] `bun run lint` — 0 errors
- [x] `bun run type-check` — clean (also enforced by the pre-commit hook on each commit)
- [ ] Reviewer: iOS sim, Goals → a goal → Add Link → largest Dynamic Type; type a valid URL so the preview card renders, then a caption. Save and Cancel must be reachable by scroll with the keyboard up, and the return key on the URL field must read "done". `full-ride.yaml` not re-run here (no simulator in this worktree session).

## Related Issues

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcCGTTZFXrEdg81gnS4Ge8
